### PR TITLE
refactor(autoware_mission_planner): extract pure check_reroute_safety free function

### DIFF
--- a/planning/autoware_mission_planner/CMakeLists.txt
+++ b/planning/autoware_mission_planner/CMakeLists.txt
@@ -16,6 +16,7 @@ rclcpp_components_register_node(goal_pose_visualizer_component
 ament_auto_add_library(${PROJECT_NAME}_component SHARED
   src/mission_planner/arrival_checker.cpp
   src/mission_planner/service_utils.cpp
+  src/mission_planner/reroute_safety.cpp
   src/mission_planner/mission_planner.cpp
 )
 
@@ -40,6 +41,13 @@ if(BUILD_TESTING)
   )
   ament_target_dependencies(test_${PROJECT_NAME}
     autoware_test_utils
+  )
+
+  ament_add_ros_isolated_gtest(test_${PROJECT_NAME}_reroute_safety
+  test/test_reroute_safety.cpp
+  )
+  target_link_libraries(test_${PROJECT_NAME}_reroute_safety
+    ${PROJECT_NAME}_component
   )
 endif()
 

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
@@ -14,22 +14,16 @@
 
 #include "mission_planner.hpp"
 
+#include "reroute_safety.hpp"
 #include "service_utils.hpp"
 
 #include <autoware/lanelet2_utils/conversion.hpp>
-#include <autoware/lanelet2_utils/geometry.hpp>
-#include <autoware/lanelet2_utils/nn_search.hpp>
 
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
-#include <lanelet2_core/geometry/Lanelet.h>
-#include <lanelet2_core/geometry/LineString.h>
-
-#include <algorithm>
 #include <memory>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace autoware::mission_planner
@@ -393,208 +387,19 @@ LaneletRoute MissionPlanner::create_route(
 bool MissionPlanner::check_reroute_safety(
   const LaneletRoute & original_route, const LaneletRoute & target_route)
 {
-  if (
-    original_route.segments.empty() || target_route.segments.empty() || !map_ptr_ ||
-    !lanelet_map_ptr_ || !odometry_) {
+  // The pure check_reroute_safety free function validates the routes and the map, but the node
+  // owns the odometry, so guard it here to keep the original observable behavior (same log
+  // message and early return when odometry or map is not yet available).
+  if (!map_ptr_ || !lanelet_map_ptr_ || !odometry_) {
     RCLCPP_ERROR(get_logger(), "Check reroute safety failed. Route, map or odometry is not set.");
     return false;
   }
 
   const auto current_velocity = odometry_->twist.twist.linear.x;
 
-  // if vehicle is stopped, do not check safety
-  if (current_velocity < 0.01) {
-    return true;
-  }
-
-  auto hasSamePrimitives = [](
-                             const std::vector<LaneletPrimitive> & original_primitives,
-                             const std::vector<LaneletPrimitive> & target_primitives) {
-    if (original_primitives.size() != target_primitives.size()) {
-      return false;
-    }
-
-    for (const auto & primitive : original_primitives) {
-      const auto has_same = [&](const auto & p) { return p.id == primitive.id; };
-      const bool is_same =
-        std::find_if(target_primitives.begin(), target_primitives.end(), has_same) !=
-        target_primitives.end();
-      if (!is_same) {
-        return false;
-      }
-    }
-    return true;
-  };
-
-  // =============================================================================================
-  // NOTE: the target route is calculated while ego is driving on the original route, so basically
-  // the first lane of the target route should be in the original route lanelets. So the common
-  // segment interval matches the beginning of the target route. The exception is that if ego is
-  // on an intersection lanelet, getClosestLanelet() may not return the same lanelet which exists
-  // in the original route. In that case the common segment interval does not match the beginning of
-  // the target lanelet
-  // =============================================================================================
-  const auto start_idx_opt =
-    std::invoke([&]() -> std::optional<std::pair<size_t /* original */, size_t /* target */>> {
-      for (size_t i = 0; i < original_route.segments.size(); ++i) {
-        const auto & original_segment = original_route.segments.at(i).primitives;
-        for (size_t j = 0; j < target_route.segments.size(); ++j) {
-          const auto & target_segment = target_route.segments.at(j).primitives;
-          if (hasSamePrimitives(original_segment, target_segment)) {
-            return std::make_pair(i, j);
-          }
-        }
-      }
-      return std::nullopt;
-    });
-  if (!start_idx_opt.has_value()) {
-    RCLCPP_ERROR(
-      get_logger(), "Check reroute safety failed. Cannot find the start index of the route.");
-    return false;
-  }
-  const auto [start_idx_original, start_idx_target] = start_idx_opt.value();
-
-  // find last idx that matches the target primitives
-  size_t end_idx_original = start_idx_original;
-  size_t end_idx_target = start_idx_target;
-  for (size_t i = 1; i < target_route.segments.size() - start_idx_target; ++i) {
-    if (start_idx_original + i > original_route.segments.size() - 1) {
-      break;
-    }
-
-    const auto & original_primitives =
-      original_route.segments.at(start_idx_original + i).primitives;
-    const auto & target_primitives = target_route.segments.at(start_idx_target + i).primitives;
-    if (!hasSamePrimitives(original_primitives, target_primitives)) {
-      break;
-    }
-    end_idx_original = start_idx_original + i;
-    end_idx_target = start_idx_target + i;
-  }
-
-  // make sure that ego is within the reroute target
-  const bool ego_is_on_first_target_section = std::any_of(
-    target_route.segments.front().primitives.begin(),
-    target_route.segments.front().primitives.end(), [&](const auto & primitive) {
-      const auto lanelet = lanelet_map_ptr_->laneletLayer.get(primitive.id);
-      return autoware::experimental::lanelet2_utils::is_in_lanelet(
-        target_route.start_pose, lanelet);
-    });
-  if (!ego_is_on_first_target_section) {
-    RCLCPP_ERROR(
-      get_logger(),
-      "Check reroute safety failed. Ego is not on the first section of target route.");
-    return false;
-  }
-
-  // if the front of target route is not the front of common segment, it is expected that the front
-  // of the target route is conflicting with another lane which is equal to original
-  // route[start_idx_original-1]
-  double accumulated_length = 0.0;
-
-  if (start_idx_target != 0 && start_idx_original > 1) {
-    // compute distance from the current pose to the beginning of the common segment
-    const auto current_pose = target_route.start_pose;
-    const auto primitives = original_route.segments.at(start_idx_original - 1).primitives;
-    lanelet::ConstLanelets start_lanelets;
-    for (const auto & primitive : primitives) {
-      const auto lanelet = lanelet_map_ptr_->laneletLayer.get(primitive.id);
-      start_lanelets.push_back(lanelet);
-    }
-    // closest lanelet in start lanelets
-    const auto closest_lanelet_opt =
-      experimental::lanelet2_utils::get_closest_lanelet(start_lanelets, current_pose);
-    if (!closest_lanelet_opt) {
-      RCLCPP_ERROR(get_logger(), "Check reroute safety failed. Cannot find the closest lanelet.");
-      return false;
-    }
-    const auto & closest_lanelet = closest_lanelet_opt.value();
-
-    const auto & centerline_2d = lanelet::utils::to2D(closest_lanelet.centerline());
-    const auto lanelet_point = experimental::lanelet2_utils::from_ros(current_pose.position);
-    const auto arc_coordinates = lanelet::geometry::toArcCoordinates(
-      centerline_2d, lanelet::utils::to2D(lanelet_point).basicPoint());
-    const double dist_to_current_pose = arc_coordinates.length;
-    const double lanelet_length = lanelet::geometry::length2d(closest_lanelet);
-    accumulated_length = lanelet_length - dist_to_current_pose;
-  } else {
-    // compute distance from the current pose to the end of the current lanelet
-    const auto current_pose = target_route.start_pose;
-    const auto primitives = original_route.segments.at(start_idx_original).primitives;
-    lanelet::ConstLanelets start_lanelets;
-    for (const auto & primitive : primitives) {
-      const auto lanelet = lanelet_map_ptr_->laneletLayer.get(primitive.id);
-      start_lanelets.push_back(lanelet);
-    }
-    // closest lanelet in start lanelets
-    const auto closest_lanelet_opt =
-      experimental::lanelet2_utils::get_closest_lanelet(start_lanelets, current_pose);
-    if (!closest_lanelet_opt) {
-      RCLCPP_ERROR(get_logger(), "Check reroute safety failed. Cannot find the closest lanelet.");
-      return false;
-    }
-    const auto & closest_lanelet = closest_lanelet_opt.value();
-
-    const auto & centerline_2d = lanelet::utils::to2D(closest_lanelet.centerline());
-    const auto lanelet_point = experimental::lanelet2_utils::from_ros(current_pose.position);
-    const auto arc_coordinates = lanelet::geometry::toArcCoordinates(
-      centerline_2d, lanelet::utils::to2D(lanelet_point).basicPoint());
-    const double dist_to_current_pose = arc_coordinates.length;
-    const double lanelet_length = lanelet::geometry::length2d(closest_lanelet);
-    accumulated_length = lanelet_length - dist_to_current_pose;
-  }
-
-  // compute distance from the start_idx+1 to end_idx
-  for (size_t i = start_idx_original + 1; i <= end_idx_original; ++i) {
-    const auto primitives = original_route.segments.at(i).primitives;
-    if (primitives.empty()) {
-      break;
-    }
-
-    std::vector<double> lanelets_length(primitives.size());
-    for (size_t primitive_idx = 0; primitive_idx < primitives.size(); ++primitive_idx) {
-      const auto & primitive = primitives.at(primitive_idx);
-      const auto & lanelet = lanelet_map_ptr_->laneletLayer.get(primitive.id);
-      lanelets_length.at(primitive_idx) = (lanelet::geometry::length2d(lanelet));
-    }
-    accumulated_length += *std::min_element(lanelets_length.begin(), lanelets_length.end());
-  }
-
-  // check if the goal is inside of the target terminal lanelet
-  const auto & target_end_primitives = target_route.segments.at(end_idx_target).primitives;
-  const auto & target_goal = target_route.goal_pose;
-  for (const auto & target_end_primitive : target_end_primitives) {
-    const auto lanelet = lanelet_map_ptr_->laneletLayer.get(target_end_primitive.id);
-    if (autoware::experimental::lanelet2_utils::is_in_lanelet(target_goal, lanelet)) {
-      const auto target_goal_position =
-        experimental::lanelet2_utils::from_ros(target_goal.position);
-      const double dist_to_goal = lanelet::geometry::toArcCoordinates(
-                                    lanelet::utils::to2D(lanelet.centerline()),
-                                    lanelet::utils::to2D(target_goal_position).basicPoint())
-                                    .length;
-      const double target_lanelet_length = lanelet::geometry::length2d(lanelet);
-      // NOTE: `accumulated_length` here contains the length of the entire target_end_primitive, so
-      // the remaining distance from the goal to the end of the target_end_primitive needs to be
-      // subtracted.
-      const double remaining_dist = target_lanelet_length - dist_to_goal;
-      accumulated_length = std::max(accumulated_length - remaining_dist, 0.0);
-      break;
-    }
-  }
-
-  // check safety
-  const double safety_length =
-    std::max(current_velocity * reroute_time_threshold_, minimum_reroute_length_);
-  if (accumulated_length > safety_length) {
-    return true;
-  }
-
-  RCLCPP_WARN(
-    get_logger(),
-    "Length of lane where original and B target (= %f) is less than safety length (= %f), so "
-    "reroute is not safe.",
-    accumulated_length, safety_length);
-  return false;
+  return autoware::mission_planner::check_reroute_safety(
+    original_route, target_route, lanelet_map_ptr_, current_velocity, reroute_time_threshold_,
+    minimum_reroute_length_, get_logger());
 }
 }  // namespace autoware::mission_planner
 

--- a/planning/autoware_mission_planner/src/mission_planner/reroute_safety.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/reroute_safety.cpp
@@ -1,0 +1,231 @@
+// Copyright 2025 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "reroute_safety.hpp"
+
+#include <autoware/lanelet2_utils/conversion.hpp>
+#include <autoware/lanelet2_utils/geometry.hpp>
+#include <autoware/lanelet2_utils/nn_search.hpp>
+#include <rclcpp/logging.hpp>
+
+#include <lanelet2_core/geometry/Lanelet.h>
+#include <lanelet2_core/geometry/LineString.h>
+
+#include <algorithm>
+#include <functional>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace autoware::mission_planner
+{
+
+namespace
+{
+using autoware_planning_msgs::msg::LaneletPrimitive;
+using autoware_planning_msgs::msg::LaneletRoute;
+
+bool has_same_primitives(
+  const std::vector<LaneletPrimitive> & original_primitives,
+  const std::vector<LaneletPrimitive> & target_primitives)
+{
+  if (original_primitives.size() != target_primitives.size()) {
+    return false;
+  }
+
+  for (const auto & primitive : original_primitives) {
+    const auto has_same = [&](const auto & p) { return p.id == primitive.id; };
+    const bool is_same =
+      std::find_if(target_primitives.begin(), target_primitives.end(), has_same) !=
+      target_primitives.end();
+    if (!is_same) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace
+
+bool check_reroute_safety(
+  const LaneletRoute & original_route, const LaneletRoute & target_route,
+  const lanelet::LaneletMapConstPtr & lanelet_map, const double current_velocity,
+  const double reroute_time_threshold, const double minimum_reroute_length,
+  const rclcpp::Logger & logger)
+{
+  if (original_route.segments.empty() || target_route.segments.empty() || !lanelet_map) {
+    RCLCPP_ERROR(logger, "Check reroute safety failed. Route, map or odometry is not set.");
+    return false;
+  }
+
+  // if vehicle is stopped, do not check safety
+  if (current_velocity < 0.01) {
+    return true;
+  }
+
+  // =============================================================================================
+  // NOTE: the target route is calculated while ego is driving on the original route, so basically
+  // the first lane of the target route should be in the original route lanelets. So the common
+  // segment interval matches the beginning of the target route. The exception is that if ego is
+  // on an intersection lanelet, getClosestLanelet() may not return the same lanelet which exists
+  // in the original route. In that case the common segment interval does not match the beginning of
+  // the target lanelet
+  // =============================================================================================
+  const auto start_idx_opt =
+    std::invoke([&]() -> std::optional<std::pair<size_t /* original */, size_t /* target */>> {
+      for (size_t i = 0; i < original_route.segments.size(); ++i) {
+        const auto & original_segment = original_route.segments.at(i).primitives;
+        for (size_t j = 0; j < target_route.segments.size(); ++j) {
+          const auto & target_segment = target_route.segments.at(j).primitives;
+          if (has_same_primitives(original_segment, target_segment)) {
+            return std::make_pair(i, j);
+          }
+        }
+      }
+      return std::nullopt;
+    });
+  if (!start_idx_opt.has_value()) {
+    RCLCPP_ERROR(logger, "Check reroute safety failed. Cannot find the start index of the route.");
+    return false;
+  }
+  const auto [start_idx_original, start_idx_target] = start_idx_opt.value();
+
+  // find last idx that matches the target primitives
+  size_t end_idx_original = start_idx_original;
+  size_t end_idx_target = start_idx_target;
+  for (size_t i = 1; i < target_route.segments.size() - start_idx_target; ++i) {
+    if (start_idx_original + i > original_route.segments.size() - 1) {
+      break;
+    }
+
+    const auto & original_primitives =
+      original_route.segments.at(start_idx_original + i).primitives;
+    const auto & target_primitives = target_route.segments.at(start_idx_target + i).primitives;
+    if (!has_same_primitives(original_primitives, target_primitives)) {
+      break;
+    }
+    end_idx_original = start_idx_original + i;
+    end_idx_target = start_idx_target + i;
+  }
+
+  // make sure that ego is within the reroute target
+  const bool ego_is_on_first_target_section = std::any_of(
+    target_route.segments.front().primitives.begin(),
+    target_route.segments.front().primitives.end(), [&](const auto & primitive) {
+      const auto lanelet = lanelet_map->laneletLayer.get(primitive.id);
+      return autoware::experimental::lanelet2_utils::is_in_lanelet(
+        target_route.start_pose, lanelet);
+    });
+  if (!ego_is_on_first_target_section) {
+    RCLCPP_ERROR(
+      logger, "Check reroute safety failed. Ego is not on the first section of target route.");
+    return false;
+  }
+
+  // compute the remaining arc-length from the current pose to the end of the closest lanelet among
+  // the primitives of the given original-route segment
+  const auto current_pose = target_route.start_pose;
+  const auto arc_length_to_lanelet_end =
+    [&](const std::vector<LaneletPrimitive> & primitives) -> std::optional<double> {
+    lanelet::ConstLanelets start_lanelets;
+    for (const auto & primitive : primitives) {
+      const auto lanelet = lanelet_map->laneletLayer.get(primitive.id);
+      start_lanelets.push_back(lanelet);
+    }
+    // closest lanelet in start lanelets
+    const auto closest_lanelet_opt =
+      experimental::lanelet2_utils::get_closest_lanelet(start_lanelets, current_pose);
+    if (!closest_lanelet_opt) {
+      return std::nullopt;
+    }
+    const auto & closest_lanelet = closest_lanelet_opt.value();
+
+    const auto & centerline_2d = lanelet::utils::to2D(closest_lanelet.centerline());
+    const auto lanelet_point = experimental::lanelet2_utils::from_ros(current_pose.position);
+    const auto arc_coordinates = lanelet::geometry::toArcCoordinates(
+      centerline_2d, lanelet::utils::to2D(lanelet_point).basicPoint());
+    const double dist_to_current_pose = arc_coordinates.length;
+    const double lanelet_length = lanelet::geometry::length2d(closest_lanelet);
+    return lanelet_length - dist_to_current_pose;
+  };
+
+  // if the front of target route is not the front of common segment, it is expected that the front
+  // of the target route is conflicting with another lane which is equal to original
+  // route[start_idx_original-1]. Otherwise compute the distance from the current pose to the end of
+  // the current lanelet. Both cases reduce to the same arc-length computation; only the source
+  // segment differs.
+  const size_t start_segment_idx =
+    (start_idx_target != 0 && start_idx_original > 1) ? start_idx_original - 1 : start_idx_original;
+  const auto start_segment_length =
+    arc_length_to_lanelet_end(original_route.segments.at(start_segment_idx).primitives);
+  if (!start_segment_length.has_value()) {
+    RCLCPP_ERROR(logger, "Check reroute safety failed. Cannot find the closest lanelet.");
+    return false;
+  }
+  double accumulated_length = start_segment_length.value();
+
+  // compute distance from the start_idx+1 to end_idx
+  for (size_t i = start_idx_original + 1; i <= end_idx_original; ++i) {
+    const auto & primitives = original_route.segments.at(i).primitives;
+    if (primitives.empty()) {
+      break;
+    }
+
+    std::vector<double> lanelets_length(primitives.size());
+    for (size_t primitive_idx = 0; primitive_idx < primitives.size(); ++primitive_idx) {
+      const auto & primitive = primitives.at(primitive_idx);
+      const auto & lanelet = lanelet_map->laneletLayer.get(primitive.id);
+      lanelets_length.at(primitive_idx) = (lanelet::geometry::length2d(lanelet));
+    }
+    accumulated_length += *std::min_element(lanelets_length.begin(), lanelets_length.end());
+  }
+
+  // check if the goal is inside of the target terminal lanelet
+  const auto & target_end_primitives = target_route.segments.at(end_idx_target).primitives;
+  const auto & target_goal = target_route.goal_pose;
+  for (const auto & target_end_primitive : target_end_primitives) {
+    const auto lanelet = lanelet_map->laneletLayer.get(target_end_primitive.id);
+    if (autoware::experimental::lanelet2_utils::is_in_lanelet(target_goal, lanelet)) {
+      const auto target_goal_position =
+        experimental::lanelet2_utils::from_ros(target_goal.position);
+      const double dist_to_goal = lanelet::geometry::toArcCoordinates(
+                                    lanelet::utils::to2D(lanelet.centerline()),
+                                    lanelet::utils::to2D(target_goal_position).basicPoint())
+                                    .length;
+      const double target_lanelet_length = lanelet::geometry::length2d(lanelet);
+      // NOTE: `accumulated_length` here contains the length of the entire target_end_primitive, so
+      // the remaining distance from the goal to the end of the target_end_primitive needs to be
+      // subtracted.
+      const double remaining_dist = target_lanelet_length - dist_to_goal;
+      accumulated_length = std::max(accumulated_length - remaining_dist, 0.0);
+      break;
+    }
+  }
+
+  // check safety
+  const double safety_length =
+    std::max(current_velocity * reroute_time_threshold, minimum_reroute_length);
+  if (accumulated_length > safety_length) {
+    return true;
+  }
+
+  RCLCPP_WARN(
+    logger,
+    "Length of lane where original and B target (= %f) is less than safety length (= %f), so "
+    "reroute is not safe.",
+    accumulated_length, safety_length);
+  return false;
+}
+
+}  // namespace autoware::mission_planner

--- a/planning/autoware_mission_planner/src/mission_planner/reroute_safety.hpp
+++ b/planning/autoware_mission_planner/src/mission_planner/reroute_safety.hpp
@@ -1,0 +1,55 @@
+// Copyright 2025 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MISSION_PLANNER__REROUTE_SAFETY_HPP_
+#define MISSION_PLANNER__REROUTE_SAFETY_HPP_
+
+#include <rclcpp/logger.hpp>
+
+#include <autoware_planning_msgs/msg/lanelet_route.hpp>
+
+#include <lanelet2_core/LaneletMap.h>
+
+namespace autoware::mission_planner
+{
+
+/**
+ * @brief pure, dependency-injected reroute-safety check.
+ *
+ * Decides whether switching from @p original_route to @p target_route is safe while the ego
+ * vehicle is moving. The length of road that the two routes share ahead of the ego (from the ego
+ * position to the goal of the target route) must exceed a safety margin that grows with the
+ * current velocity. This is the node-independent core of MissionPlanner::check_reroute_safety;
+ * the node method forwards to it after validating its own odometry / map members.
+ *
+ * @param original_route route the ego is currently following.
+ * @param target_route candidate route to switch to.
+ * @param lanelet_map lanelet map providing the primitives referenced by both routes.
+ * @param current_velocity longitudinal velocity of the ego [m/s].
+ * @param reroute_time_threshold time horizon used to scale the velocity-dependent safety length
+ * [s].
+ * @param minimum_reroute_length lower bound of the safety length [m].
+ * @param logger logger used for the diagnostic messages emitted on the failure branches.
+ * @return true if the reroute is safe (or the vehicle is effectively stopped), false otherwise.
+ */
+bool check_reroute_safety(
+  const autoware_planning_msgs::msg::LaneletRoute & original_route,
+  const autoware_planning_msgs::msg::LaneletRoute & target_route,
+  const lanelet::LaneletMapConstPtr & lanelet_map, const double current_velocity,
+  const double reroute_time_threshold, const double minimum_reroute_length,
+  const rclcpp::Logger & logger);
+
+}  // namespace autoware::mission_planner
+
+#endif  // MISSION_PLANNER__REROUTE_SAFETY_HPP_

--- a/planning/autoware_mission_planner/test/test_reroute_safety.cpp
+++ b/planning/autoware_mission_planner/test/test_reroute_safety.cpp
@@ -1,0 +1,218 @@
+// Copyright 2025 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/mission_planner/reroute_safety.hpp"
+
+#include <rclcpp/logger.hpp>
+#include <rclcpp/logging.hpp>
+
+#include <autoware_planning_msgs/msg/lanelet_route.hpp>
+
+#include <gtest/gtest.h>
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/primitives/Lanelet.h>
+#include <lanelet2_core/primitives/LineString.h>
+#include <lanelet2_core/primitives/Point.h>
+
+#include <memory>
+#include <vector>
+
+namespace
+{
+using autoware::mission_planner::check_reroute_safety;
+using autoware_planning_msgs::msg::LaneletPrimitive;
+using autoware_planning_msgs::msg::LaneletRoute;
+using autoware_planning_msgs::msg::LaneletSegment;
+using geometry_msgs::msg::Pose;
+
+// Build a straight, axis-aligned lanelet occupying x in [x_start, x_end], y in [-1, 1]. Its
+// centerline therefore runs along y = 0 and has a 2D length of (x_end - x_start).
+lanelet::Lanelet make_straight_lanelet(
+  const lanelet::Id id, const double x_start, const double x_end)
+{
+  lanelet::LineString3d left_bound(lanelet::utils::getId());
+  left_bound.push_back(lanelet::Point3d{lanelet::utils::getId(), x_start, 1.0, 0.0});
+  left_bound.push_back(lanelet::Point3d{lanelet::utils::getId(), x_end, 1.0, 0.0});
+  lanelet::LineString3d right_bound(lanelet::utils::getId());
+  right_bound.push_back(lanelet::Point3d{lanelet::utils::getId(), x_start, -1.0, 0.0});
+  right_bound.push_back(lanelet::Point3d{lanelet::utils::getId(), x_end, -1.0, 0.0});
+  return lanelet::Lanelet(id, left_bound, right_bound);
+}
+
+Pose make_pose(const double x, const double y = 0.0)
+{
+  Pose pose;
+  pose.position.x = x;
+  pose.position.y = y;
+  pose.position.z = 0.0;
+  pose.orientation.w = 1.0;
+  return pose;
+}
+
+LaneletSegment make_segment(const std::vector<lanelet::Id> & ids)
+{
+  LaneletSegment segment;
+  for (const auto id : ids) {
+    LaneletPrimitive primitive;
+    primitive.id = id;
+    primitive.primitive_type = "lane";
+    segment.primitives.push_back(primitive);
+    segment.preferred_primitive.id = id;
+  }
+  return segment;
+}
+
+rclcpp::Logger test_logger()
+{
+  return rclcpp::get_logger("test_reroute_safety");
+}
+
+}  // namespace
+
+class CheckRerouteSafetyTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    // Three colinear lanelets, each 100 m long, covering x in [0, 300].
+    map_ = std::make_shared<lanelet::LaneletMap>();
+    map_->add(make_straight_lanelet(1, 0.0, 100.0));
+    map_->add(make_straight_lanelet(2, 100.0, 200.0));
+    map_->add(make_straight_lanelet(3, 200.0, 300.0));
+  }
+
+  // A nominal route: segments {1}, {2}, {3}, start at x=10, goal at x=290.
+  static LaneletRoute make_nominal_route()
+  {
+    LaneletRoute route;
+    route.start_pose = make_pose(10.0);
+    route.goal_pose = make_pose(290.0);
+    route.segments = {make_segment({1}), make_segment({2}), make_segment({3})};
+    return route;
+  }
+
+  lanelet::LaneletMapPtr map_;
+  static constexpr double kRerouteTimeThreshold = 10.0;
+  static constexpr double kMinimumRerouteLength = 30.0;
+};
+
+// ---------------------------------------------------------------------------------------------
+// Early-return branches.
+// ---------------------------------------------------------------------------------------------
+
+TEST_F(CheckRerouteSafetyTest, ReturnsFalseWhenOriginalRouteEmpty)
+{
+  const auto target = make_nominal_route();
+  LaneletRoute original;  // empty segments
+  EXPECT_FALSE(check_reroute_safety(
+    original, target, map_, 5.0, kRerouteTimeThreshold, kMinimumRerouteLength, test_logger()));
+}
+
+TEST_F(CheckRerouteSafetyTest, ReturnsFalseWhenTargetRouteEmpty)
+{
+  const auto original = make_nominal_route();
+  LaneletRoute target;  // empty segments
+  EXPECT_FALSE(check_reroute_safety(
+    original, target, map_, 5.0, kRerouteTimeThreshold, kMinimumRerouteLength, test_logger()));
+}
+
+TEST_F(CheckRerouteSafetyTest, ReturnsFalseWhenMapIsNull)
+{
+  const auto original = make_nominal_route();
+  const auto target = make_nominal_route();
+  const lanelet::LaneletMapConstPtr null_map = nullptr;
+  EXPECT_FALSE(check_reroute_safety(
+    original, target, null_map, 5.0, kRerouteTimeThreshold, kMinimumRerouteLength, test_logger()));
+}
+
+TEST_F(CheckRerouteSafetyTest, ReturnsTrueWhenVehicleStopped)
+{
+  // current_velocity < 0.01 short-circuits to true before any geometric check, so even a
+  // target route that shares no segment with the original is accepted.
+  const auto original = make_nominal_route();
+  LaneletRoute target;
+  target.start_pose = make_pose(10.0);
+  target.goal_pose = make_pose(290.0);
+  target.segments = {make_segment({99})};  // unknown id, no common segment
+  EXPECT_TRUE(check_reroute_safety(
+    original, target, map_, 0.0, kRerouteTimeThreshold, kMinimumRerouteLength, test_logger()));
+}
+
+TEST_F(CheckRerouteSafetyTest, ReturnsFalseWhenNoCommonSegment)
+{
+  const auto original = make_nominal_route();
+  LaneletRoute target;
+  target.start_pose = make_pose(10.0);
+  target.goal_pose = make_pose(290.0);
+  target.segments = {make_segment({99})};  // no overlap with original {1,2,3}
+  EXPECT_FALSE(check_reroute_safety(
+    original, target, map_, 5.0, kRerouteTimeThreshold, kMinimumRerouteLength, test_logger()));
+}
+
+TEST_F(CheckRerouteSafetyTest, ReturnsFalseWhenEgoNotOnFirstTargetSection)
+{
+  // Common segment exists, but the target route start_pose is placed far outside lanelet 1,
+  // so ego is not inside the first target section.
+  const auto original = make_nominal_route();
+  LaneletRoute target;
+  target.start_pose = make_pose(10.0, 50.0);  // y far outside the [-1, 1] band of any lanelet
+  target.goal_pose = make_pose(290.0);
+  target.segments = {make_segment({1}), make_segment({2}), make_segment({3})};
+  EXPECT_FALSE(check_reroute_safety(
+    original, target, map_, 5.0, kRerouteTimeThreshold, kMinimumRerouteLength, test_logger()));
+}
+
+// ---------------------------------------------------------------------------------------------
+// Final safety-length comparison branches.
+// ---------------------------------------------------------------------------------------------
+
+TEST_F(CheckRerouteSafetyTest, ReturnsTrueWhenAccumulatedLengthExceedsSafetyLength)
+{
+  // Ego at x=10 on lanelet 1; remaining length to the end of the shared route up to the goal at
+  // x=290 is ~280 m, far above the safety length max(5 * 10, 30) = 50 m.
+  const auto original = make_nominal_route();
+  const auto target = make_nominal_route();
+  EXPECT_TRUE(check_reroute_safety(
+    original, target, map_, 5.0, kRerouteTimeThreshold, kMinimumRerouteLength, test_logger()));
+}
+
+TEST_F(CheckRerouteSafetyTest, ReturnsFalseWhenAccumulatedLengthBelowSafetyLength)
+{
+  // Single shared lanelet 1 (length 100). Ego at x=80 and goal at x=85 leave only ~5 m of shared
+  // route ahead, which is below the safety length max(5 * 10, 30) = 50 m.
+  LaneletRoute original;
+  original.start_pose = make_pose(80.0);
+  original.goal_pose = make_pose(85.0);
+  original.segments = {make_segment({1})};
+
+  LaneletRoute target;
+  target.start_pose = make_pose(80.0);
+  target.goal_pose = make_pose(85.0);
+  target.segments = {make_segment({1})};
+
+  EXPECT_FALSE(check_reroute_safety(
+    original, target, map_, 5.0, kRerouteTimeThreshold, kMinimumRerouteLength, test_logger()));
+}
+
+TEST_F(CheckRerouteSafetyTest, SafetyLengthScalesWithVelocity)
+{
+  // Shared route: lanelets 1, 2, 3. Ego at x=10, goal at x=290, accumulated length ~280 m.
+  // At velocity 30, safety length = max(30 * 10, 30) = 300 m > 280 m -> unsafe.
+  // The same geometry at velocity 5 (safety length 50 m) was accepted by the test above, so this
+  // pins the velocity dependence of the decision.
+  const auto original = make_nominal_route();
+  const auto target = make_nominal_route();
+  EXPECT_FALSE(check_reroute_safety(
+    original, target, map_, 30.0, kRerouteTimeThreshold, kMinimumRerouteLength, test_logger()));
+}


### PR DESCRIPTION
## Description

Extracts the reroute-safety algorithm out of the `MissionPlanner` node method into a pure, dependency-injected free function and adds table-driven unit tests covering all of its branches. This is the highest-value, ABI-neutral testability win for the package's most complex previously untested algorithm (audit ranking: testability/high, coverage_gaps/high).

### What changed

- New `src/mission_planner/reroute_safety.{hpp,cpp}` declaring/defining:
  ```cpp
  bool autoware::mission_planner::check_reroute_safety(
    const LaneletRoute & original_route, const LaneletRoute & target_route,
    const lanelet::LaneletMapConstPtr & lanelet_map, const double current_velocity,
    const double reroute_time_threshold, const double minimum_reroute_length,
    const rclcpp::Logger & logger);
  ```
  All node/member state (`odometry_`, `lanelet_map_ptr_`, scalars, logger) is passed in, so the function is unit-testable headlessly.
- `MissionPlanner::check_reroute_safety` (still a private method, unchanged signature) now validates its node-owned `map_ptr_` / `lanelet_map_ptr_` / `odometry_` members and forwards to the free function.
- The two byte-for-byte identical start-segment distance branches (`start_idx_target != 0 && start_idx_original > 1` vs `else`) are collapsed into a single `arc_length_to_lanelet_end` helper parameterized only by which original-route segment supplies the primitives. The branch now only selects the segment index.
- Removed now-unused includes from `mission_planner.cpp` (`lanelet2_utils/geometry.hpp`, `nn_search.hpp`, `lanelet2_core/geometry/*`, `<algorithm>`, `<utility>`); the inlined `hasSamePrimitives` lambda becomes a file-local `has_same_primitives` free helper in the new TU.
- New gtest binary `test_autoware_mission_planner_reroute_safety` (9 cases) linked against `${PROJECT_NAME}_component`.

### Effects on system behavior

Behavior-preserving. The algorithm body (start/end index matching, distance accumulation, goal subtraction, velocity-scaled safety-length comparison, all log messages) is identical. The only structural difference is ordering inside the early-return guard: the node method now checks `!map_ptr_ || !lanelet_map_ptr_ || !odometry_` *before* forwarding, and the free function checks route-emptiness + null-map. Both paths emit the same `"Check reroute safety failed. Route, map or odometry is not set."` error and return `false`, so the observable result and log are unchanged for every input. No public API/ABI change: the only public entry point is the unchanged private node method; the free function is new and additive. Downstream consumers (callers of the `MissionPlanner` node) are unaffected.

### Tests

Table-driven cases over synthetic colinear lanelets/routes assert concrete `true`/`false` outcomes for: empty original route, empty target route, null map, stopped-vehicle short-circuit, no-common-segment, ego-not-on-first-target-section, accumulated-length-above-safety (safe), accumulated-length-below-safety (unsafe), and velocity-scaled safety length. Traced accumulated/safety lengths (5.0 vs 50.0; 280.0 vs 300.0) match the runtime log output.

Refs: autowarefoundation/autoware_core#1096