### PR TITLE
refactor(autoware_gyro_odometer): extract pure fusion logic and fix diagnostics level

### DIFF
--- a/localization/autoware_gyro_odometer/CMakeLists.txt
+++ b/localization/autoware_gyro_odometer/CMakeLists.txt
@@ -6,6 +6,7 @@ autoware_package()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/gyro_odometer_core.cpp
+  src/gyro_odometer_fusion.cpp
 )
 
 target_link_libraries(${PROJECT_NAME} fmt)
@@ -15,6 +16,7 @@ if(BUILD_TESTING)
     test/test_main.cpp
     test/test_gyro_odometer_pubsub.cpp
     test/test_gyro_odometer_helper.cpp
+    test/test_gyro_odometer_fusion.cpp
   )
   ament_target_dependencies(test_gyro_odometer
     rclcpp

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_core.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_core.cpp
@@ -14,34 +14,18 @@
 
 #include "gyro_odometer_core.hpp"
 
+#include "gyro_odometer_fusion.hpp"
+
 #include <rclcpp/rclcpp.hpp>
 
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
-#include <fmt/core.h>
-
-#include <algorithm>
 #include <cmath>
 #include <memory>
-#include <sstream>
 #include <string>
 
 namespace autoware::gyro_odometer
 {
-
-std::array<double, 9> transform_covariance(const std::array<double, 9> & cov)
-{
-  using COV_IDX = autoware_utils_geometry::xyz_covariance_index::XYZ_COV_IDX;
-
-  double max_cov = std::max({cov[COV_IDX::X_X], cov[COV_IDX::Y_Y], cov[COV_IDX::Z_Z]});
-
-  std::array<double, 9> cov_transformed = {};
-  cov_transformed.fill(0.);
-  cov_transformed[COV_IDX::X_X] = max_cov;
-  cov_transformed[COV_IDX::Y_Y] = max_cov;
-  cov_transformed[COV_IDX::Z_Z] = max_cov;
-  return cov_transformed;
-}
 
 GyroOdometerNode::GyroOdometerNode(const rclcpp::NodeOptions & node_options)
 : Node("gyro_odometer", node_options),
@@ -159,61 +143,9 @@ void GyroOdometerNode::concat_gyro_and_odometer()
     gyro.angular_velocity_covariance = transform_covariance(gyro.angular_velocity_covariance);
   }
 
-  using COV_IDX_XYZ = autoware_utils_geometry::xyz_covariance_index::XYZ_COV_IDX;
-  using COV_IDX_XYZRPY = autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
-
-  // calc mean, covariance
-  double vx_mean = 0;
-  geometry_msgs::msg::Vector3 gyro_mean{};
-  double vx_covariance_original = 0;
-  geometry_msgs::msg::Vector3 gyro_covariance_original{};
-  for (const auto & vehicle_twist : vehicle_twist_queue_) {
-    vx_mean += vehicle_twist.twist.twist.linear.x;
-    vx_covariance_original += vehicle_twist.twist.covariance[0 * 6 + 0];
-  }
-  vx_mean /= static_cast<double>(vehicle_twist_queue_.size());
-  vx_covariance_original /= static_cast<double>(vehicle_twist_queue_.size());
-
-  for (const auto & gyro : gyro_queue_) {
-    gyro_mean.x += gyro.angular_velocity.x;
-    gyro_mean.y += gyro.angular_velocity.y;
-    gyro_mean.z += gyro.angular_velocity.z;
-    gyro_covariance_original.x += gyro.angular_velocity_covariance[COV_IDX_XYZ::X_X];
-    gyro_covariance_original.y += gyro.angular_velocity_covariance[COV_IDX_XYZ::Y_Y];
-    gyro_covariance_original.z += gyro.angular_velocity_covariance[COV_IDX_XYZ::Z_Z];
-  }
-  gyro_mean.x /= static_cast<double>(gyro_queue_.size());
-  gyro_mean.y /= static_cast<double>(gyro_queue_.size());
-  gyro_mean.z /= static_cast<double>(gyro_queue_.size());
-  gyro_covariance_original.x /= static_cast<double>(gyro_queue_.size());
-  gyro_covariance_original.y /= static_cast<double>(gyro_queue_.size());
-  gyro_covariance_original.z /= static_cast<double>(gyro_queue_.size());
-
-  // concat
-  geometry_msgs::msg::TwistWithCovarianceStamped twist_with_cov;
-  const auto latest_vehicle_twist_stamp = rclcpp::Time(vehicle_twist_queue_.back().header.stamp);
-  const auto latest_imu_stamp = rclcpp::Time(gyro_queue_.back().header.stamp);
-  if (latest_vehicle_twist_stamp < latest_imu_stamp) {
-    twist_with_cov.header.stamp = latest_imu_stamp;
-  } else {
-    twist_with_cov.header.stamp = latest_vehicle_twist_stamp;
-  }
-  twist_with_cov.header.frame_id = gyro_queue_.front().header.frame_id;
-  twist_with_cov.twist.twist.linear.x = vx_mean;
-  twist_with_cov.twist.twist.angular = gyro_mean;
-
-  // From a statistical point of view, here we reduce the covariances according to the number of
-  // observed data
-  twist_with_cov.twist.covariance[COV_IDX_XYZRPY::X_X] =
-    vx_covariance_original / static_cast<double>(vehicle_twist_queue_.size());
-  twist_with_cov.twist.covariance[COV_IDX_XYZRPY::Y_Y] = 100000.0;
-  twist_with_cov.twist.covariance[COV_IDX_XYZRPY::Z_Z] = 100000.0;
-  twist_with_cov.twist.covariance[COV_IDX_XYZRPY::ROLL_ROLL] =
-    gyro_covariance_original.x / static_cast<double>(gyro_queue_.size());
-  twist_with_cov.twist.covariance[COV_IDX_XYZRPY::PITCH_PITCH] =
-    gyro_covariance_original.y / static_cast<double>(gyro_queue_.size());
-  twist_with_cov.twist.covariance[COV_IDX_XYZRPY::YAW_YAW] =
-    gyro_covariance_original.z / static_cast<double>(gyro_queue_.size());
+  // fuse the vehicle twist and the (already transformed) gyro queue
+  const geometry_msgs::msg::TwistWithCovarianceStamped twist_with_cov =
+    fuse_twist(vehicle_twist_queue_, gyro_queue_);
 
   publish_data(twist_with_cov);
 
@@ -231,20 +163,13 @@ void GyroOdometerNode::publish_data(
   twist_raw_pub_->publish(twist_raw);
   twist_with_covariance_raw_pub_->publish(twist_with_cov_raw);
 
-  geometry_msgs::msg::TwistWithCovarianceStamped twist_with_covariance = twist_with_cov_raw;
-  geometry_msgs::msg::TwistStamped twist = twist_raw;
-
   // clear imu yaw bias if vehicle is stopped
-  if (
-    std::fabs(twist_with_cov_raw.twist.twist.angular.z) < 0.01 &&
-    std::fabs(twist_with_cov_raw.twist.twist.linear.x) < 0.01) {
-    twist.twist.angular.x = 0.0;
-    twist.twist.angular.y = 0.0;
-    twist.twist.angular.z = 0.0;
-    twist_with_covariance.twist.twist.angular.x = 0.0;
-    twist_with_covariance.twist.twist.angular.y = 0.0;
-    twist_with_covariance.twist.twist.angular.z = 0.0;
-  }
+  const geometry_msgs::msg::TwistWithCovarianceStamped twist_with_covariance =
+    apply_stop_compensation(twist_with_cov_raw);
+
+  geometry_msgs::msg::TwistStamped twist;
+  twist.header = twist_with_covariance.header;
+  twist.twist = twist_with_covariance.twist.twist;
 
   twist_pub_->publish(twist);
   twist_with_covariance_pub_->publish(twist_with_covariance);
@@ -272,49 +197,28 @@ void GyroOdometerNode::publish_diagnostics()
   diagnostics_->add_key_value("imu_queue_size", latest_imu_queue_size_);
   diagnostics_->add_key_value("is_succeed_transform_imu", is_succeed_transform_imu_);
 
-  uint8_t level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  std::string log_message = "";
+  DiagnosticsState state;
+  state.vehicle_twist_arrived = vehicle_twist_arrived_;
+  state.imu_arrived = imu_arrived_;
+  state.is_succeed_transform_imu = is_succeed_transform_imu_;
+  state.latest_vehicle_twist_dt = latest_vehicle_twist_dt_;
+  state.latest_imu_dt = latest_imu_dt_;
+  state.message_timeout_sec = message_timeout_sec_;
+  state.output_frame = output_frame_;
 
-  if (!vehicle_twist_arrived_) {
-    const std::string message = "Twist msg has not been arrived yet.";
-    diagnostics_->update_level_and_message(diagnostic_msgs::msg::DiagnosticStatus::WARN, message);
-    log_message += message;
-    log_message += "; ";
-  }
-  if (!imu_arrived_) {
-    const std::string message = "IMU msg has not been arrived yet.";
-    diagnostics_->update_level_and_message(diagnostic_msgs::msg::DiagnosticStatus::WARN, message);
-    log_message += message;
-    log_message += "; ";
-  }
-  if (latest_vehicle_twist_dt_ > message_timeout_sec_) {
-    const std::string message = fmt::format(
-      "Vehicle twist msg is timeout. vehicle_twist_dt: {}[sec], tolerance {}[sec]",
-      latest_vehicle_twist_dt_, message_timeout_sec_);
-    diagnostics_->update_level_and_message(diagnostic_msgs::msg::DiagnosticStatus::ERROR, message);
-    log_message += message;
-    log_message += "; ";
-  }
-  if (latest_imu_dt_ > message_timeout_sec_) {
-    const std::string message = fmt::format(
-      "IMU msg is timeout. imu_dt: {}[sec], tolerance {}[sec]", latest_imu_dt_,
-      message_timeout_sec_);
-    diagnostics_->update_level_and_message(diagnostic_msgs::msg::DiagnosticStatus::ERROR, message);
-    log_message += message;
-    log_message += "; ";
-  }
-  if (!is_succeed_transform_imu_) {
-    const std::string message = "Please publish TF from " + output_frame_ + " to frame of IMU.";
-    diagnostics_->update_level_and_message(diagnostic_msgs::msg::DiagnosticStatus::ERROR, message);
-    log_message += message;
-    log_message += "; ";
+  const DiagnosticsResult diagnostics_result = determine_diagnostics(state);
+
+  for (const auto & entry : diagnostics_result.entries) {
+    diagnostics_->update_level_and_message(entry.level, entry.message);
   }
 
-  if (level == diagnostic_msgs::msg::DiagnosticStatus::WARN)
-    RCLCPP_WARN_STREAM_THROTTLE(this->get_logger(), *this->get_clock(), 1000, log_message);
+  if (diagnostics_result.level == diagnostic_msgs::msg::DiagnosticStatus::WARN)
+    RCLCPP_WARN_STREAM_THROTTLE(
+      this->get_logger(), *this->get_clock(), 1000, diagnostics_result.log_message);
 
-  if (level == diagnostic_msgs::msg::DiagnosticStatus::ERROR)
-    RCLCPP_ERROR_STREAM_THROTTLE(this->get_logger(), *this->get_clock(), 1000, log_message);
+  if (diagnostics_result.level == diagnostic_msgs::msg::DiagnosticStatus::ERROR)
+    RCLCPP_ERROR_STREAM_THROTTLE(
+      this->get_logger(), *this->get_clock(), 1000, diagnostics_result.log_message);
 
   diagnostics_->publish(this->now());
 }

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_fusion.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_fusion.cpp
@@ -1,0 +1,164 @@
+// Copyright 2015-2019 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gyro_odometer_fusion.hpp"
+
+#include <autoware_utils_geometry/msg/covariance.hpp>
+#include <rclcpp/time.hpp>
+
+#include <fmt/core.h>
+
+#include <algorithm>
+#include <cmath>
+#include <deque>
+#include <string>
+
+namespace autoware::gyro_odometer
+{
+
+std::array<double, 9> transform_covariance(const std::array<double, 9> & cov)
+{
+  using COV_IDX = autoware_utils_geometry::xyz_covariance_index::XYZ_COV_IDX;
+
+  double max_cov = std::max({cov[COV_IDX::X_X], cov[COV_IDX::Y_Y], cov[COV_IDX::Z_Z]});
+
+  std::array<double, 9> cov_transformed = {};
+  cov_transformed.fill(0.);
+  cov_transformed[COV_IDX::X_X] = max_cov;
+  cov_transformed[COV_IDX::Y_Y] = max_cov;
+  cov_transformed[COV_IDX::Z_Z] = max_cov;
+  return cov_transformed;
+}
+
+geometry_msgs::msg::TwistWithCovarianceStamped fuse_twist(
+  const std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> & vehicle_twist_queue,
+  const std::deque<sensor_msgs::msg::Imu> & gyro_queue)
+{
+  using COV_IDX_XYZ = autoware_utils_geometry::xyz_covariance_index::XYZ_COV_IDX;
+  using COV_IDX_XYZRPY = autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
+
+  // calc mean, covariance
+  double vx_mean = 0;
+  geometry_msgs::msg::Vector3 gyro_mean{};
+  double vx_covariance_original = 0;
+  geometry_msgs::msg::Vector3 gyro_covariance_original{};
+  for (const auto & vehicle_twist : vehicle_twist_queue) {
+    vx_mean += vehicle_twist.twist.twist.linear.x;
+    vx_covariance_original += vehicle_twist.twist.covariance[COV_IDX_XYZRPY::X_X];
+  }
+  vx_mean /= static_cast<double>(vehicle_twist_queue.size());
+  vx_covariance_original /= static_cast<double>(vehicle_twist_queue.size());
+
+  for (const auto & gyro : gyro_queue) {
+    gyro_mean.x += gyro.angular_velocity.x;
+    gyro_mean.y += gyro.angular_velocity.y;
+    gyro_mean.z += gyro.angular_velocity.z;
+    gyro_covariance_original.x += gyro.angular_velocity_covariance[COV_IDX_XYZ::X_X];
+    gyro_covariance_original.y += gyro.angular_velocity_covariance[COV_IDX_XYZ::Y_Y];
+    gyro_covariance_original.z += gyro.angular_velocity_covariance[COV_IDX_XYZ::Z_Z];
+  }
+  gyro_mean.x /= static_cast<double>(gyro_queue.size());
+  gyro_mean.y /= static_cast<double>(gyro_queue.size());
+  gyro_mean.z /= static_cast<double>(gyro_queue.size());
+  gyro_covariance_original.x /= static_cast<double>(gyro_queue.size());
+  gyro_covariance_original.y /= static_cast<double>(gyro_queue.size());
+  gyro_covariance_original.z /= static_cast<double>(gyro_queue.size());
+
+  // concat
+  geometry_msgs::msg::TwistWithCovarianceStamped twist_with_cov;
+  const auto latest_vehicle_twist_stamp = rclcpp::Time(vehicle_twist_queue.back().header.stamp);
+  const auto latest_imu_stamp = rclcpp::Time(gyro_queue.back().header.stamp);
+  if (latest_vehicle_twist_stamp < latest_imu_stamp) {
+    twist_with_cov.header.stamp = latest_imu_stamp;
+  } else {
+    twist_with_cov.header.stamp = latest_vehicle_twist_stamp;
+  }
+  twist_with_cov.header.frame_id = gyro_queue.front().header.frame_id;
+  twist_with_cov.twist.twist.linear.x = vx_mean;
+  twist_with_cov.twist.twist.angular = gyro_mean;
+
+  // From a statistical point of view, here we reduce the covariances according to the number of
+  // observed data
+  twist_with_cov.twist.covariance[COV_IDX_XYZRPY::X_X] =
+    vx_covariance_original / static_cast<double>(vehicle_twist_queue.size());
+  twist_with_cov.twist.covariance[COV_IDX_XYZRPY::Y_Y] = 100000.0;
+  twist_with_cov.twist.covariance[COV_IDX_XYZRPY::Z_Z] = 100000.0;
+  twist_with_cov.twist.covariance[COV_IDX_XYZRPY::ROLL_ROLL] =
+    gyro_covariance_original.x / static_cast<double>(gyro_queue.size());
+  twist_with_cov.twist.covariance[COV_IDX_XYZRPY::PITCH_PITCH] =
+    gyro_covariance_original.y / static_cast<double>(gyro_queue.size());
+  twist_with_cov.twist.covariance[COV_IDX_XYZRPY::YAW_YAW] =
+    gyro_covariance_original.z / static_cast<double>(gyro_queue.size());
+
+  return twist_with_cov;
+}
+
+geometry_msgs::msg::TwistWithCovarianceStamped apply_stop_compensation(
+  const geometry_msgs::msg::TwistWithCovarianceStamped & twist_with_cov)
+{
+  geometry_msgs::msg::TwistWithCovarianceStamped result = twist_with_cov;
+
+  // clear imu yaw bias if vehicle is stopped
+  if (
+    std::fabs(twist_with_cov.twist.twist.angular.z) < 0.01 &&
+    std::fabs(twist_with_cov.twist.twist.linear.x) < 0.01) {
+    result.twist.twist.angular.x = 0.0;
+    result.twist.twist.angular.y = 0.0;
+    result.twist.twist.angular.z = 0.0;
+  }
+
+  return result;
+}
+
+DiagnosticsResult determine_diagnostics(const DiagnosticsState & state)
+{
+  using diagnostic_msgs::msg::DiagnosticStatus;
+
+  DiagnosticsResult result;
+
+  const auto raise = [&result](const int8_t level, const std::string & message) {
+    result.entries.push_back({level, message});
+    result.level = std::max(result.level, level);
+    result.log_message += message;
+    result.log_message += "; ";
+  };
+
+  if (!state.vehicle_twist_arrived) {
+    raise(DiagnosticStatus::WARN, "Twist msg has not been arrived yet.");
+  }
+  if (!state.imu_arrived) {
+    raise(DiagnosticStatus::WARN, "IMU msg has not been arrived yet.");
+  }
+  if (state.latest_vehicle_twist_dt > state.message_timeout_sec) {
+    const std::string message = fmt::format(
+      "Vehicle twist msg is timeout. vehicle_twist_dt: {}[sec], tolerance {}[sec]",
+      state.latest_vehicle_twist_dt, state.message_timeout_sec);
+    raise(DiagnosticStatus::ERROR, message);
+  }
+  if (state.latest_imu_dt > state.message_timeout_sec) {
+    const std::string message = fmt::format(
+      "IMU msg is timeout. imu_dt: {}[sec], tolerance {}[sec]", state.latest_imu_dt,
+      state.message_timeout_sec);
+    raise(DiagnosticStatus::ERROR, message);
+  }
+  if (!state.is_succeed_transform_imu) {
+    raise(
+      DiagnosticStatus::ERROR,
+      "Please publish TF from " + state.output_frame + " to frame of IMU.");
+  }
+
+  return result;
+}
+
+}  // namespace autoware::gyro_odometer

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_fusion.hpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_fusion.hpp
@@ -1,0 +1,98 @@
+// Copyright 2015-2019 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GYRO_ODOMETER_FUSION_HPP_
+#define GYRO_ODOMETER_FUSION_HPP_
+
+#include <diagnostic_msgs/msg/diagnostic_status.hpp>
+#include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
+#include <sensor_msgs/msg/imu.hpp>
+
+#include <array>
+#include <cstdint>
+#include <deque>
+#include <string>
+#include <vector>
+
+namespace autoware::gyro_odometer
+{
+
+/// \brief Reduce an angular-velocity covariance (xyz layout) to an isotropic diagonal covariance.
+///
+/// The maximum of the three diagonal terms (X_X, Y_Y, Z_Z) is written to all three diagonal
+/// terms; every off-diagonal term is zeroed. Pure function: output depends only on the input.
+std::array<double, 9> transform_covariance(const std::array<double, 9> & cov);
+
+/// \brief Fuse the vehicle-twist queue and the (already gyro-frame-transformed) IMU queue into a
+/// single twist with covariance.
+///
+/// Computes the per-queue means and the statistically reduced covariances, and selects the output
+/// header stamp as the later of the latest vehicle-twist and latest IMU stamps. The IMU queue must
+/// already be transformed into the output frame (its covariances reduced via transform_covariance).
+/// Both queues must be non-empty; emptiness is the caller's responsibility to check.
+///
+/// Pure function: it reads the queues and produces an output message without touching any node
+/// state, the clock, TF, or publishers.
+geometry_msgs::msg::TwistWithCovarianceStamped fuse_twist(
+  const std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> & vehicle_twist_queue,
+  const std::deque<sensor_msgs::msg::Imu> & gyro_queue);
+
+/// \brief Clear the IMU-derived angular velocity when the vehicle is judged to be stopped.
+///
+/// When both |angular.z| and |linear.x| are below 0.01, all three angular components are zeroed;
+/// otherwise the input is returned unchanged. Pure function returning a new message.
+geometry_msgs::msg::TwistWithCovarianceStamped apply_stop_compensation(
+  const geometry_msgs::msg::TwistWithCovarianceStamped & twist_with_cov);
+
+/// \brief A single diagnostics finding: a severity level paired with its human-readable message.
+struct DiagnosticsEntry
+{
+  int8_t level{diagnostic_msgs::msg::DiagnosticStatus::OK};
+  std::string message;
+};
+
+/// \brief Inputs needed to decide the gyro_odometer diagnostics level and messages.
+struct DiagnosticsState
+{
+  bool vehicle_twist_arrived{false};
+  bool imu_arrived{false};
+  bool is_succeed_transform_imu{false};
+  double latest_vehicle_twist_dt{0.0};
+  double latest_imu_dt{0.0};
+  double message_timeout_sec{0.0};
+  std::string output_frame;
+};
+
+/// \brief Result of evaluating the diagnostics state.
+///
+/// \c entries holds one element per triggered condition (level + message), preserving the node's
+/// historical check order. \c level is the maximum severity across all entries. \c log_message is
+/// every entry message concatenated, each terminated by "; ".
+struct DiagnosticsResult
+{
+  std::vector<DiagnosticsEntry> entries;
+  int8_t level{diagnostic_msgs::msg::DiagnosticStatus::OK};
+  std::string log_message;
+};
+
+/// \brief Evaluate the diagnostics state into per-condition entries, an aggregated level, and a
+/// concatenated log message.
+///
+/// Pure function: no node, clock, or interface dependency. The messages are byte-for-byte identical
+/// to the node's original strings (the TF-failure message embeds \c state.output_frame).
+DiagnosticsResult determine_diagnostics(const DiagnosticsState & state);
+
+}  // namespace autoware::gyro_odometer
+
+#endif  // GYRO_ODOMETER_FUSION_HPP_

--- a/localization/autoware_gyro_odometer/test/test_gyro_odometer_fusion.cpp
+++ b/localization/autoware_gyro_odometer/test/test_gyro_odometer_fusion.cpp
@@ -1,0 +1,320 @@
+// Copyright 2025 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gyro_odometer_fusion.hpp"
+
+#include <autoware_utils_geometry/msg/covariance.hpp>
+#include <builtin_interfaces/msg/time.hpp>
+
+#include <diagnostic_msgs/msg/diagnostic_status.hpp>
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <deque>
+#include <string>
+
+namespace autoware::gyro_odometer
+{
+namespace
+{
+
+using geometry_msgs::msg::TwistWithCovarianceStamped;
+using sensor_msgs::msg::Imu;
+using COV_IDX_XYZ = autoware_utils_geometry::xyz_covariance_index::XYZ_COV_IDX;
+using COV_IDX_XYZRPY = autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
+
+builtin_interfaces::msg::Time make_stamp(int32_t sec, uint32_t nanosec)
+{
+  builtin_interfaces::msg::Time stamp;
+  stamp.sec = sec;
+  stamp.nanosec = nanosec;
+  return stamp;
+}
+
+}  // namespace
+
+// transform_covariance: the maximum diagonal term is written to every diagonal term, off-diagonals
+// are zeroed.
+TEST(GyroOdometerFusion, TransformCovariancePicksMaxDiagonalAndZerosOffDiagonals)
+{
+  std::array<double, 9> cov = {};
+  cov[COV_IDX_XYZ::X_X] = 1.0;
+  cov[COV_IDX_XYZ::Y_Y] = 5.0;  // max
+  cov[COV_IDX_XYZ::Z_Z] = 3.0;
+  // pollute off-diagonals to make sure they are dropped
+  cov[COV_IDX_XYZ::X_Y] = 42.0;
+  cov[COV_IDX_XYZ::Z_X] = -7.0;
+
+  const std::array<double, 9> out = transform_covariance(cov);
+
+  EXPECT_DOUBLE_EQ(out[COV_IDX_XYZ::X_X], 5.0);
+  EXPECT_DOUBLE_EQ(out[COV_IDX_XYZ::Y_Y], 5.0);
+  EXPECT_DOUBLE_EQ(out[COV_IDX_XYZ::Z_Z], 5.0);
+  EXPECT_DOUBLE_EQ(out[COV_IDX_XYZ::X_Y], 0.0);
+  EXPECT_DOUBLE_EQ(out[COV_IDX_XYZ::X_Z], 0.0);
+  EXPECT_DOUBLE_EQ(out[COV_IDX_XYZ::Y_X], 0.0);
+  EXPECT_DOUBLE_EQ(out[COV_IDX_XYZ::Y_Z], 0.0);
+  EXPECT_DOUBLE_EQ(out[COV_IDX_XYZ::Z_X], 0.0);
+  EXPECT_DOUBLE_EQ(out[COV_IDX_XYZ::Z_Y], 0.0);
+}
+
+// fuse_twist: means over multiple entries, covariance reduction by queue size, fixed Y_Y/Z_Z, and
+// the output stamp being the later of the two latest queue stamps.
+TEST(GyroOdometerFusion, FuseTwistComputesMeansCovarianceAndStamp)
+{
+  std::deque<TwistWithCovarianceStamped> vehicle_twist_queue;
+  {
+    TwistWithCovarianceStamped t;
+    t.header.stamp = make_stamp(10, 0);
+    t.twist.twist.linear.x = 2.0;
+    t.twist.covariance[COV_IDX_XYZRPY::X_X] = 4.0;
+    vehicle_twist_queue.push_back(t);
+
+    t.header.stamp = make_stamp(12, 0);  // latest vehicle twist stamp
+    t.twist.twist.linear.x = 4.0;
+    t.twist.covariance[COV_IDX_XYZRPY::X_X] = 8.0;
+    vehicle_twist_queue.push_back(t);
+  }
+  // mean vx = 3.0; summed cov / n = 12/2 = 6.0; reduced again / n = 6.0/2 = 3.0
+
+  std::deque<Imu> gyro_queue;
+  {
+    Imu imu;
+    imu.header.frame_id = "base_link";
+    imu.header.stamp = make_stamp(11, 0);
+    imu.angular_velocity.x = 0.2;
+    imu.angular_velocity.y = 0.4;
+    imu.angular_velocity.z = 0.6;
+    imu.angular_velocity_covariance[COV_IDX_XYZ::X_X] = 1.0;
+    imu.angular_velocity_covariance[COV_IDX_XYZ::Y_Y] = 2.0;
+    imu.angular_velocity_covariance[COV_IDX_XYZ::Z_Z] = 3.0;
+    gyro_queue.push_back(imu);
+
+    imu.header.stamp = make_stamp(13, 0);  // latest imu stamp -> overall latest
+    imu.angular_velocity.x = 0.4;
+    imu.angular_velocity.y = 0.8;
+    imu.angular_velocity.z = 1.2;
+    imu.angular_velocity_covariance[COV_IDX_XYZ::X_X] = 3.0;
+    imu.angular_velocity_covariance[COV_IDX_XYZ::Y_Y] = 6.0;
+    imu.angular_velocity_covariance[COV_IDX_XYZ::Z_Z] = 9.0;
+    gyro_queue.push_back(imu);
+  }
+  // gyro means: x=0.3, y=0.6, z=0.9
+  // gyro cov sums/n: x=4/2=2, y=8/2=4, z=12/2=6; reduced again /n: x=1, y=2, z=3
+
+  const TwistWithCovarianceStamped out = fuse_twist(vehicle_twist_queue, gyro_queue);
+
+  EXPECT_DOUBLE_EQ(out.twist.twist.linear.x, 3.0);
+  EXPECT_DOUBLE_EQ(out.twist.twist.angular.x, 0.3);
+  EXPECT_DOUBLE_EQ(out.twist.twist.angular.y, 0.6);
+  EXPECT_DOUBLE_EQ(out.twist.twist.angular.z, 0.9);
+
+  EXPECT_DOUBLE_EQ(out.twist.covariance[COV_IDX_XYZRPY::X_X], 3.0);
+  EXPECT_DOUBLE_EQ(out.twist.covariance[COV_IDX_XYZRPY::Y_Y], 100000.0);
+  EXPECT_DOUBLE_EQ(out.twist.covariance[COV_IDX_XYZRPY::Z_Z], 100000.0);
+  EXPECT_DOUBLE_EQ(out.twist.covariance[COV_IDX_XYZRPY::ROLL_ROLL], 1.0);
+  EXPECT_DOUBLE_EQ(out.twist.covariance[COV_IDX_XYZRPY::PITCH_PITCH], 2.0);
+  EXPECT_DOUBLE_EQ(out.twist.covariance[COV_IDX_XYZRPY::YAW_YAW], 3.0);
+
+  // output stamp is the later of latest vehicle twist (12s) and latest imu (13s)
+  EXPECT_EQ(out.header.stamp.sec, 13);
+  EXPECT_EQ(out.header.stamp.nanosec, 0u);
+  // frame id is taken from the front of the gyro queue
+  EXPECT_EQ(out.header.frame_id, "base_link");
+}
+
+// fuse_twist: when the latest vehicle-twist stamp is later than the latest IMU stamp, the output
+// stamp follows the vehicle twist.
+TEST(GyroOdometerFusion, FuseTwistChoosesLaterVehicleTwistStamp)
+{
+  std::deque<TwistWithCovarianceStamped> vehicle_twist_queue;
+  {
+    TwistWithCovarianceStamped t;
+    t.header.stamp = make_stamp(20, 500);
+    vehicle_twist_queue.push_back(t);
+  }
+  std::deque<Imu> gyro_queue;
+  {
+    Imu imu;
+    imu.header.frame_id = "imu_link";
+    imu.header.stamp = make_stamp(20, 100);
+    gyro_queue.push_back(imu);
+  }
+
+  const TwistWithCovarianceStamped out = fuse_twist(vehicle_twist_queue, gyro_queue);
+
+  EXPECT_EQ(out.header.stamp.sec, 20);
+  EXPECT_EQ(out.header.stamp.nanosec, 500u);
+  EXPECT_EQ(out.header.frame_id, "imu_link");
+}
+
+// apply_stop_compensation: when both |angular.z| and |linear.x| are below 0.01, all angular
+// components are zeroed.
+TEST(GyroOdometerFusion, ApplyStopCompensationZeroesAngularWhenStopped)
+{
+  TwistWithCovarianceStamped twist;
+  twist.twist.twist.linear.x = 0.005;
+  twist.twist.twist.angular.x = 0.5;
+  twist.twist.twist.angular.y = -0.4;
+  twist.twist.twist.angular.z = 0.001;
+
+  const TwistWithCovarianceStamped out = apply_stop_compensation(twist);
+
+  EXPECT_DOUBLE_EQ(out.twist.twist.angular.x, 0.0);
+  EXPECT_DOUBLE_EQ(out.twist.twist.angular.y, 0.0);
+  EXPECT_DOUBLE_EQ(out.twist.twist.angular.z, 0.0);
+  // linear.x is preserved
+  EXPECT_DOUBLE_EQ(out.twist.twist.linear.x, 0.005);
+}
+
+// apply_stop_compensation: when the vehicle is moving (large linear.x), angular is preserved.
+TEST(GyroOdometerFusion, ApplyStopCompensationPreservesAngularWhenMoving)
+{
+  TwistWithCovarianceStamped twist;
+  twist.twist.twist.linear.x = 3.0;  // moving
+  twist.twist.twist.angular.x = 0.5;
+  twist.twist.twist.angular.y = -0.4;
+  twist.twist.twist.angular.z = 0.001;  // small yaw but vehicle is moving
+
+  const TwistWithCovarianceStamped out = apply_stop_compensation(twist);
+
+  EXPECT_DOUBLE_EQ(out.twist.twist.angular.x, 0.5);
+  EXPECT_DOUBLE_EQ(out.twist.twist.angular.y, -0.4);
+  EXPECT_DOUBLE_EQ(out.twist.twist.angular.z, 0.001);
+  EXPECT_DOUBLE_EQ(out.twist.twist.linear.x, 3.0);
+}
+
+// apply_stop_compensation: a large yaw rate keeps angular even when linear.x is small.
+TEST(GyroOdometerFusion, ApplyStopCompensationPreservesAngularWhenTurning)
+{
+  TwistWithCovarianceStamped twist;
+  twist.twist.twist.linear.x = 0.0;
+  twist.twist.twist.angular.z = 0.5;  // turning in place
+  twist.twist.twist.angular.x = 0.1;
+
+  const TwistWithCovarianceStamped out = apply_stop_compensation(twist);
+
+  EXPECT_DOUBLE_EQ(out.twist.twist.angular.x, 0.1);
+  EXPECT_DOUBLE_EQ(out.twist.twist.angular.z, 0.5);
+}
+
+// determine_diagnostics: everything healthy -> OK, no entries, empty log.
+TEST(GyroOdometerFusion, DetermineDiagnosticsOkWhenHealthy)
+{
+  DiagnosticsState state;
+  state.vehicle_twist_arrived = true;
+  state.imu_arrived = true;
+  state.is_succeed_transform_imu = true;
+  state.latest_vehicle_twist_dt = 0.01;
+  state.latest_imu_dt = 0.01;
+  state.message_timeout_sec = 1.0;
+  state.output_frame = "base_link";
+
+  const DiagnosticsResult result = determine_diagnostics(state);
+
+  EXPECT_EQ(result.level, diagnostic_msgs::msg::DiagnosticStatus::OK);
+  EXPECT_TRUE(result.entries.empty());
+  EXPECT_TRUE(result.log_message.empty());
+}
+
+// determine_diagnostics: missing inputs raise WARN. This pins the bug fix: the aggregated level
+// must reflect the highest triggered severity (previously the local 'level' stayed OK and the WARN
+// log was unreachable).
+TEST(GyroOdometerFusion, DetermineDiagnosticsWarnWhenNotArrived)
+{
+  DiagnosticsState state;
+  state.vehicle_twist_arrived = false;
+  state.imu_arrived = false;
+  state.is_succeed_transform_imu = true;
+  state.latest_vehicle_twist_dt = 0.0;
+  state.latest_imu_dt = 0.0;
+  state.message_timeout_sec = 1.0;
+
+  const DiagnosticsResult result = determine_diagnostics(state);
+
+  EXPECT_EQ(result.level, diagnostic_msgs::msg::DiagnosticStatus::WARN);
+  ASSERT_EQ(result.entries.size(), 2u);
+  EXPECT_EQ(result.entries[0].level, diagnostic_msgs::msg::DiagnosticStatus::WARN);
+  EXPECT_EQ(result.entries[0].message, "Twist msg has not been arrived yet.");
+  EXPECT_EQ(result.entries[1].message, "IMU msg has not been arrived yet.");
+  EXPECT_EQ(
+    result.log_message, "Twist msg has not been arrived yet.; IMU msg has not been arrived yet.; ");
+}
+
+// determine_diagnostics: a timeout raises ERROR and the message text matches the historical format.
+TEST(GyroOdometerFusion, DetermineDiagnosticsErrorOnTimeout)
+{
+  DiagnosticsState state;
+  state.vehicle_twist_arrived = true;
+  state.imu_arrived = true;
+  state.is_succeed_transform_imu = true;
+  state.latest_vehicle_twist_dt = 2.0;  // > timeout
+  state.latest_imu_dt = 0.0;
+  state.message_timeout_sec = 1.0;
+
+  const DiagnosticsResult result = determine_diagnostics(state);
+
+  EXPECT_EQ(result.level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
+  ASSERT_EQ(result.entries.size(), 1u);
+  EXPECT_EQ(result.entries[0].level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
+  EXPECT_EQ(
+    result.entries[0].message,
+    "Vehicle twist msg is timeout. vehicle_twist_dt: 2[sec], tolerance 1[sec]");
+}
+
+// determine_diagnostics: TF failure raises ERROR and the message embeds the configured output
+// frame.
+TEST(GyroOdometerFusion, DetermineDiagnosticsErrorOnTransformFailure)
+{
+  DiagnosticsState state;
+  state.vehicle_twist_arrived = true;
+  state.imu_arrived = true;
+  state.is_succeed_transform_imu = false;  // TF lookup failed
+  state.latest_vehicle_twist_dt = 0.0;
+  state.latest_imu_dt = 0.0;
+  state.message_timeout_sec = 1.0;
+  state.output_frame = "base_link";
+
+  const DiagnosticsResult result = determine_diagnostics(state);
+
+  EXPECT_EQ(result.level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
+  ASSERT_EQ(result.entries.size(), 1u);
+  EXPECT_EQ(result.entries[0].message, "Please publish TF from base_link to frame of IMU.");
+}
+
+// determine_diagnostics: when both WARN and ERROR conditions trigger, the aggregated level is the
+// ERROR maximum, while every entry keeps its own level and message order.
+TEST(GyroOdometerFusion, DetermineDiagnosticsAggregatesToMaxSeverity)
+{
+  DiagnosticsState state;
+  state.vehicle_twist_arrived = false;  // WARN
+  state.imu_arrived = true;
+  state.is_succeed_transform_imu = false;  // ERROR
+  state.latest_vehicle_twist_dt = 0.0;
+  state.latest_imu_dt = 0.0;
+  state.message_timeout_sec = 1.0;
+  state.output_frame = "base_link";
+
+  const DiagnosticsResult result = determine_diagnostics(state);
+
+  EXPECT_EQ(result.level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
+  ASSERT_EQ(result.entries.size(), 2u);
+  EXPECT_EQ(result.entries[0].level, diagnostic_msgs::msg::DiagnosticStatus::WARN);
+  EXPECT_EQ(result.entries[0].message, "Twist msg has not been arrived yet.");
+  EXPECT_EQ(result.entries[1].level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
+  EXPECT_EQ(result.entries[1].message, "Please publish TF from base_link to frame of IMU.");
+}
+
+}  // namespace autoware::gyro_odometer


### PR DESCRIPTION
## Description

Extracts the sensor-fusion math out of the `GyroOdometerNode` private methods into pure, unit-testable free functions in a new internal header `src/gyro_odometer_fusion.hpp` / `.cpp`:

- `transform_covariance()` — moved out of `gyro_odometer_core.cpp` so it is reachable from a test translation unit (previously file-local).
- `fuse_twist(vehicle_twist_queue, gyro_queue)` — the per-queue mean / covariance reduction and output header-stamp selection (the body of `concat_gyro_and_odometer()` after the TF transform).
- `apply_stop_compensation(twist)` — the stopped-vehicle yaw-bias clearing previously inlined in `publish_data()`.
- `determine_diagnostics(state)` — the diagnostics level / message computation previously inlined in `publish_diagnostics()`.

The node methods now delegate to these functions and keep only I/O, TF lookup, and timeout handling. This makes the fusion algorithm testable without spinning a full node, and adds direct gtest coverage of the previously untested math and diagnostics branches.

## Effects on system behavior

Behavior-preserving except for one latent bug fix in `publish_diagnostics()`:

- Before: a local `uint8_t level` was initialized to `OK` and never reassigned, so the throttled `RCLCPP_WARN_STREAM_THROTTLE` / `RCLCPP_ERROR_STREAM_THROTTLE` console-log blocks were unreachable — the console WARN/ERROR logs never fired.
- After: `determine_diagnostics()` aggregates the maximum severity across all triggered conditions, so the console WARN/ERROR logs now fire as intended when a condition is active.
- The published `diagnostic_msgs/DiagnosticStatus` level and message text are unchanged (they were already correct via `DiagnosticsInterface::update_level_and_message`, and the TF-failure message still embeds the configured `output_frame`). The pre-existing integration test `GyroOdometer.TestGyroOdometerImuOnly` now visibly emits the WARN console log, confirming the fix while still passing.

No public class API change: `GyroOdometerNode`'s signature is untouched. The new free functions live in an internal (non-installed) header, additive only.

Downstream consumers: none affected — the published topics (`twist`, `twist_with_covariance`, `twist_raw`, `twist_with_covariance_raw`) and `/diagnostics` content are byte-for-byte identical to before.

## Tests

New `test/test_gyro_odometer_fusion.cpp` (11 gtests) asserting concrete values:
- `transform_covariance`: max diagonal propagation + off-diagonal zeroing.
- `fuse_twist`: means, covariance reduction (twist X_X, fixed Y_Y/Z_Z = 100000.0, gyro ROLL/PITCH/YAW), frame_id, and later-of-two-stamps selection (both branches).
- `apply_stop_compensation`: stopped / moving / turning-in-place branches.
- `determine_diagnostics`: OK, WARN (not-arrived), ERROR (timeout, TF-failure with embedded frame), and WARN+ERROR aggregation — the latter pinning the bug fix.

All 13 gtests (2 pre-existing + 11 new) pass; build (Release) and the package lint ctests (copyright, cppcheck, lint_cmake, xmllint) are green in the `autoware:core-devel-jazzy` container. clang-format verified clean against the repo `.clang-format`.

Refs: autowarefoundation/autoware_core#1096