### PR TITLE
test(autoware_osqp_interface): cover uncovered branches and extract status-message builder

### DIFF
--- a/common/autoware_osqp_interface/include/autoware/osqp_interface/osqp_interface.hpp
+++ b/common/autoware_osqp_interface/include/autoware/osqp_interface/osqp_interface.hpp
@@ -24,6 +24,7 @@
 
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -31,6 +32,20 @@
 namespace autoware::osqp_interface
 {
 constexpr c_float INF = 1e30;
+
+namespace detail
+{
+/// \brief Build the warning message logged by OSQPInterface::logUnsolvedStatus.
+/// \param status The OSQP solution status value (1 means "solved").
+/// \param status_message Human-readable status string from the solver.
+/// \param prefix_message Optional prefix prepended to the message.
+/// \return std::nullopt when the problem was solved (status == 1), otherwise the
+///         message string that would be logged as a warning.
+/// \details This is a pure free function so the message-construction logic can be
+///          unit-tested without a live ROS logger.
+OSQP_INTERFACE_PUBLIC std::optional<std::string> build_unsolved_status_message(
+  const int status, const std::string & status_message, const std::string & prefix_message);
+}  // namespace detail
 
 struct OSQPResult
 {

--- a/common/autoware_osqp_interface/src/osqp_interface.cpp
+++ b/common/autoware_osqp_interface/src/osqp_interface.cpp
@@ -21,12 +21,35 @@
 #include <iostream>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <vector>
 
 namespace autoware::osqp_interface
 {
+namespace detail
+{
+std::optional<std::string> build_unsolved_status_message(
+  const int status, const std::string & status_message, const std::string & prefix_message)
+{
+  if (status == 1) {
+    // No need to log since optimization was solved.
+    return std::nullopt;
+  }
+
+  // create message
+  std::string output_message = "";
+  if (prefix_message != "") {
+    output_message = prefix_message + " ";
+  }
+
+  output_message += "Optimization failed due to " + status_message;
+
+  return output_message;
+}
+}  // namespace detail
+
 OSQPInterface::OSQPInterface(const c_float eps_abs, const bool polish)
 : m_work{nullptr, OSQPWorkspaceDeleter}
 {
@@ -417,21 +440,14 @@ OSQPResult OSQPInterface::optimize(
 void OSQPInterface::logUnsolvedStatus(const std::string & prefix_message) const
 {
   const int status = static_cast<int>(getStatus());
-  if (status == 1) {
+  const auto output_message =
+    detail::build_unsolved_status_message(status, getStatusMessage(), prefix_message);
+  if (!output_message) {
     // No need to log since optimization was solved.
     return;
   }
 
-  // create message
-  std::string output_message = "";
-  if (prefix_message != "") {
-    output_message = prefix_message + " ";
-  }
-
-  const auto status_message = getStatusMessage();
-  output_message += "Optimization failed due to " + status_message;
-
   // log with warning
-  RCLCPP_WARN(rclcpp::get_logger("osqp_interface"), "%s", output_message.c_str());
+  RCLCPP_WARN(rclcpp::get_logger("osqp_interface"), "%s", output_message->c_str());
 }
 }  // namespace autoware::osqp_interface

--- a/common/autoware_osqp_interface/test/test_csc_matrix_conv.cpp
+++ b/common/autoware_osqp_interface/test/test_csc_matrix_conv.cpp
@@ -164,6 +164,47 @@ TEST(TestCscMatrixConv, Trapezoidal)
     EXPECT_EQ(e.what(), std::string("Matrix must be square (n, n)"));
   }
 }
+TEST(TestCscMatrixConv, NearZeroPruning)
+{
+  using autoware::osqp_interface::calCSCMatrix;
+  using autoware::osqp_interface::calCSCMatrixTrapezoidal;
+  using autoware::osqp_interface::CSC_Matrix;
+
+  // Values with magnitude < 1e-9 are treated as zero (pruned); values >= 1e-9 are kept.
+  // Row vector: [below-threshold, above-threshold, negative-below-threshold, negative-kept]
+  Eigen::MatrixXd rect(1, 4);
+  rect << 1.0e-10, 1.0e-8, -1.0e-10, -1.0e-8;
+
+  const CSC_Matrix csc = calCSCMatrix(rect);
+  // Only the two >= 1e-9 magnitude values survive.
+  ASSERT_EQ(csc.m_vals.size(), size_t(2));
+  EXPECT_DOUBLE_EQ(csc.m_vals[0], 1.0e-8);
+  EXPECT_DOUBLE_EQ(csc.m_vals[1], -1.0e-8);
+  ASSERT_EQ(csc.m_row_idxs.size(), size_t(2));
+  EXPECT_EQ(csc.m_row_idxs[0], c_int(0));
+  EXPECT_EQ(csc.m_row_idxs[1], c_int(0));
+  // One entry per column boundary: col 0 pruned, col 1 keeps 1, col 2 pruned, col 3 keeps 1.
+  ASSERT_EQ(csc.m_col_idxs.size(), size_t(5));
+  EXPECT_EQ(csc.m_col_idxs[0], c_int(0));
+  EXPECT_EQ(csc.m_col_idxs[1], c_int(0));
+  EXPECT_EQ(csc.m_col_idxs[2], c_int(1));
+  EXPECT_EQ(csc.m_col_idxs[3], c_int(1));
+  EXPECT_EQ(csc.m_col_idxs[4], c_int(2));
+
+  // The same threshold applies along the diagonal of the trapezoidal conversion.
+  Eigen::MatrixXd square(2, 2);
+  square << 1.0e-10, 1.0e-8, 0.0, -1.0e-10;
+  const CSC_Matrix square_csc = calCSCMatrixTrapezoidal(square);
+  // (0,0)=1e-10 pruned, (0,1)=1e-8 kept, (1,1)=-1e-10 pruned.
+  ASSERT_EQ(square_csc.m_vals.size(), size_t(1));
+  EXPECT_DOUBLE_EQ(square_csc.m_vals[0], 1.0e-8);
+  ASSERT_EQ(square_csc.m_row_idxs.size(), size_t(1));
+  EXPECT_EQ(square_csc.m_row_idxs[0], c_int(0));
+  ASSERT_EQ(square_csc.m_col_idxs.size(), size_t(3));
+  EXPECT_EQ(square_csc.m_col_idxs[0], c_int(0));
+  EXPECT_EQ(square_csc.m_col_idxs[1], c_int(0));
+  EXPECT_EQ(square_csc.m_col_idxs[2], c_int(1));
+}
 TEST(TestCscMatrixConv, Print)
 {
   using autoware::osqp_interface::calCSCMatrix;

--- a/common/autoware_osqp_interface/test/test_osqp_interface.cpp
+++ b/common/autoware_osqp_interface/test/test_osqp_interface.cpp
@@ -18,6 +18,9 @@
 #include <Eigen/Core>
 
 #include <iostream>
+#include <optional>
+#include <stdexcept>
+#include <string>
 #include <tuple>
 #include <vector>
 
@@ -194,5 +197,110 @@ TEST(TestOsqpInterface, BasicQp)
     EXPECT_EQ(osqp.getStatus(), 1);
     EXPECT_EQ(osqp.getStatusMessage(), "solved");
   }
+}
+
+// Each of the five dimension-consistency checks in initializeProblem(Eigen, ...) must throw
+// std::invalid_argument with a descriptive message. The happy path is already covered by
+// TestOsqpInterface.BasicQp; here we pin the individual failure branches.
+TEST(TestOsqpInterface, InitializeProblemDimensionMismatch)
+{
+  using autoware::osqp_interface::OSQPInterface;
+
+  // Consistent baseline: P is 2x2, A is 2x2, q/l/u sized accordingly.
+  const Eigen::MatrixXd P = (Eigen::MatrixXd(2, 2) << 4, 1, 1, 2).finished();
+  const Eigen::MatrixXd A = (Eigen::MatrixXd(2, 2) << 1, 1, 1, 0).finished();
+  const std::vector<double> q = {1.0, 1.0};
+  const std::vector<double> l = {0.0, 0.0};
+  const std::vector<double> u = {1.0, 1.0};
+
+  OSQPInterface osqp;
+
+  // 1. P not square.
+  {
+    const Eigen::MatrixXd p_non_square = Eigen::MatrixXd::Zero(2, 3);
+    EXPECT_THROW(osqp.initializeProblem(p_non_square, A, q, l, u), std::invalid_argument);
+  }
+  // 2. P.rows() != q.size().
+  {
+    const std::vector<double> q_bad = {1.0, 1.0, 1.0};
+    EXPECT_THROW(osqp.initializeProblem(P, A, q_bad, l, u), std::invalid_argument);
+  }
+  // 3. P.rows() != A.cols().
+  {
+    const Eigen::MatrixXd a_bad = Eigen::MatrixXd::Zero(2, 3);
+    EXPECT_THROW(osqp.initializeProblem(P, a_bad, q, l, u), std::invalid_argument);
+  }
+  // 4. A.rows() != l.size().
+  {
+    const std::vector<double> l_bad = {0.0, 0.0, 0.0};
+    EXPECT_THROW(osqp.initializeProblem(P, A, q, l_bad, u), std::invalid_argument);
+  }
+  // 5. A.rows() != u.size().
+  {
+    const std::vector<double> u_bad = {1.0, 1.0, 1.0};
+    EXPECT_THROW(osqp.initializeProblem(P, A, q, l, u_bad), std::invalid_argument);
+  }
+
+  // Sanity: the baseline (all consistent) does not throw.
+  EXPECT_NO_THROW(osqp.initializeProblem(P, A, q, l, u));
+}
+
+// Warm-start setters must return false (and not crash) when called before the workspace has been
+// initialized, i.e. on a default-constructed interface.
+TEST(TestOsqpInterface, WarmStartBeforeInitializationFails)
+{
+  using autoware::osqp_interface::OSQPInterface;
+
+  OSQPInterface osqp;  // no problem set up yet -> m_work_initialized == false
+  const std::vector<double> primal = {0.0, 0.0};
+  const std::vector<double> dual = {0.0, 0.0};
+
+  EXPECT_FALSE(osqp.setPrimalVariables(primal));
+  EXPECT_FALSE(osqp.setDualVariables(dual));
+  EXPECT_FALSE(osqp.setWarmStart(primal, dual));
+}
+
+// The pure message-builder backing logUnsolvedStatus covers every branch:
+// solved (status == 1) -> nullopt, unsolved without/with prefix.
+TEST(TestOsqpInterface, BuildUnsolvedStatusMessage)
+{
+  using autoware::osqp_interface::detail::build_unsolved_status_message;
+
+  // status == 1 means solved: no message.
+  EXPECT_FALSE(build_unsolved_status_message(1, "solved", "").has_value());
+  EXPECT_FALSE(build_unsolved_status_message(1, "solved", "prefix").has_value());
+
+  // Unsolved without a prefix.
+  {
+    const auto msg = build_unsolved_status_message(-3, "primal infeasible", "");
+    ASSERT_TRUE(msg.has_value());
+    EXPECT_EQ(*msg, "Optimization failed due to primal infeasible");
+  }
+
+  // Unsolved with a prefix (a single space separates prefix and body).
+  {
+    const auto msg = build_unsolved_status_message(-4, "dual infeasible", "[MPC]");
+    ASSERT_TRUE(msg.has_value());
+    EXPECT_EQ(*msg, "[MPC] Optimization failed due to dual infeasible");
+  }
+}
+
+// logUnsolvedStatus is the thin wrapper around the builder; after a solved problem it must be a
+// no-op (status == 1 -> nullopt) and must never throw.
+TEST(TestOsqpInterface, LogUnsolvedStatusSolvedIsNoThrow)
+{
+  using autoware::osqp_interface::OSQPInterface;
+
+  const Eigen::MatrixXd P = (Eigen::MatrixXd(2, 2) << 4, 1, 1, 2).finished();
+  const Eigen::MatrixXd A = (Eigen::MatrixXd(4, 2) << 1, 1, 1, 0, 0, 1, 0, 1).finished();
+  const std::vector<double> q = {1.0, 1.0};
+  const std::vector<double> l = {1.0, 0.0, 0.0, -autoware::osqp_interface::INF};
+  const std::vector<double> u = {1.0, 0.7, 0.7, autoware::osqp_interface::INF};
+
+  OSQPInterface osqp(P, A, q, l, u, 1e-6);
+  osqp.optimize();
+  ASSERT_EQ(osqp.getStatus(), 1);  // solved
+  EXPECT_NO_THROW(osqp.logUnsolvedStatus());
+  EXPECT_NO_THROW(osqp.logUnsolvedStatus("prefix"));
 }
 }  // namespace


### PR DESCRIPTION
## Description

This PR raises unit-test coverage of `autoware_osqp_interface` over its currently-uncovered branches and performs one small, additive, internal extraction needed to make the OSQP status-message logic testable without a live ROS logger.

### Tests added (all assert concrete values / branches, not just no-throw)

- **`initializeProblem(Eigen, ...)` dimension-mismatch throws** — one `EXPECT_THROW(std::invalid_argument)` per branch: P non-square, `P.rows() != q.size()`, `P.rows() != A.cols()`, `A.rows() != l.size()`, `A.rows() != u.size()`, plus a consistent-baseline `EXPECT_NO_THROW` sanity case. (`test_osqp_interface.cpp`)
- **Warm-start failure when uninitialized** — `setPrimalVariables` / `setDualVariables` / `setWarmStart` return `false` on a default-constructed interface (the `!m_work_initialized` early-return paths). (`test_osqp_interface.cpp`)
- **`logUnsolvedStatus` message-construction branches** — solved (`status == 1`) returns no message, unsolved without prefix, unsolved with prefix, asserting the exact output strings; plus a no-op/no-throw check of the public `logUnsolvedStatus()` wrapper after a solved problem. (`test_osqp_interface.cpp`)
- **CSC near-zero pruning threshold** — `calCSCMatrix` / `calCSCMatrixTrapezoidal` drop `|val| < 1e-9` and keep `>= 1e-9`, verified for both positive and negative tiny magnitudes, asserting the full CSC contents (vals/row_idxs/col_idxs). (`test_csc_matrix_conv.cpp`)

### Internal extraction (additive, behavior-preserving)

`logUnsolvedStatus`'s message-building logic is extracted into a pure free function `detail::build_unsolved_status_message(int status, const std::string & status_message, const std::string & prefix_message)` returning `std::optional<std::string>` (`std::nullopt` when solved). `OSQPInterface::logUnsolvedStatus` becomes a thin wrapper that calls it and then `RCLCPP_WARN`s the result. The public `logUnsolvedStatus` signature is unchanged; the new symbol is the only API addition.

## Effects on system behavior

None. The refactor is behavior-preserving: the message produced and the solved-case early-return are identical to before (now covered by tests). No public signatures changed; the only API change is the addition of the internal `detail::build_unsolved_status_message` free function. No downstream consumers are affected.

Refs: autowarefoundation/autoware_core#1096