### PR TITLE
refactor(autoware_localization_util): delegate util_func helpers to autoware_utils

### DIFF
--- a/localization/autoware_localization_util/package.xml
+++ b/localization/autoware_localization_util/package.xml
@@ -15,6 +15,8 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_utils_geometry</depend>
+  <depend>autoware_utils_math</depend>
   <depend>diagnostic_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>

--- a/localization/autoware_localization_util/src/util_func.cpp
+++ b/localization/autoware_localization_util/src/util_func.cpp
@@ -14,6 +14,9 @@
 
 #include <autoware/localization_util/matrix_type.hpp>
 #include <autoware/localization_util/util_func.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
+#include <autoware_utils_math/normalization.hpp>
+#include <autoware_utils_math/unit_conversion.hpp>
 
 #include <algorithm>
 #include <string>
@@ -51,13 +54,9 @@ std_msgs::msg::ColorRGBA exchange_color_crc(double x)
 
 double calc_diff_for_radian(const double lhs_rad, const double rhs_rad)
 {
-  double diff_rad = lhs_rad - rhs_rad;
-  if (diff_rad > M_PI) {
-    diff_rad = diff_rad - 2 * M_PI;
-  } else if (diff_rad < -M_PI) {
-    diff_rad = diff_rad + 2 * M_PI;
-  }
-  return diff_rad;
+  // Delegate to autoware_utils_math::normalize_radian. Unlike the previous single-step wrap, this
+  // correctly normalizes differences whose magnitude exceeds 3*pi. The output range is [-pi, pi).
+  return autoware_utils_math::normalize_radian(lhs_rad - rhs_rad);
 }
 
 Eigen::Map<const RowMatrixXd> make_eigen_covariance(const std::array<double, 36> & covariance)
@@ -68,10 +67,7 @@ Eigen::Map<const RowMatrixXd> make_eigen_covariance(const std::array<double, 36>
 // x: roll, y: pitch, z: yaw
 geometry_msgs::msg::Vector3 get_rpy(const geometry_msgs::msg::Pose & pose)
 {
-  geometry_msgs::msg::Vector3 rpy;
-  tf2::Quaternion q(pose.orientation.x, pose.orientation.y, pose.orientation.z, pose.orientation.w);
-  tf2::Matrix3x3(q).getRPY(rpy.x, rpy.y, rpy.z);
-  return rpy;
+  return autoware_utils_geometry::get_rpy(pose);
 }
 
 geometry_msgs::msg::Vector3 get_rpy(const geometry_msgs::msg::PoseStamped & pose)
@@ -87,23 +83,15 @@ geometry_msgs::msg::Vector3 get_rpy(const geometry_msgs::msg::PoseWithCovariance
 geometry_msgs::msg::Quaternion rpy_rad_to_quaternion(
   const double r_rad, const double p_rad, const double y_rad)
 {
-  tf2::Quaternion q;
-  q.setRPY(r_rad, p_rad, y_rad);
-  geometry_msgs::msg::Quaternion quaternion_msg;
-  quaternion_msg.x = q.x();
-  quaternion_msg.y = q.y();
-  quaternion_msg.z = q.z();
-  quaternion_msg.w = q.w();
-  return quaternion_msg;
+  return autoware_utils_geometry::create_quaternion_from_rpy(r_rad, p_rad, y_rad);
 }
 
 geometry_msgs::msg::Quaternion rpy_deg_to_quaternion(
   const double r_deg, const double p_deg, const double y_deg)
 {
-  const double r_rad = r_deg * M_PI / 180.0;
-  const double p_rad = p_deg * M_PI / 180.0;
-  const double y_rad = y_deg * M_PI / 180.0;
-  return rpy_rad_to_quaternion(r_rad, p_rad, y_rad);
+  return rpy_rad_to_quaternion(
+    autoware_utils_math::deg2rad(r_deg), autoware_utils_math::deg2rad(p_deg),
+    autoware_utils_math::deg2rad(y_deg));
 }
 
 geometry_msgs::msg::Twist calc_twist(
@@ -227,10 +215,7 @@ geometry_msgs::msg::Pose matrix4f_to_pose(const Eigen::Matrix4f & eigen_pose_mat
 
 double norm(const geometry_msgs::msg::Point & p1, const geometry_msgs::msg::Point & p2)
 {
-  const double dx = p1.x - p2.x;
-  const double dy = p1.y - p2.y;
-  const double dz = p1.z - p2.z;
-  return std::sqrt(dx * dx + dy * dy + dz * dz);
+  return autoware_utils_geometry::calc_distance3d(p1, p2);
 }
 
 void output_pose_with_cov_to_log(

--- a/localization/autoware_localization_util/test/test_util_func.cpp
+++ b/localization/autoware_localization_util/test/test_util_func.cpp
@@ -71,6 +71,39 @@ TEST(UtilFuncTest, CalcDiffForRadian)
   EXPECT_NEAR(calc_diff_for_radian(0.0, 6.0), 0.28318530718, 1e-6);
 }
 
+// Characterization: a difference already strictly inside (-pi, pi) is returned unchanged, and a
+// difference in (pi, 3*pi) / (-3*pi, -pi) is wrapped by a single +/-2*pi into (-pi, pi). Away from
+// the +/-pi boundary this matches both the previous single-step implementation and
+// autoware_utils_math::normalize_radian.
+TEST(UtilFuncTest, CalcDiffForRadianWrapsIntoPrincipalRange)
+{
+  EXPECT_NEAR(calc_diff_for_radian(0.0, 0.0), 0.0, 1e-12);
+  EXPECT_NEAR(calc_diff_for_radian(M_PI - 0.1, 0.0), M_PI - 0.1, 1e-12);
+  EXPECT_NEAR(calc_diff_for_radian(-M_PI + 0.1, 0.0), -M_PI + 0.1, 1e-12);
+  // diff = 1.5*pi -> wraps to 1.5*pi - 2*pi = -0.5*pi
+  EXPECT_NEAR(calc_diff_for_radian(1.5 * M_PI, 0.0), -0.5 * M_PI, 1e-12);
+  // diff = -1.5*pi -> wraps to -1.5*pi + 2*pi = 0.5*pi
+  EXPECT_NEAR(calc_diff_for_radian(-1.5 * M_PI, 0.0), 0.5 * M_PI, 1e-12);
+}
+
+// RED-for-the-fix: a difference whose magnitude exceeds 3*pi cannot be brought into [-pi, pi) by a
+// single +/-2*pi step. The previous single-step implementation left it out of range; delegating to
+// autoware_utils_math::normalize_radian wraps it correctly. diff = 3.5*pi -> normalized to -0.5*pi.
+TEST(UtilFuncTest, CalcDiffForRadianWrapsLargeDifference)
+{
+  const double diff = calc_diff_for_radian(3.5 * M_PI, 0.0);
+  // Half-open interval [-pi, pi): lower bound inclusive, upper bound exclusive.
+  EXPECT_GE(diff, -M_PI);
+  EXPECT_LT(diff, M_PI);
+  EXPECT_NEAR(diff, -0.5 * M_PI, 1e-9);
+
+  const double diff_neg = calc_diff_for_radian(-3.5 * M_PI, 0.0);
+  // Half-open interval [-pi, pi): lower bound inclusive, upper bound exclusive.
+  EXPECT_GE(diff_neg, -M_PI);
+  EXPECT_LT(diff_neg, M_PI);
+  EXPECT_NEAR(diff_neg, 0.5 * M_PI, 1e-9);
+}
+
 TEST(UtilFuncTest, MakeEigenCovariance)
 {
   std::array<double, 36> covariance;
@@ -319,6 +352,26 @@ TEST(UtilFuncTest, NormCalculation)
     std::sqrt(std::pow(p1.x - p2.x, 2) + std::pow(p1.y - p2.y, 2) + std::pow(p1.z - p2.z, 2));
 
   EXPECT_DOUBLE_EQ(norm(p1, p2), expected);
+}
+
+// Characterization for the Euclidean 3D distance contract that norm() must keep when delegating to
+// autoware_utils_geometry::calc_distance3d: symmetry, zero for identical points, and a 3-4-12
+// triple whose distance is exactly 13.
+TEST(UtilFuncTest, NormContract)
+{
+  geometry_msgs::msg::Point a;
+  a.x = 0.0;
+  a.y = 0.0;
+  a.z = 0.0;
+
+  geometry_msgs::msg::Point b;
+  b.x = 3.0;
+  b.y = 4.0;
+  b.z = 12.0;
+
+  EXPECT_NEAR(norm(a, b), 13.0, 1e-9);
+  EXPECT_NEAR(norm(b, a), 13.0, 1e-9);
+  EXPECT_DOUBLE_EQ(norm(a, a), 0.0);
 }
 
 TEST(UtilFuncTest, OutputPoseToCovLog)


### PR DESCRIPTION
## Description

Internally delegate `util_func`'s `get_rpy` (3 overloads), `norm`, `rpy_rad_to_quaternion`, `rpy_deg_to_quaternion` and `calc_diff_for_radian` to their `autoware_utils_geometry` / `autoware_utils_math` equivalents, removing duplicated tf2/math code. The public signatures are kept unchanged, so the consumer packages (`ndt_scan_matcher`, `ekf_localizer`, `gyro_odometer`) are unaffected.

Mapping:
- `get_rpy(Pose/PoseStamped/PoseWithCovarianceStamped)` -> `autoware_utils_geometry::get_rpy`
- `rpy_rad_to_quaternion` -> `autoware_utils_geometry::create_quaternion_from_rpy`
- `rpy_deg_to_quaternion` -> `create_quaternion_from_rpy(autoware_utils_math::deg2rad(...))`
- `norm` -> `autoware_utils_geometry::calc_distance3d`
- `calc_diff_for_radian` -> `autoware_utils_math::normalize_radian`

`autoware_utils_geometry` and `autoware_utils_math` are added to `package.xml` (kept sorted).

## Effects on system behavior

`get_rpy`, `norm`, `rpy_rad_to_quaternion` and `rpy_deg_to_quaternion` are behavior-preserving. `autoware_utils_math::pi` equals `M_PI` exactly, so the deg->rad conversion is bit-identical.

`calc_diff_for_radian` changes behavior only for inputs the previous implementation handled incorrectly: the old single-step wrap could not normalize a difference whose magnitude exceeds 3*pi (it left the result outside the principal range), whereas `normalize_radian` (fmod-based) wraps it correctly. Additionally the output range becomes `[-pi, pi)` instead of `(-pi, pi]`, so the boundary value exactly `+pi` now maps to `-pi`. In practice `calc_diff_for_radian` is used by `calc_twist` on per-axis RPY differences between consecutive poses; the affected cases are antipodal-orientation (measure-zero) and wraps beyond 3*pi that should never occur for adjacent localization poses. A characterization test pins the shared in-range behavior and a RED test pins the corrected large-difference normalization.

`norm` delegates to `calc_distance3d`, which uses nested `std::hypot` rather than `sqrt(sum of squares)`; results may differ by at most ~1 ULP for extreme inputs (identical for the existing test inputs).

## Tests

`colcon build` + `colcon test` for `autoware_localization_util` pass in the `autoware:core-devel-jazzy` container (51 tests, 0 failures; `test_util_func` now has 13 cases). `pre-commit` (clang-format, cpplint, sort-package-xml, check-package-depends, ...) passes on all changed files.

Refs: autowarefoundation/autoware_core#1096