### PR TITLE
fix(autoware_qp_interface): report real OSQP solver status and drop redundant vector copies

### DIFF
--- a/common/autoware_qp_interface/CMakeLists.txt
+++ b/common/autoware_qp_interface/CMakeLists.txt
@@ -52,12 +52,15 @@ ament_export_libraries(osqp::osqp)
 if(BUILD_TESTING)
   set(TEST_SOURCES
     test/test_osqp_interface.cpp
+    test/test_osqp_interface_status.cpp
     test/test_csc_matrix_conv.cpp
     test/test_proxqp_interface.cpp
     test/test_qp_interface.cpp
   )
   set(TEST_OSQP_INTERFACE_EXE test_osqp_interface)
   ament_add_ros_isolated_gtest(${TEST_OSQP_INTERFACE_EXE} ${TEST_SOURCES})
+  # allow tests to reach the internal (non-installed) headers under src/
+  target_include_directories(${TEST_OSQP_INTERFACE_EXE} PRIVATE src)
   target_link_libraries(${TEST_OSQP_INTERFACE_EXE} ${PROJECT_NAME})
 endif()
 

--- a/common/autoware_qp_interface/include/autoware/qp_interface/osqp_interface.hpp
+++ b/common/autoware_qp_interface/include/autoware/qp_interface/osqp_interface.hpp
@@ -126,7 +126,10 @@ private:
   std::unique_ptr<OSQPSettings> settings_;
   std::unique_ptr<OSQPData> data_;
   // store last work info since work is cleaned up at every execution to prevent memory leak.
-  OSQPInfo latest_work_info_;
+  // Value-initialized so that all members are zeroed before the first solve; the constructor
+  // additionally sets status_val to OSQP_UNSOLVED so that getStatus()/isSolved() are deterministic
+  // (report "not solved") when queried before optimize() has ever run.
+  OSQPInfo latest_work_info_{};
   // Number of parameters to optimize
   int64_t param_n_;
   // Flag to check if the current work exists

--- a/common/autoware_qp_interface/src/osqp_interface.cpp
+++ b/common/autoware_qp_interface/src/osqp_interface.cpp
@@ -15,6 +15,7 @@
 #include "autoware/qp_interface/osqp_interface.hpp"
 
 #include "autoware/qp_interface/osqp_csc_matrix_conv.hpp"
+#include "osqp_interface_status.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -25,6 +26,38 @@
 
 namespace autoware::qp_interface
 {
+std::string status_to_string(c_int status_val)
+{
+  switch (status_val) {
+    case OSQP_SOLVED:
+      return "OSQP_SOLVED";
+    case OSQP_SOLVED_INACCURATE:
+      return "OSQP_SOLVED_INACCURATE";
+    case OSQP_MAX_ITER_REACHED:
+      return "OSQP_MAX_ITER_REACHED";
+    case OSQP_PRIMAL_INFEASIBLE:
+      return "OSQP_PRIMAL_INFEASIBLE";
+    case OSQP_PRIMAL_INFEASIBLE_INACCURATE:
+      return "OSQP_PRIMAL_INFEASIBLE_INACCURATE";
+    case OSQP_DUAL_INFEASIBLE:
+      return "OSQP_DUAL_INFEASIBLE";
+    case OSQP_DUAL_INFEASIBLE_INACCURATE:
+      return "OSQP_DUAL_INFEASIBLE_INACCURATE";
+    case OSQP_SIGINT:
+      return "OSQP_SIGINT";
+    case OSQP_NON_CVX:
+      return "OSQP_NON_CVX";
+    case OSQP_UNSOLVED:
+      return "OSQP_UNSOLVED";
+#ifdef OSQP_TIME_LIMIT_REACHED
+    case OSQP_TIME_LIMIT_REACHED:
+      return "OSQP_TIME_LIMIT_REACHED";
+#endif
+    default:
+      return "OSQP_UNKNOWN";
+  }
+}
+
 OSQPInterface::OSQPInterface(
   const bool enable_warm_start, const int max_iteration, const c_float eps_abs,
   const c_float eps_rel, const bool polish, const bool verbose)
@@ -46,6 +79,10 @@ OSQPInterface::OSQPInterface(
     settings_->polish = polish;
   }
   exitflag_ = 0;
+  // latest_work_info_ is value-initialized (all members zeroed) at its declaration. status_val == 0
+  // is not a meaningful OSQP status, so explicitly set it to OSQP_UNSOLVED so that a pre-solve
+  // getStatus()/isSolved() is deterministic and reports "not solved".
+  latest_work_info_.status_val = OSQP_UNSOLVED;
 }
 
 OSQPInterface::OSQPInterface(
@@ -298,33 +335,25 @@ void OSQPInterface::updateCscA(const CSC_Matrix & A_csc)
 
 void OSQPInterface::updateQ(const std::vector<double> & q_new)
 {
-  std::vector<double> q_tmp(q_new.begin(), q_new.end());
-  double * q_dyn = q_tmp.data();
-  osqp_update_lin_cost(work_.get(), q_dyn);
+  // OSQP takes a const c_float* (== const double*), so the vector data can be
+  // passed directly without copying into a temporary.
+  osqp_update_lin_cost(work_.get(), q_new.data());
 }
 
 void OSQPInterface::updateL(const std::vector<double> & l_new)
 {
-  std::vector<double> l_tmp(l_new.begin(), l_new.end());
-  double * l_dyn = l_tmp.data();
-  osqp_update_lower_bound(work_.get(), l_dyn);
+  osqp_update_lower_bound(work_.get(), l_new.data());
 }
 
 void OSQPInterface::updateU(const std::vector<double> & u_new)
 {
-  std::vector<double> u_tmp(u_new.begin(), u_new.end());
-  double * u_dyn = u_tmp.data();
-  osqp_update_upper_bound(work_.get(), u_dyn);
+  osqp_update_upper_bound(work_.get(), u_new.data());
 }
 
 void OSQPInterface::updateBounds(
   const std::vector<double> & l_new, const std::vector<double> & u_new)
 {
-  std::vector<double> l_tmp(l_new.begin(), l_new.end());
-  std::vector<double> u_tmp(u_new.begin(), u_new.end());
-  double * l_dyn = l_tmp.data();
-  double * u_dyn = u_tmp.data();
-  osqp_update_bounds(work_.get(), l_dyn, u_dyn);
+  osqp_update_bounds(work_.get(), l_new.data(), u_new.data());
 }
 
 int OSQPInterface::getIterationNumber() const
@@ -334,7 +363,7 @@ int OSQPInterface::getIterationNumber() const
 
 std::string OSQPInterface::getStatus() const
 {
-  return "OSQP_SOLVED";
+  return status_to_string(latest_work_info_.status_val);
 }
 
 bool OSQPInterface::isSolved() const

--- a/common/autoware_qp_interface/src/osqp_interface_status.hpp
+++ b/common/autoware_qp_interface/src/osqp_interface_status.hpp
@@ -1,0 +1,36 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This is an internal (non-installed) header. It is intentionally kept
+// out of the public include/ tree so that it is not part of the package's
+// exported API/ABI. It exists to make the pure status-mapping helper unit
+// testable.
+
+#ifndef OSQP_INTERFACE_STATUS_HPP_
+#define OSQP_INTERFACE_STATUS_HPP_
+
+#include <osqp/osqp.h>
+
+#include <string>
+
+namespace autoware::qp_interface
+{
+/// \brief Map an OSQP solver status value to its canonical string name.
+/// \param status_val One of the OSQP_* status codes defined in osqp.h.
+/// \return The string name of the status (e.g. "OSQP_SOLVED"), or
+///         "OSQP_UNKNOWN" for an unrecognized value.
+std::string status_to_string(c_int status_val);
+}  // namespace autoware::qp_interface
+
+#endif  // OSQP_INTERFACE_STATUS_HPP_

--- a/common/autoware_qp_interface/src/proxqp_interface.cpp
+++ b/common/autoware_qp_interface/src/proxqp_interface.cpp
@@ -69,16 +69,10 @@ void ProxQPInterface::initializeProblemImpl(
     static_cast<Eigen::Index>(variables_num), static_cast<Eigen::Index>(constraints_num));
   P_sparse = P.sparseView();
 
-  // NOTE: const std vector cannot be converted to eigen vector
-  std::vector<double> non_const_q = q;
-  Eigen::VectorXd eigen_q = Eigen::Map<Eigen::VectorXd, Eigen::Unaligned>(
-    non_const_q.data(), static_cast<Eigen::Index>(non_const_q.size()));
-  std::vector<double> l_std_vec = l;
-  Eigen::VectorXd eigen_l = Eigen::Map<Eigen::VectorXd, Eigen::Unaligned>(
-    l_std_vec.data(), static_cast<Eigen::Index>(l_std_vec.size()));
-  std::vector<double> u_std_vec = u;
-  Eigen::VectorXd eigen_u = Eigen::Map<Eigen::VectorXd, Eigen::Unaligned>(
-    u_std_vec.data(), static_cast<Eigen::Index>(u_std_vec.size()));
+  // Map the const std::vector data directly into Eigen vectors without copying.
+  const Eigen::Map<const Eigen::VectorXd> eigen_q(q.data(), static_cast<Eigen::Index>(q.size()));
+  const Eigen::Map<const Eigen::VectorXd> eigen_l(l.data(), static_cast<Eigen::Index>(l.size()));
+  const Eigen::Map<const Eigen::VectorXd> eigen_u(u.data(), static_cast<Eigen::Index>(u.size()));
 
   if (enable_warm_start) {
     qp_ptr_->update(

--- a/common/autoware_qp_interface/test/test_osqp_interface.cpp
+++ b/common/autoware_qp_interface/test/test_osqp_interface.cpp
@@ -256,7 +256,13 @@ TEST(TestOsqpInterface, UpdateSettingsAfterInitialization)
   const auto solution = osqp.optimize(P_csc_new, A_csc_new, q, l, u);
   const auto status = osqp.getStatus();
 
-  EXPECT_EQ(status, "OSQP_SOLVED");
+  // The redefined problem (P = ones(2, 2), A = ones(4, 2) with the original
+  // bounds) is primal infeasible: the first constraint forces x0 + x1 == 1
+  // while the second and third force x0 + x1 <= 0.7. Now that getStatus()
+  // reports the real solver status (instead of the previously hardcoded
+  // "OSQP_SOLVED"), assert the true outcome.
+  EXPECT_EQ(status, "OSQP_PRIMAL_INFEASIBLE");
+  EXPECT_FALSE(osqp.isSolved());
 }
 
 }  // namespace

--- a/common/autoware_qp_interface/test/test_osqp_interface_status.cpp
+++ b/common/autoware_qp_interface/test/test_osqp_interface_status.cpp
@@ -1,0 +1,89 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/qp_interface/osqp_interface.hpp"
+#include "gtest/gtest.h"
+#include "osqp_interface_status.hpp"
+
+#include <Eigen/Core>
+
+#include <string>
+#include <vector>
+
+namespace
+{
+// Unit tests for the pure status-mapping helper. These pin the mapping from the
+// raw OSQP status codes to their canonical string names independently of any
+// solver run.
+TEST(TestOsqpInterfaceStatus, StatusToString)
+{
+  using autoware::qp_interface::status_to_string;
+
+  EXPECT_EQ(status_to_string(OSQP_SOLVED), "OSQP_SOLVED");
+  EXPECT_EQ(status_to_string(OSQP_SOLVED_INACCURATE), "OSQP_SOLVED_INACCURATE");
+  EXPECT_EQ(status_to_string(OSQP_MAX_ITER_REACHED), "OSQP_MAX_ITER_REACHED");
+  EXPECT_EQ(status_to_string(OSQP_PRIMAL_INFEASIBLE), "OSQP_PRIMAL_INFEASIBLE");
+  EXPECT_EQ(
+    status_to_string(OSQP_PRIMAL_INFEASIBLE_INACCURATE), "OSQP_PRIMAL_INFEASIBLE_INACCURATE");
+  EXPECT_EQ(status_to_string(OSQP_DUAL_INFEASIBLE), "OSQP_DUAL_INFEASIBLE");
+  EXPECT_EQ(status_to_string(OSQP_DUAL_INFEASIBLE_INACCURATE), "OSQP_DUAL_INFEASIBLE_INACCURATE");
+  EXPECT_EQ(status_to_string(OSQP_SIGINT), "OSQP_SIGINT");
+  EXPECT_EQ(status_to_string(OSQP_NON_CVX), "OSQP_NON_CVX");
+  EXPECT_EQ(status_to_string(OSQP_UNSOLVED), "OSQP_UNSOLVED");
+#ifdef OSQP_TIME_LIMIT_REACHED
+  EXPECT_EQ(status_to_string(OSQP_TIME_LIMIT_REACHED), "OSQP_TIME_LIMIT_REACHED");
+#endif
+
+  // Unknown / unmapped value falls back to a sentinel rather than mis-reporting
+  // a solved status.
+  EXPECT_EQ(status_to_string(static_cast<c_int>(12345)), "OSQP_UNKNOWN");
+}
+
+// Coverage: a primal-infeasible problem must NOT report solved. With the old
+// hardcoded getStatus() this fails because it always returned "OSQP_SOLVED".
+TEST(TestOsqpInterfaceStatus, InfeasibleProblemReportsNotSolved)
+{
+  using autoware::qp_interface::calCSCMatrix;
+  using autoware::qp_interface::calCSCMatrixTrapezoidal;
+  using autoware::qp_interface::CSC_Matrix;
+
+  // min 1/2 x'Px + q'x  s.t.  l <= A x <= u, with contradictory bounds:
+  //   x >= 1  and  x <= 0  ->  primal infeasible.
+  const Eigen::MatrixXd P = (Eigen::MatrixXd(1, 1) << 1.0).finished();
+  const Eigen::MatrixXd A = (Eigen::MatrixXd(2, 1) << 1.0, 1.0).finished();
+  const std::vector<double> q = {0.0};
+  const std::vector<double> l = {1.0, -autoware::qp_interface::OSQP_INF};
+  const std::vector<double> u = {autoware::qp_interface::OSQP_INF, 0.0};
+
+  autoware::qp_interface::OSQPInterface osqp(false, 4000, 1e-6);
+  osqp.optimize(calCSCMatrixTrapezoidal(P), calCSCMatrix(A), q, l, u);
+
+  EXPECT_FALSE(osqp.isSolved());
+  const auto status = osqp.getStatus();
+  EXPECT_NE(status, "OSQP_SOLVED");
+}
+
+// A freshly-constructed interface (no optimize() call yet) must report a
+// deterministic "not solved" state. latest_work_info_ is value-initialized and
+// its status_val is set to OSQP_UNSOLVED in the constructor, so this does not
+// read uninitialized memory.
+TEST(TestOsqpInterfaceStatus, FreshlyConstructedIsNotSolved)
+{
+  // This constructor only sets up settings; it does not run the solver.
+  autoware::qp_interface::OSQPInterface osqp(false, 4000, 1e-6);
+
+  EXPECT_FALSE(osqp.isSolved());
+  EXPECT_EQ(osqp.getStatus(), "OSQP_UNSOLVED");
+}
+}  // namespace


### PR DESCRIPTION
## Description

This PR fixes a correctness defect in `OSQPInterface` plus two copy-free cleanups, all scoped to `autoware_qp_interface`.

1. Bug fix: `OSQPInterface::getStatus()` was hardcoded to always return `"OSQP_SOLVED"`, so it masked every non-solved outcome (max-iteration reached, primal/dual infeasible, unsolved, etc.). Only `isSolved()` actually discriminated, leaving any caller that logged or branched on the status string with a value that was always wrong on failure. The status-to-string mapping is extracted into a pure free function `status_to_string(c_int)` in a new internal (non-installed) header `src/osqp_interface_status.hpp`, covering all `OSQP_*` codes (`SOLVED`, `SOLVED_INACCURATE`, `MAX_ITER_REACHED`, `PRIMAL_INFEASIBLE[_INACCURATE]`, `DUAL_INFEASIBLE[_INACCURATE]`, `SIGINT`, `NON_CVX`, `UNSOLVED`, and `TIME_LIMIT_REACHED` under its `#ifdef` guard) with an `OSQP_UNKNOWN` fallback for unrecognized values. `getStatus()` now returns `status_to_string(latest_work_info_.status_val)`.

2. Performance cleanup (OSQP path): `updateQ` / `updateL` / `updateU` / `updateBounds` previously allocated a per-call `std::vector` copy of their input before handing it to OSQP. The OSQP C API (`osqp_update_lin_cost` / `osqp_update_lower_bound` / `osqp_update_upper_bound` / `osqp_update_bounds`) takes a `const c_float*` and `c_float == double`, so the input vector's `.data()` pointer is now passed directly with no copy.

3. Performance cleanup (ProxQP path): in `proxqp_interface.cpp` the `q` / `l` / `u` `std::vector` copies are replaced with `Eigen::Map<const Eigen::VectorXd>` views over the const data pointers, which ProxQP `init` / `update` consume read-only via `Eigen::Ref<const VectorXd>`.

The new internal header lives under `src/` and is intentionally not added to the installed `include/` tree, so it is not part of the package's exported API.

## Related links

**Parent Issue:**

- None

## How was this PR tested?

- Container build and test (`autoware:core-devel-jazzy`): `colcon build --packages-select autoware_qp_interface` followed by `colcon test --packages-select autoware_qp_interface` and `colcon test-result --verbose`. Result: `51 tests, 0 errors, 0 failures, 14 skipped`; the gtest binary reported `[ PASSED ] 16 tests`, and the 4 linters (copyright, cppcheck, lint_cmake, xmllint) were green.
- New unit tests:
  - `TestOsqpInterfaceStatus.StatusToString` pins the pure helper mapping for every status code and the unknown-value fallback to `OSQP_UNKNOWN`.
  - `TestOsqpInterfaceStatus.InfeasibleProblemReportsNotSolved` runs a deliberately primal-infeasible problem and asserts `isSolved() == false` and `getStatus() != "OSQP_SOLVED"`. This fails against the old hardcoded implementation and passes with the fix.
- Updated existing test: `TestOsqpInterface.UpdateSettingsAfterInitialization` previously only passed because of the hardcoded status; it now asserts the true outcome (`OSQP_PRIMAL_INFEASIBLE`, `isSolved() == false`).
- RED/GREEN was confirmed: reverting `getStatus()` to the hardcoded string makes both coverage tests fail (observed `"OSQP_SOLVED"` vs expected `"OSQP_PRIMAL_INFEASIBLE"`), proving the bug was real and the new behavior correct.
- The perf changes are characterization-pinned by `TestOsqpInterface.BasicQp` and `TestProxqpInterface.BasicQp`, which assert the exact solution `[0.3, 0.7]` to `1e-8` across both the no-warm-start (init) and warm-start (update) paths; both still pass, so the copy-free refactor preserves the numerical result.

## Notes for reviewers

The `status_to_string` helper has external linkage in the built `.so` because it is defined at namespace scope in the `.cpp`. It is not declared in any installed header, so it is not part of the usable public API and the no-public-signature-change requirement holds. The internal-header approach is used purely so the pure helper can be unit-tested directly.

## Interface changes

None.

## Effects on system behavior

`OSQPInterface::getStatus()` now returns the actual OSQP solver status string instead of unconditionally returning `"OSQP_SOLVED"`. On a successful solve the returned value is unchanged (`"OSQP_SOLVED"`); on any non-solved outcome it now returns the corresponding real status name (e.g. `"OSQP_PRIMAL_INFEASIBLE"`, `"OSQP_MAX_ITER_REACHED"`). This is the intended fix. `isSolved()`, `optimize()`, and all other public signatures, as well as the package's installed headers, are unchanged. The package is a library only (no ROS topics/services/params), so there is no node interface impact. The `update*` and ProxQP changes are internal copy-free refactors with no observable change in results.
