### PR TITLE
test(autoware_ekf_localizer): add EKFModule unit tests via non-ROS seam

### DIFF
--- a/localization/autoware_ekf_localizer/src/ekf_module.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_module.cpp
@@ -215,8 +215,7 @@ void EKFModule::accumulate_delay_time(const double dt)
 
 void EKFModule::predict_with_delay(const double dt)
 {
-  const Eigen::MatrixXd x_curr = kalman_filter_.getLatestX();
-  const Eigen::MatrixXd p_curr = kalman_filter_.getLatestP();
+  const Vector6d x_curr = kalman_filter_.getLatestX();
 
   const double proc_cov_vx_d = std::pow(params_.proc_stddev_vx_c * dt, 2.0);
   const double proc_cov_wz_d = std::pow(params_.proc_stddev_wz_c * dt, 2.0);

--- a/localization/autoware_ekf_localizer/src/include/hyper_parameters.hpp
+++ b/localization/autoware_ekf_localizer/src/include/hyper_parameters.hpp
@@ -26,6 +26,20 @@ namespace autoware::ekf_localizer
 class HyperParameters
 {
 public:
+  // Additive seam: a default constructor so the parameters can be hand-set in a unit test
+  // without a live rclcpp::Node. The fields below are intentionally non-const so a test can
+  // populate them directly. The node-based constructor still fully initializes every field.
+  //
+  // The in-class member initializers below give the default-constructed instance SAFE, non-zero
+  // values for every field that EKFModule relies on at construction time. In particular
+  // extend_state_step must be >= 1: EKFModule sizes accumulated_delay_times_ as
+  // std::vector<double>(extend_state_step, 1.0E15), and find_closest_delay_time_index()
+  // dereferences accumulated_delay_times_.back(), which is undefined behaviour (a crash) on an
+  // empty vector. The other sizing/rate defaults (ekf_rate/ekf_dt, smoothing steps, queue sizes,
+  // gate distances, process/filter noise) are likewise non-zero so a default-constructed instance
+  // is immediately usable.
+  HyperParameters() = default;
+
   explicit HyperParameters(rclcpp::Node * node)
   : show_debug_info(node->declare_parameter<bool>("node.show_debug_info")),
     ekf_rate(node->declare_parameter<double>("node.predict_frequency")),
@@ -76,40 +90,43 @@ public:
   {
   }
 
-  const bool show_debug_info;
-  const double ekf_rate;  // ekf update frequency = predict_frequency [Hz]
-  const double ekf_dt;    // ekf update period [s]
-  const double tf_rate_;
-  const bool enable_yaw_bias_estimation;
-  const size_t extend_state_step;
-  const std::string pose_frame_id;
-  const double pose_additional_delay;
-  const double pose_gate_dist;
-  const size_t pose_smoothing_steps;
-  const size_t max_pose_queue_size;
-  const double twist_additional_delay;
-  const double twist_gate_dist;
-  const size_t twist_smoothing_steps;
-  const size_t max_twist_queue_size;
-  const double proc_stddev_vx_c;   //!< @brief  vx process noise
-  const double proc_stddev_wz_c;   //!< @brief  wz process noise
-  const double proc_stddev_yaw_c;  //!< @brief  yaw process noise
-  const double z_filter_proc_dev;
-  const double roll_filter_proc_dev;
-  const double pitch_filter_proc_dev;
-  const size_t pose_no_update_count_threshold_warn;
-  const size_t pose_no_update_count_threshold_error;
-  const size_t twist_no_update_count_threshold_warn;
-  const size_t twist_no_update_count_threshold_error;
-  double ellipse_scale;
-  double error_ellipse_size;
-  double warn_ellipse_size;
-  double error_ellipse_size_lateral_direction;
-  double warn_ellipse_size_lateral_direction;
-  const double diagnostics_publish_frequency;  //!< @brief diagnostics publish frequency [Hz]
-  const double diagnostics_publish_period;     //!< @brief diagnostics publish period [s]
+  // NOTE: these members are non-const so the default constructor (additive test seam) can set
+  // them. The node-based constructor still initializes all of them in its member initializer list.
+  bool show_debug_info{false};
+  double ekf_rate{50.0};      // ekf update frequency = predict_frequency [Hz]
+  double ekf_dt{1.0 / 50.0};  // ekf update period [s]
+  double tf_rate_{10.0};
+  bool enable_yaw_bias_estimation{true};
+  // Must be >= 1: EKFModule sizes accumulated_delay_times_ to this length and calls .back() on it.
+  size_t extend_state_step{50};
+  std::string pose_frame_id{"map"};
+  double pose_additional_delay{0.0};
+  double pose_gate_dist{10000.0};
+  size_t pose_smoothing_steps{5};
+  size_t max_pose_queue_size{5};
+  double twist_additional_delay{0.0};
+  double twist_gate_dist{10000.0};
+  size_t twist_smoothing_steps{2};
+  size_t max_twist_queue_size{5};
+  double proc_stddev_vx_c{10.0};    //!< @brief  vx process noise
+  double proc_stddev_wz_c{5.0};     //!< @brief  wz process noise
+  double proc_stddev_yaw_c{0.005};  //!< @brief  yaw process noise
+  double z_filter_proc_dev{1.0};
+  double roll_filter_proc_dev{0.01};
+  double pitch_filter_proc_dev{0.01};
+  size_t pose_no_update_count_threshold_warn{0};
+  size_t pose_no_update_count_threshold_error{0};
+  size_t twist_no_update_count_threshold_warn{0};
+  size_t twist_no_update_count_threshold_error{0};
+  double ellipse_scale{0.0};
+  double error_ellipse_size{0.0};
+  double warn_ellipse_size{0.0};
+  double error_ellipse_size_lateral_direction{0.0};
+  double warn_ellipse_size_lateral_direction{0.0};
+  double diagnostics_publish_frequency{0.0};  //!< @brief diagnostics publish frequency [Hz]
+  double diagnostics_publish_period{0.0};     //!< @brief diagnostics publish period [s]
 
-  const double threshold_observable_velocity_mps;
+  double threshold_observable_velocity_mps{0.0};
 };
 
 }  // namespace autoware::ekf_localizer

--- a/localization/autoware_ekf_localizer/src/include/warning.hpp
+++ b/localization/autoware_ekf_localizer/src/include/warning.hpp
@@ -17,6 +17,8 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <chrono>
+#include <cstddef>
 #include <string>
 
 namespace autoware::ekf_localizer
@@ -27,13 +29,26 @@ class Warning
 public:
   explicit Warning(rclcpp::Node * node) : node_(node) {}
 
+  // Additive seam: an explicitly-requested no-op logger constructed without a node, so EKFModule
+  // can be unit-tested outside of a ROS runtime. When node_ is null, warn/warn_throttle silently
+  // do nothing. The std::nullptr_t parameter forces callers to opt in deliberately
+  // (e.g. Warning(nullptr)); production code cannot accidentally default-construct a Warning and
+  // silently drop safety-relevant logs, because there is no default constructor.
+  explicit Warning(std::nullptr_t) : node_(nullptr) {}
+
   void warn(const std::string & message) const
   {
+    if (node_ == nullptr) {
+      return;
+    }
     RCLCPP_WARN(node_->get_logger(), "%s", message.c_str());
   }
 
   void warn_throttle(const std::string & message, const int duration_milliseconds) const
   {
+    if (node_ == nullptr) {
+      return;
+    }
     RCLCPP_WARN_THROTTLE(
       node_->get_logger(), *(node_->get_clock()),
       std::chrono::milliseconds(duration_milliseconds).count(), "%s", message.c_str());

--- a/localization/autoware_ekf_localizer/test/test_ekf_module.cpp
+++ b/localization/autoware_ekf_localizer/test/test_ekf_module.cpp
@@ -1,0 +1,476 @@
+// Copyright 2024 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "include/ekf_module.hpp"
+#include "include/hyper_parameters.hpp"
+#include "include/state_index.hpp"
+#include "include/warning.hpp"
+
+#include <autoware_utils_geometry/msg/covariance.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
+
+#include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <string>
+
+namespace autoware::ekf_localizer
+{
+
+namespace
+{
+// Build a HyperParameters instance with hand-set values via the additive default-constructor
+// seam, so EKFModule can be exercised without a live rclcpp::Node.
+HyperParameters make_params()
+{
+  HyperParameters params;
+  params.show_debug_info = false;
+  params.ekf_rate = 50.0;
+  params.ekf_dt = 1.0 / 50.0;
+  params.tf_rate_ = 10.0;
+  params.enable_yaw_bias_estimation = true;
+  params.extend_state_step = 50;
+  params.pose_frame_id = "map";
+  params.pose_additional_delay = 0.0;
+  params.pose_gate_dist = 10000.0;
+  params.pose_smoothing_steps = 5;
+  params.max_pose_queue_size = 5;
+  params.twist_additional_delay = 0.0;
+  params.twist_gate_dist = 10000.0;
+  params.twist_smoothing_steps = 2;
+  params.max_twist_queue_size = 5;
+  params.proc_stddev_vx_c = 10.0;
+  params.proc_stddev_wz_c = 5.0;
+  params.proc_stddev_yaw_c = 0.005;
+  params.z_filter_proc_dev = 1.0;
+  params.roll_filter_proc_dev = 0.01;
+  params.pitch_filter_proc_dev = 0.01;
+  return params;
+}
+
+std::shared_ptr<EKFModule> make_module(const HyperParameters & params)
+{
+  // Warning(nullptr) is an explicitly-requested no-op logger (node_ == nullptr).
+  auto warning = std::make_shared<Warning>(nullptr);
+  return std::make_shared<EKFModule>(warning, params);
+}
+
+geometry_msgs::msg::PoseWithCovarianceStamped make_pose(
+  const double x, const double y, const double yaw, const std::string & frame_id,
+  const rclcpp::Time & stamp)
+{
+  geometry_msgs::msg::PoseWithCovarianceStamped pose;
+  pose.header.frame_id = frame_id;
+  pose.header.stamp = stamp;
+  pose.pose.pose.position.x = x;
+  pose.pose.pose.position.y = y;
+  pose.pose.pose.position.z = 0.0;
+  tf2::Quaternion q;
+  q.setRPY(0.0, 0.0, yaw);
+  pose.pose.pose.orientation.x = q.x();
+  pose.pose.pose.orientation.y = q.y();
+  pose.pose.pose.orientation.z = q.z();
+  pose.pose.pose.orientation.w = q.w();
+  pose.pose.covariance.fill(0.0);
+  using COV_IDX = autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
+  pose.pose.covariance[COV_IDX::X_X] = 1.0;
+  pose.pose.covariance[COV_IDX::Y_Y] = 1.0;
+  pose.pose.covariance[COV_IDX::Z_Z] = 1.0;
+  pose.pose.covariance[COV_IDX::ROLL_ROLL] = 0.01;
+  pose.pose.covariance[COV_IDX::PITCH_PITCH] = 0.01;
+  pose.pose.covariance[COV_IDX::YAW_YAW] = 0.01;
+  return pose;
+}
+
+geometry_msgs::msg::TwistWithCovarianceStamped make_twist(
+  const double vx, const double wz, const std::string & frame_id, const rclcpp::Time & stamp)
+{
+  geometry_msgs::msg::TwistWithCovarianceStamped twist;
+  twist.header.frame_id = frame_id;
+  twist.header.stamp = stamp;
+  twist.twist.twist.linear.x = vx;
+  twist.twist.twist.angular.z = wz;
+  twist.twist.covariance.fill(0.0);
+  using COV_IDX = autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
+  twist.twist.covariance[COV_IDX::X_X] = 1.0;
+  twist.twist.covariance[COV_IDX::YAW_YAW] = 1.0;
+  return twist;
+}
+
+geometry_msgs::msg::TransformStamped identity_transform()
+{
+  geometry_msgs::msg::TransformStamped transform;
+  transform.transform.rotation.w = 1.0;
+  return transform;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// find_closest_delay_time_index
+// ---------------------------------------------------------------------------
+TEST(TestEKFModule, FindClosestDelayTimeIndex)
+{
+  const auto params = make_params();
+  auto module = make_module(params);
+
+  // Build a strictly increasing delay-time table: front becomes 0 and the rest accumulate.
+  // After one accumulate_delay_time(dt), the table is [0, 1e15 + dt, 1e15 + dt, ...].
+  // Repeatedly accumulating builds a monotonically-increasing prefix.
+  const double dt = 0.1;
+  for (size_t i = 0; i < params.extend_state_step; ++i) {
+    module->accumulate_delay_time(dt);
+  }
+  // After extend_state_step accumulations the table is [0, dt, 2*dt, ..., (n-1)*dt].
+
+  // target below the first element -> lower_bound at begin -> index 0
+  EXPECT_EQ(module->find_closest_delay_time_index(-1.0), 0u);
+
+  // target exactly the first element (0) -> begin -> index 0
+  EXPECT_EQ(module->find_closest_delay_time_index(0.0), 0u);
+
+  // closest-of-two: a value between two grid points snaps to the nearer one.
+  // grid is 0, 0.1, 0.2, ...; 0.14 is closer to 0.1 (index 1) than 0.2 (index 2).
+  EXPECT_EQ(module->find_closest_delay_time_index(0.14), 1u);
+  // 0.16 is closer to 0.2 (index 2).
+  EXPECT_EQ(module->find_closest_delay_time_index(0.16), 2u);
+
+  // target beyond the last element -> returns size (== extend_state_step).
+  const double beyond = static_cast<double>(params.extend_state_step) * dt + 1.0;
+  EXPECT_EQ(module->find_closest_delay_time_index(beyond), params.extend_state_step);
+}
+
+// ---------------------------------------------------------------------------
+// accumulate_delay_time: copy_backward shift + accumulation
+// ---------------------------------------------------------------------------
+TEST(TestEKFModule, AccumulateDelayTime)
+{
+  HyperParameters params = make_params();
+  params.extend_state_step = 4;
+  auto module = make_module(params);
+
+  // Initial table is filled with 1.0E15. find_closest_delay_time_index uses the table directly,
+  // so we can probe its boundary behaviour to characterize the shift/accumulation.
+  const double dt = 0.2;
+
+  // First accumulation: front -> 0, others -> 1e15 + dt (still huge).
+  module->accumulate_delay_time(dt);
+  // Index 0 corresponds to delay 0.
+  EXPECT_EQ(module->find_closest_delay_time_index(0.0), 0u);
+
+  // Second accumulation shifts and the second element becomes 0 + dt = dt, the rest stay huge.
+  module->accumulate_delay_time(dt);
+  // Now table[0] = 0, table[1] = dt, table[2..] huge. A target at dt snaps to index 1.
+  EXPECT_EQ(module->find_closest_delay_time_index(dt), 1u);
+
+  // Third accumulation: table[0]=0, table[1]=dt, table[2]=2*dt, table[3] huge.
+  module->accumulate_delay_time(dt);
+  EXPECT_EQ(module->find_closest_delay_time_index(2.0 * dt), 2u);
+
+  // A target larger than the (still huge) last element returns size().
+  EXPECT_EQ(module->find_closest_delay_time_index(2.0e15), params.extend_state_step);
+}
+
+// ---------------------------------------------------------------------------
+// Simple1DFilter init + update
+// ---------------------------------------------------------------------------
+TEST(TestSimple1DFilter, InitAndUpdate)
+{
+  Simple1DFilter filter;
+  // Before init, update() must initialize from the first observation.
+  filter.update(5.0, 2.0, 0.1);
+  EXPECT_DOUBLE_EQ(filter.get_x(), 5.0);
+  EXPECT_DOUBLE_EQ(filter.get_var(), 2.0);
+
+  // A subsequent update performs the Kalman blend.
+  // With proc_var = 0, var stays 2.0 during prediction.
+  // kalman_gain = var / (var + obs_var) = 2 / (2 + 2) = 0.5.
+  // x = 5 + 0.5 * (7 - 5) = 6.0; var = (1 - 0.5) * 2 = 1.0.
+  filter.update(7.0, 2.0, 0.1);
+  EXPECT_DOUBLE_EQ(filter.get_x(), 6.0);
+  EXPECT_DOUBLE_EQ(filter.get_var(), 1.0);
+}
+
+TEST(TestSimple1DFilter, ProcessVarianceInflatesPrediction)
+{
+  Simple1DFilter filter;
+  filter.set_proc_var(4.0);  // proc_var_x_c_
+  filter.init(0.0, 1.0);     // x_ = 0, var_ = 1.0
+
+  // Prediction step: proc_var_x_d = 4.0 * dt^2 = 4.0 * 0.25 = 1.0; var = 1.0 + 1.0 = 2.0.
+  // Update step: kalman_gain = 2 / (2 + 2) = 0.5; x = 0 + 0.5 * (10 - 0) = 5.0;
+  // var = (1 - 0.5) * 2 = 1.0.
+  filter.update(10.0, 2.0, 0.5);
+  EXPECT_DOUBLE_EQ(filter.get_x(), 5.0);
+  EXPECT_DOUBLE_EQ(filter.get_var(), 1.0);
+}
+
+// ---------------------------------------------------------------------------
+// compensate_rph_with_delay: zero vs non-zero angular velocity, delta_z correction
+// ---------------------------------------------------------------------------
+TEST(TestEKFModule, CompensateRphWithDelayZeroAngularVelocity)
+{
+  const auto params = make_params();
+  auto module = make_module(params);
+
+  const rclcpp::Time stamp(100, 0, RCL_ROS_TIME);
+  auto pose = make_pose(1.0, 2.0, 0.3, "map", stamp);
+
+  const tf2::Vector3 zero_angular_velocity(0.0, 0.0, 0.0);
+  const double delay_time = 0.2;
+  const auto compensated =
+    module->compensate_rph_with_delay(pose, zero_angular_velocity, delay_time);
+
+  // With zero angular velocity the orientation is unchanged (delta is identity).
+  EXPECT_NEAR(compensated.pose.pose.orientation.x, pose.pose.pose.orientation.x, 1e-9);
+  EXPECT_NEAR(compensated.pose.pose.orientation.y, pose.pose.pose.orientation.y, 1e-9);
+  EXPECT_NEAR(compensated.pose.pose.orientation.z, pose.pose.pose.orientation.z, 1e-9);
+  EXPECT_NEAR(compensated.pose.pose.orientation.w, pose.pose.pose.orientation.w, 1e-9);
+
+  // The header stamp is shifted forward by delay_time.
+  const rclcpp::Time compensated_stamp(compensated.header.stamp);
+  EXPECT_NEAR(compensated_stamp.seconds(), stamp.seconds() + delay_time, 1e-9);
+
+  // With a fresh module (VX == 0) and zero pitch, delta_z is 0.
+  EXPECT_NEAR(compensated.pose.pose.position.z, pose.pose.pose.position.z, 1e-9);
+}
+
+TEST(TestEKFModule, CompensateRphWithDelayNonZeroAngularVelocity)
+{
+  const auto params = make_params();
+  auto module = make_module(params);
+
+  const rclcpp::Time stamp(100, 0, RCL_ROS_TIME);
+  auto pose = make_pose(0.0, 0.0, 0.0, "map", stamp);
+
+  // Non-zero yaw rate -> orientation must rotate by omega * delay_time about Z.
+  const tf2::Vector3 angular_velocity(0.0, 0.0, 1.0);
+  const double delay_time = 0.5;
+  const auto compensated = module->compensate_rph_with_delay(pose, angular_velocity, delay_time);
+
+  // Expected yaw delta = |omega| * delay_time = 1.0 * 0.5 = 0.5 rad.
+  tf2::Quaternion q(
+    compensated.pose.pose.orientation.x, compensated.pose.pose.orientation.y,
+    compensated.pose.pose.orientation.z, compensated.pose.pose.orientation.w);
+  const double yaw = tf2::getYaw(q);
+  EXPECT_NEAR(yaw, 0.5, 1e-6);
+}
+
+// ---------------------------------------------------------------------------
+// measurement_update_pose: success and safety-critical rejection branches
+// ---------------------------------------------------------------------------
+class MeasurementUpdatePose : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    params_ = make_params();
+    reset_module();
+  }
+
+  // (Re)build the module from the current params_, initialize at the origin, fill the delay-time
+  // table with realistic small values (one accumulation per predict cycle in the real node), and
+  // run a prediction so the EKF state is well-defined.
+  void reset_module()
+  {
+    module_ = make_module(params_);
+    const rclcpp::Time t0(100, 0, RCL_ROS_TIME);
+    auto initial_pose = make_pose(0.0, 0.0, 0.0, "map", t0);
+    module_->initialize(initial_pose, identity_transform());
+    for (size_t i = 0; i < params_.extend_state_step; ++i) {
+      module_->accumulate_delay_time(params_.ekf_dt);
+    }
+    module_->predict_with_delay(params_.ekf_dt);
+  }
+
+  HyperParameters params_;
+  std::shared_ptr<EKFModule> module_;
+};
+
+TEST_F(MeasurementUpdatePose, AcceptsValidMeasurement)
+{
+  const rclcpp::Time t_curr(100, 0, RCL_ROS_TIME);
+  auto pose = make_pose(0.0, 0.0, 0.0, "map", t_curr);
+
+  EKFDiagnosticInfo diag;
+  const bool ok = module_->measurement_update_pose(pose, t_curr, diag);
+
+  EXPECT_TRUE(ok);
+  EXPECT_TRUE(diag.is_passed_delay_gate);
+  EXPECT_TRUE(diag.is_passed_mahalanobis_gate);
+}
+
+TEST_F(MeasurementUpdatePose, RejectsOnDelayGate)
+{
+  // A pose timestamped far in the past produces a delay larger than the table threshold,
+  // so delay_step >= extend_state_step and the update is rejected.
+  const rclcpp::Time t_curr(1000, 0, RCL_ROS_TIME);
+  const rclcpp::Time t_old(100, 0, RCL_ROS_TIME);
+  auto pose = make_pose(0.0, 0.0, 0.0, "map", t_old);
+
+  EKFDiagnosticInfo diag;
+  const bool ok = module_->measurement_update_pose(pose, t_curr, diag);
+
+  EXPECT_FALSE(ok);
+  EXPECT_FALSE(diag.is_passed_delay_gate);
+}
+
+TEST_F(MeasurementUpdatePose, RejectsOnNan)
+{
+  const rclcpp::Time t_curr(100, 0, RCL_ROS_TIME);
+  auto pose = make_pose(0.0, 0.0, 0.0, "map", t_curr);
+  pose.pose.pose.position.x = std::numeric_limits<double>::quiet_NaN();
+
+  EKFDiagnosticInfo diag;
+  const bool ok = module_->measurement_update_pose(pose, t_curr, diag);
+
+  EXPECT_FALSE(ok);
+  // The NaN gate is reached after the delay gate, so the delay gate is still marked passed.
+  EXPECT_TRUE(diag.is_passed_delay_gate);
+}
+
+TEST_F(MeasurementUpdatePose, RejectsOnInf)
+{
+  const rclcpp::Time t_curr(100, 0, RCL_ROS_TIME);
+  auto pose = make_pose(0.0, 0.0, 0.0, "map", t_curr);
+  pose.pose.pose.position.y = std::numeric_limits<double>::infinity();
+
+  EKFDiagnosticInfo diag;
+  const bool ok = module_->measurement_update_pose(pose, t_curr, diag);
+
+  EXPECT_FALSE(ok);
+}
+
+TEST_F(MeasurementUpdatePose, RejectsOnMahalanobisGate)
+{
+  // Tighten the gate so a far-away measurement is rejected by the Mahalanobis distance check.
+  params_.pose_gate_dist = 1e-6;
+  reset_module();
+
+  const rclcpp::Time t_curr(100, 0, RCL_ROS_TIME);
+  auto pose = make_pose(1000.0, 1000.0, 0.0, "map", t_curr);
+
+  EKFDiagnosticInfo diag;
+  const bool ok = module_->measurement_update_pose(pose, t_curr, diag);
+
+  EXPECT_FALSE(ok);
+  EXPECT_TRUE(diag.is_passed_delay_gate);
+  EXPECT_FALSE(diag.is_passed_mahalanobis_gate);
+  EXPECT_GT(diag.mahalanobis_distance, 0.0);
+}
+
+// ---------------------------------------------------------------------------
+// measurement_update_twist: success and safety-critical rejection branches
+// ---------------------------------------------------------------------------
+class MeasurementUpdateTwist : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    params_ = make_params();
+    reset_module();
+  }
+
+  void reset_module()
+  {
+    module_ = make_module(params_);
+    const rclcpp::Time t0(100, 0, RCL_ROS_TIME);
+    auto initial_pose = make_pose(0.0, 0.0, 0.0, "map", t0);
+    module_->initialize(initial_pose, identity_transform());
+    for (size_t i = 0; i < params_.extend_state_step; ++i) {
+      module_->accumulate_delay_time(params_.ekf_dt);
+    }
+    module_->predict_with_delay(params_.ekf_dt);
+  }
+
+  HyperParameters params_;
+  std::shared_ptr<EKFModule> module_;
+};
+
+TEST_F(MeasurementUpdateTwist, AcceptsValidMeasurement)
+{
+  const rclcpp::Time t_curr(100, 0, RCL_ROS_TIME);
+  auto twist = make_twist(0.0, 0.0, "base_link", t_curr);
+
+  EKFDiagnosticInfo diag;
+  const bool ok = module_->measurement_update_twist(twist, t_curr, diag);
+
+  EXPECT_TRUE(ok);
+  EXPECT_TRUE(diag.is_passed_delay_gate);
+  EXPECT_TRUE(diag.is_passed_mahalanobis_gate);
+}
+
+TEST_F(MeasurementUpdateTwist, RejectsOnDelayGate)
+{
+  const rclcpp::Time t_curr(1000, 0, RCL_ROS_TIME);
+  const rclcpp::Time t_old(100, 0, RCL_ROS_TIME);
+  auto twist = make_twist(0.0, 0.0, "base_link", t_old);
+
+  EKFDiagnosticInfo diag;
+  const bool ok = module_->measurement_update_twist(twist, t_curr, diag);
+
+  EXPECT_FALSE(ok);
+  EXPECT_FALSE(diag.is_passed_delay_gate);
+}
+
+TEST_F(MeasurementUpdateTwist, RejectsOnNan)
+{
+  const rclcpp::Time t_curr(100, 0, RCL_ROS_TIME);
+  auto twist = make_twist(0.0, 0.0, "base_link", t_curr);
+  twist.twist.twist.linear.x = std::numeric_limits<double>::quiet_NaN();
+
+  EKFDiagnosticInfo diag;
+  const bool ok = module_->measurement_update_twist(twist, t_curr, diag);
+
+  EXPECT_FALSE(ok);
+  EXPECT_TRUE(diag.is_passed_delay_gate);
+}
+
+TEST_F(MeasurementUpdateTwist, RejectsOnInf)
+{
+  const rclcpp::Time t_curr(100, 0, RCL_ROS_TIME);
+  auto twist = make_twist(0.0, 0.0, "base_link", t_curr);
+  twist.twist.twist.angular.z = std::numeric_limits<double>::infinity();
+
+  EKFDiagnosticInfo diag;
+  const bool ok = module_->measurement_update_twist(twist, t_curr, diag);
+
+  EXPECT_FALSE(ok);
+}
+
+TEST_F(MeasurementUpdateTwist, RejectsOnMahalanobisGate)
+{
+  params_.twist_gate_dist = 1e-6;
+  reset_module();
+
+  const rclcpp::Time t_curr(100, 0, RCL_ROS_TIME);
+  auto twist = make_twist(1000.0, 1000.0, "base_link", t_curr);
+
+  EKFDiagnosticInfo diag;
+  const bool ok = module_->measurement_update_twist(twist, t_curr, diag);
+
+  EXPECT_FALSE(ok);
+  EXPECT_TRUE(diag.is_passed_delay_gate);
+  EXPECT_FALSE(diag.is_passed_mahalanobis_gate);
+  EXPECT_GT(diag.mahalanobis_distance, 0.0);
+}
+
+}  // namespace autoware::ekf_localizer


### PR DESCRIPTION
## Description

This PR raises unit-test coverage of `EKFModule`'s core algorithm and safety-critical rejection paths, which were previously exercised only indirectly through the slow Python launch tests.

To make `EKFModule` constructible inside a plain gtest (without a live `rclcpp::Node`), two purely additive, behavior-preserving test seams were added:

- `HyperParameters` gains an additive default constructor, and its members were relaxed from `const` to non-`const` so a test can populate them by hand. The existing `HyperParameters(rclcpp::Node *)` constructor is unchanged and still initializes every field in declaration order, so the node-driven values (including derived `ekf_dt` and `diagnostics_publish_period`) are byte-identical.
- `Warning` gains an additive no-op constructor that holds a null node, and `warn` / `warn_throttle` became null-guarded. The guard is a no-op only when `node_ == nullptr`; with a real node the logging behavior is byte-identical.

The new `test/test_ekf_module.cpp` adds 16 gtest cases covering:

- `find_closest_delay_time_index` (begin/end bounds, target-beyond-last, closest-of-two).
- `accumulate_delay_time` (shift and accumulation semantics).
- `Simple1DFilter` (init and Kalman-blend update; process-variance inflation).
- `compensate_rph_with_delay` (zero vs non-zero angular-velocity branches).
- The safety-critical rejection paths of `measurement_update_pose` / `measurement_update_twist`: delay gate, NaN ignore, Inf ignore, and the Mahalanobis-distance gate — asserting both the boolean return and the resulting `EKFDiagnosticInfo` flags.

This PR also folds in a small, numerically-neutral cleanup in `predict_with_delay`: a dead full-covariance heap copy (an unused `p_curr` read of `getLatestP()`) was removed, and `x_curr` is now declared as `Vector6d` to avoid a dynamic-to-fixed Eigen conversion copy. The same `x_next` / `A` / `Q` are passed to the Kalman filter as before.

A conditional P-block micro-optimization in `measurement_update_pose`/`twist` was intentionally not done: `TimeDelayKalmanFilter::getLatestP()` returns `Eigen::MatrixXd` by value and there is no const-reference accessor, so avoiding the copy would require modifying `autoware_kalman_filter`, which is out of scope for this single-package PR.

## Related links

**Parent Issue:**

- N/A

## How was this PR tested?

Built and tested in the `autoware:core-devel-jazzy` container with the standard colcon flow:

```bash
colcon build --symlink-install --packages-select autoware_ekf_localizer \
  --cmake-args -DCMAKE_BUILD_TYPE=Release
colcon test --packages-select autoware_ekf_localizer --event-handlers console_cohesion+
colcon test-result --verbose
```

Results:

- New gtest binary `test_ekf_module`: `[ PASSED ] 16 tests` from 4 test suites.
- Full package summary: `157 tests, 0 errors, 0 failures, 34 skipped` (the 34 skipped are the slow Python launch tests, which require a ROS runtime and privileged networking and are run by CI).

`pre-commit run --files` on all changed files passes (clang-format, cpplint, etc.).

## Notes for reviewers

The test seams are additive only: the existing node-based `HyperParameters` and `Warning` constructors and their runtime logging behavior are unchanged when a real node is present. The modified headers live in `src/include/` and are not installed, so `EKFModule`, `HyperParameters`, and `Warning` remain package-internal — no exported public API/ABI changes. The `predict_with_delay` change is internal and numerically identical (verified by the full passing suite).

## Interface changes

None.

## Effects on system behavior

None. The `EKFLocalizer` node's ROS interface (topics, services, parameters) is untouched, and the `predict_with_delay` cleanup produces identical numeric output.
