### PR TITLE
refactor(autoware_behavior_velocity_planner): extract node-agnostic data-ingestion helpers

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/CMakeLists.txt
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 ament_auto_add_library(${PROJECT_NAME}_lib SHARED
+  src/data_processing.cpp
   src/node.cpp
   src/planner_manager.cpp
   src/test_utils.cpp
@@ -32,6 +33,14 @@ if(BUILD_TESTING)
     ${PROJECT_NAME}_lib
   )
   target_include_directories(test_${PROJECT_NAME} PRIVATE src)
+
+  ament_auto_add_gtest(test_${PROJECT_NAME}_data_processing
+    test/test_data_processing.cpp
+  )
+  target_link_libraries(test_${PROJECT_NAME}_data_processing
+    ${PROJECT_NAME}_lib
+  )
+  target_include_directories(test_${PROJECT_NAME}_data_processing PRIVATE src)
 endif()
 
 autoware_ament_auto_package(INSTALL_TO_SHARE

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/data_processing.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/data_processing.cpp
@@ -1,0 +1,72 @@
+// Copyright 2025 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "data_processing.hpp"
+
+#include <autoware/behavior_velocity_planner_common/planner_data.hpp>
+
+#include <algorithm>
+
+namespace autoware::behavior_velocity_planner::data_processing
+{
+TrafficSignalAggregation apply_traffic_signals(
+  const TrafficSignalMap & previous_last_observed,
+  const autoware_perception_msgs::msg::TrafficLightGroupArray & msg)
+{
+  TrafficSignalAggregation result;
+  for (const auto & signal : msg.traffic_light_groups) {
+    TrafficSignalStamped traffic_signal;
+    traffic_signal.stamp = msg.stamp;
+    traffic_signal.signal = signal;
+    result.raw[signal.traffic_light_group_id] = traffic_signal;
+    const bool is_unknown_observation =
+      std::any_of(signal.elements.begin(), signal.elements.end(), [](const auto & element) {
+        return element.color == autoware_perception_msgs::msg::TrafficLightElement::UNKNOWN;
+      });
+    // if the observation is UNKNOWN and past observation is available, only update the timestamp
+    // and keep the body of the info
+    const auto old_data = previous_last_observed.find(signal.traffic_light_group_id);
+    if (is_unknown_observation && old_data != previous_last_observed.end()) {
+      // copy last observation
+      result.last_observed[signal.traffic_light_group_id] = old_data->second;
+      // update timestamp
+      result.last_observed[signal.traffic_light_group_id].stamp = msg.stamp;
+    } else {
+      // if (1)the observation is not UNKNOWN or (2)the very first observation is UNKNOWN
+      result.last_observed[signal.traffic_light_group_id] = traffic_signal;
+    }
+  }
+  return result;
+}
+
+void prune_velocity_buffer(
+  std::deque<geometry_msgs::msg::TwistStamped> & velocity_buffer, const rclcpp::Time & now)
+{
+  while (!velocity_buffer.empty()) {
+    // Check oldest data time. Build the comparison time with the same clock type as `now` so the
+    // helper stays clock/node-agnostic instead of assuming the default RCL_ROS_TIME.
+    const rclcpp::Time s(velocity_buffer.back().header.stamp, now.get_clock_type());
+    const auto time_diff =
+      now >= s ? now - s : rclcpp::Duration(0, 0);  // Note: negative time throws an exception.
+
+    // Finish when oldest data is newer than threshold
+    if (time_diff.seconds() <= PlannerData::velocity_buffer_time_sec) {
+      break;
+    }
+
+    // Remove old data
+    velocity_buffer.pop_back();
+  }
+}
+}  // namespace autoware::behavior_velocity_planner::data_processing

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/data_processing.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/data_processing.hpp
@@ -1,0 +1,73 @@
+// Copyright 2025 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DATA_PROCESSING_HPP_
+#define DATA_PROCESSING_HPP_
+
+#include <autoware/behavior_velocity_planner_common/utilization/util.hpp>
+#include <rclcpp/time.hpp>
+
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+
+#include <lanelet2_core/Forward.h>
+
+#include <deque>
+#include <map>
+
+// Package-internal, node-agnostic data-ingestion helpers shared by the legacy and experimental
+// BehaviorVelocityPlannerNode variants. These are pure transforms over PlannerData fields so they
+// can be unit-tested without spinning a node.
+namespace autoware::behavior_velocity_planner::data_processing
+{
+using TrafficSignalMap = std::map<lanelet::Id, TrafficSignalStamped>;
+
+/**
+ * @brief Result of aggregating an incoming traffic-light-group observation.
+ *
+ * @c raw mirrors the latest message verbatim. @c last_observed applies the
+ * "keep last observation on UNKNOWN" contract: when an incoming group is observed as UNKNOWN and a
+ * previous observation exists, the previous body is kept and only its timestamp is refreshed.
+ */
+struct TrafficSignalAggregation
+{
+  TrafficSignalMap raw;
+  TrafficSignalMap last_observed;
+};
+
+/**
+ * @brief Aggregate an incoming traffic-light-group array into raw and last-observed maps.
+ *
+ * @param previous_last_observed last-observed map from the previous cycle.
+ * @param msg incoming traffic-light-group array.
+ * @return the new raw and last-observed maps.
+ */
+TrafficSignalAggregation apply_traffic_signals(
+  const TrafficSignalMap & previous_last_observed,
+  const autoware_perception_msgs::msg::TrafficLightGroupArray & msg);
+
+/**
+ * @brief Drop velocity-buffer entries older than @c PlannerData::velocity_buffer_time_sec.
+ *
+ * The oldest entries live at the back of the buffer. Entries whose stamp is in the future relative
+ * to @c now (negative time difference) are treated as age 0 and are therefore retained.
+ *
+ * @param[in,out] velocity_buffer buffer to prune in place (newest at front, oldest at back).
+ * @param now reference time used to compute each entry's age.
+ */
+void prune_velocity_buffer(
+  std::deque<geometry_msgs::msg::TwistStamped> & velocity_buffer, const rclcpp::Time & now);
+}  // namespace autoware::behavior_velocity_planner::data_processing
+
+#endif  // DATA_PROCESSING_HPP_

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/experimental/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/experimental/node.cpp
@@ -14,6 +14,8 @@
 
 #include "autoware/behavior_velocity_planner/experimental/node.hpp"
 
+#include "../data_processing.hpp"
+
 #include <autoware/trajectory/utils/find_intervals.hpp>
 #include <autoware/trajectory/utils/pretty_build.hpp>
 #include <autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp>
@@ -29,6 +31,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace autoware::behavior_velocity_planner::experimental
@@ -169,57 +172,16 @@ void BehaviorVelocityPlannerNode::processOdometry(const nav_msgs::msg::Odometry:
 
   // Add velocity to buffer
   planner_data_.velocity_buffer.push_front(*current_velocity);
-  const rclcpp::Time now = this->now();
-  while (!planner_data_.velocity_buffer.empty()) {
-    // Check oldest data time
-    const auto & s = planner_data_.velocity_buffer.back().header.stamp;
-    const auto time_diff =
-      now >= s ? now - s : rclcpp::Duration(0, 0);  // Note: negative time throws an exception.
-
-    // Finish when oldest data is newer than threshold
-    if (time_diff.seconds() <= PlannerData::velocity_buffer_time_sec) {
-      break;
-    }
-
-    // Remove old data
-    planner_data_.velocity_buffer.pop_back();
-  }
+  data_processing::prune_velocity_buffer(planner_data_.velocity_buffer, this->now());
 }
 
 void BehaviorVelocityPlannerNode::processTrafficSignals(
   const autoware_perception_msgs::msg::TrafficLightGroupArray::ConstSharedPtr msg)
 {
-  // clear previous observation
-  planner_data_.traffic_light_id_map_raw_.clear();
-  const auto traffic_light_id_map_last_observed_old =
-    planner_data_.traffic_light_id_map_last_observed_;
-  planner_data_.traffic_light_id_map_last_observed_.clear();
-  for (const auto & signal : msg->traffic_light_groups) {
-    TrafficSignalStamped traffic_signal;
-    traffic_signal.stamp = msg->stamp;
-    traffic_signal.signal = signal;
-    planner_data_.traffic_light_id_map_raw_[signal.traffic_light_group_id] = traffic_signal;
-    const bool is_unknown_observation =
-      std::any_of(signal.elements.begin(), signal.elements.end(), [](const auto & element) {
-        return element.color == autoware_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-      });
-    // if the observation is UNKNOWN and past observation is available, only update the timestamp
-    // and keep the body of the info
-    const auto old_data =
-      traffic_light_id_map_last_observed_old.find(signal.traffic_light_group_id);
-    if (is_unknown_observation && old_data != traffic_light_id_map_last_observed_old.end()) {
-      // copy last observation
-      planner_data_.traffic_light_id_map_last_observed_[signal.traffic_light_group_id] =
-        old_data->second;
-      // update timestamp
-      planner_data_.traffic_light_id_map_last_observed_[signal.traffic_light_group_id].stamp =
-        msg->stamp;
-    } else {
-      // if (1)the observation is not UNKNOWN or (2)the very first observation is UNKNOWN
-      planner_data_.traffic_light_id_map_last_observed_[signal.traffic_light_group_id] =
-        traffic_signal;
-    }
-  }
+  auto aggregation =
+    data_processing::apply_traffic_signals(planner_data_.traffic_light_id_map_last_observed_, *msg);
+  planner_data_.traffic_light_id_map_raw_ = std::move(aggregation.raw);
+  planner_data_.traffic_light_id_map_last_observed_ = std::move(aggregation.last_observed);
 }
 
 bool BehaviorVelocityPlannerNode::processData(rclcpp::Clock clock)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
@@ -14,6 +14,8 @@
 
 #include "autoware/behavior_velocity_planner/node.hpp"
 
+#include "data_processing.hpp"
+
 #include <autoware/behavior_velocity_planner_common/utilization/path_utilization.hpp>
 #include <autoware/motion_utils/trajectory/path_with_lane_id.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
@@ -32,6 +34,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace autoware::behavior_velocity_planner
@@ -172,57 +175,16 @@ void BehaviorVelocityPlannerNode::processOdometry(const nav_msgs::msg::Odometry:
 
   // Add velocity to buffer
   planner_data_.velocity_buffer.push_front(*current_velocity);
-  const rclcpp::Time now = this->now();
-  while (!planner_data_.velocity_buffer.empty()) {
-    // Check oldest data time
-    const auto & s = planner_data_.velocity_buffer.back().header.stamp;
-    const auto time_diff =
-      now >= s ? now - s : rclcpp::Duration(0, 0);  // Note: negative time throws an exception.
-
-    // Finish when oldest data is newer than threshold
-    if (time_diff.seconds() <= PlannerData::velocity_buffer_time_sec) {
-      break;
-    }
-
-    // Remove old data
-    planner_data_.velocity_buffer.pop_back();
-  }
+  data_processing::prune_velocity_buffer(planner_data_.velocity_buffer, this->now());
 }
 
 void BehaviorVelocityPlannerNode::processTrafficSignals(
   const autoware_perception_msgs::msg::TrafficLightGroupArray::ConstSharedPtr msg)
 {
-  // clear previous observation
-  planner_data_.traffic_light_id_map_raw_.clear();
-  const auto traffic_light_id_map_last_observed_old =
-    planner_data_.traffic_light_id_map_last_observed_;
-  planner_data_.traffic_light_id_map_last_observed_.clear();
-  for (const auto & signal : msg->traffic_light_groups) {
-    TrafficSignalStamped traffic_signal;
-    traffic_signal.stamp = msg->stamp;
-    traffic_signal.signal = signal;
-    planner_data_.traffic_light_id_map_raw_[signal.traffic_light_group_id] = traffic_signal;
-    const bool is_unknown_observation =
-      std::any_of(signal.elements.begin(), signal.elements.end(), [](const auto & element) {
-        return element.color == autoware_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-      });
-    // if the observation is UNKNOWN and past observation is available, only update the timestamp
-    // and keep the body of the info
-    const auto old_data =
-      traffic_light_id_map_last_observed_old.find(signal.traffic_light_group_id);
-    if (is_unknown_observation && old_data != traffic_light_id_map_last_observed_old.end()) {
-      // copy last observation
-      planner_data_.traffic_light_id_map_last_observed_[signal.traffic_light_group_id] =
-        old_data->second;
-      // update timestamp
-      planner_data_.traffic_light_id_map_last_observed_[signal.traffic_light_group_id].stamp =
-        msg->stamp;
-    } else {
-      // if (1)the observation is not UNKNOWN or (2)the very first observation is UNKNOWN
-      planner_data_.traffic_light_id_map_last_observed_[signal.traffic_light_group_id] =
-        traffic_signal;
-    }
-  }
+  auto aggregation =
+    data_processing::apply_traffic_signals(planner_data_.traffic_light_id_map_last_observed_, *msg);
+  planner_data_.traffic_light_id_map_raw_ = std::move(aggregation.raw);
+  planner_data_.traffic_light_id_map_last_observed_ = std::move(aggregation.last_observed);
 }
 
 bool BehaviorVelocityPlannerNode::processData(rclcpp::Clock clock)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/test/test_data_processing.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/test/test_data_processing.cpp
@@ -1,0 +1,175 @@
+// Copyright 2025 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "data_processing.hpp"
+
+#include <autoware/behavior_velocity_planner_common/planner_data.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+namespace autoware::behavior_velocity_planner::data_processing
+{
+namespace
+{
+using autoware_perception_msgs::msg::TrafficLightElement;
+using autoware_perception_msgs::msg::TrafficLightGroup;
+using autoware_perception_msgs::msg::TrafficLightGroupArray;
+
+builtin_interfaces::msg::Time make_time(const int32_t sec, const uint32_t nanosec = 0U)
+{
+  builtin_interfaces::msg::Time t;
+  t.sec = sec;
+  t.nanosec = nanosec;
+  return t;
+}
+
+TrafficLightGroupArray make_array(
+  const builtin_interfaces::msg::Time & stamp, const lanelet::Id id, const uint8_t color)
+{
+  TrafficLightGroupArray array;
+  array.stamp = stamp;
+  TrafficLightGroup group;
+  group.traffic_light_group_id = id;
+  TrafficLightElement element;
+  element.color = color;
+  group.elements.push_back(element);
+  array.traffic_light_groups.push_back(group);
+  return array;
+}
+
+geometry_msgs::msg::TwistStamped make_twist(
+  const builtin_interfaces::msg::Time & stamp, const double vx)
+{
+  geometry_msgs::msg::TwistStamped twist;
+  twist.header.stamp = stamp;
+  twist.twist.linear.x = vx;
+  return twist;
+}
+
+// The buffer stamps are message timestamps, which rclcpp interprets as RCL_ROS_TIME when compared
+// against the reference time. Build the reference "now" with the same clock source so the
+// comparison does not throw "can't compare times with different time sources".
+rclcpp::Time make_ros_time(const int32_t sec, const uint32_t nanosec = 0U)
+{
+  return rclcpp::Time(sec, nanosec, RCL_ROS_TIME);
+}
+}  // namespace
+
+// A non-UNKNOWN observation is stored verbatim in both maps.
+TEST(ApplyTrafficSignals, NonUnknownStoredVerbatim)
+{
+  const auto msg = make_array(make_time(5), 100, TrafficLightElement::GREEN);
+
+  const auto result = apply_traffic_signals({}, msg);
+
+  ASSERT_EQ(result.raw.size(), 1U);
+  ASSERT_EQ(result.last_observed.size(), 1U);
+  ASSERT_EQ(result.raw.count(100), 1U);
+  ASSERT_EQ(result.last_observed.count(100), 1U);
+  EXPECT_EQ(result.raw.at(100).stamp.sec, 5);
+  ASSERT_EQ(result.raw.at(100).signal.elements.size(), 1U);
+  EXPECT_EQ(result.raw.at(100).signal.elements.front().color, TrafficLightElement::GREEN);
+  EXPECT_EQ(result.last_observed.at(100).signal.elements.front().color, TrafficLightElement::GREEN);
+  EXPECT_EQ(result.last_observed.at(100).stamp.sec, 5);
+}
+
+// The very first observation being UNKNOWN is stored as-is (no prior to keep).
+TEST(ApplyTrafficSignals, FirstUnknownStoredAsIs)
+{
+  const auto msg = make_array(make_time(5), 100, TrafficLightElement::UNKNOWN);
+
+  const auto result = apply_traffic_signals({}, msg);
+
+  ASSERT_EQ(result.last_observed.count(100), 1U);
+  ASSERT_EQ(result.last_observed.at(100).signal.elements.size(), 1U);
+  EXPECT_EQ(
+    result.last_observed.at(100).signal.elements.front().color, TrafficLightElement::UNKNOWN);
+  EXPECT_EQ(result.last_observed.at(100).stamp.sec, 5);
+}
+
+// An UNKNOWN observation with a prior keeps the prior body but refreshes the timestamp.
+TEST(ApplyTrafficSignals, UnknownKeepsLastObservationRefreshesStamp)
+{
+  // Establish a GREEN observation at t=5.
+  const auto first =
+    apply_traffic_signals({}, make_array(make_time(5), 100, TrafficLightElement::GREEN));
+
+  // Then observe UNKNOWN at t=8.
+  const auto msg = make_array(make_time(8), 100, TrafficLightElement::UNKNOWN);
+  const auto result = apply_traffic_signals(first.last_observed, msg);
+
+  // raw mirrors the latest (UNKNOWN) observation verbatim.
+  ASSERT_EQ(result.raw.count(100), 1U);
+  EXPECT_EQ(result.raw.at(100).signal.elements.front().color, TrafficLightElement::UNKNOWN);
+  EXPECT_EQ(result.raw.at(100).stamp.sec, 8);
+
+  // last_observed keeps the GREEN body but refreshes the stamp to t=8.
+  ASSERT_EQ(result.last_observed.count(100), 1U);
+  EXPECT_EQ(result.last_observed.at(100).signal.elements.front().color, TrafficLightElement::GREEN);
+  EXPECT_EQ(result.last_observed.at(100).stamp.sec, 8);
+}
+
+// Stale entries (older than velocity_buffer_time_sec) are pruned from the back.
+TEST(PruneVelocityBuffer, RemovesStaleEntriesFromBack)
+{
+  std::deque<geometry_msgs::msg::TwistStamped> buffer;
+  // newest at front, oldest at back
+  buffer.push_back(make_twist(make_time(100), 1.0));  // age 0 -> kept
+  buffer.push_back(make_twist(make_time(80), 2.0));   // age 20 -> stale
+  buffer.push_back(make_twist(make_time(50), 3.0));   // age 50 -> stale
+
+  // velocity_buffer_time_sec is 10.0
+  prune_velocity_buffer(buffer, make_ros_time(100));
+
+  ASSERT_EQ(buffer.size(), 1U);
+  EXPECT_DOUBLE_EQ(buffer.front().twist.linear.x, 1.0);
+  EXPECT_EQ(buffer.front().header.stamp.sec, 100);
+}
+
+// An entry exactly at the threshold age is retained (boundary <=).
+TEST(PruneVelocityBuffer, KeepsEntryAtExactThreshold)
+{
+  std::deque<geometry_msgs::msg::TwistStamped> buffer;
+  buffer.push_back(
+    make_twist(make_time(static_cast<int32_t>(110 - PlannerData::velocity_buffer_time_sec)), 7.0));
+
+  prune_velocity_buffer(buffer, make_ros_time(110));
+
+  ASSERT_EQ(buffer.size(), 1U);
+  EXPECT_DOUBLE_EQ(buffer.front().twist.linear.x, 7.0);
+}
+
+// An entry stamped in the future relative to now is treated as age 0 and retained
+// (the negative-time guard prevents an exception).
+TEST(PruneVelocityBuffer, KeepsFutureStampedEntryWithoutThrowing)
+{
+  std::deque<geometry_msgs::msg::TwistStamped> buffer;
+  buffer.push_back(make_twist(make_time(200), 9.0));  // future relative to now=100
+
+  EXPECT_NO_THROW(prune_velocity_buffer(buffer, make_ros_time(100)));
+
+  ASSERT_EQ(buffer.size(), 1U);
+  EXPECT_DOUBLE_EQ(buffer.front().twist.linear.x, 9.0);
+}
+
+// An empty buffer is left untouched.
+TEST(PruneVelocityBuffer, EmptyBufferStaysEmpty)
+{
+  std::deque<geometry_msgs::msg::TwistStamped> buffer;
+  prune_velocity_buffer(buffer, make_ros_time(100));
+  EXPECT_TRUE(buffer.empty());
+}
+}  // namespace autoware::behavior_velocity_planner::data_processing


### PR DESCRIPTION
## Description

The legacy (`PathWithLaneId`-based) and experimental (`autoware::trajectory`-based) `BehaviorVelocityPlannerNode` variants carried byte-identical copies of two data-ingestion algorithms:

- traffic-signal aggregation in `processTrafficSignals` (the UNKNOWN-keep-last-observation contract: keep the previous signal body but refresh its timestamp), and
- velocity-buffer time pruning in `processOdometry`.

Both lived as private node methods and were reachable only by spinning a real node with a TF buffer and live subscribers, so there was no seam to unit-test the pure transforms. The only test was a launch-style smoke test (`test_node_interface.cpp`) with zero scene plugins loaded.

This PR extracts that logic into package-internal, node-agnostic free functions in a new internal header (`src/data_processing.hpp` / `src/data_processing.cpp`):

- `data_processing::apply_traffic_signals(previous_last_observed, msg)` returns the new `raw` and `last_observed` maps (pure transform).
- `data_processing::prune_velocity_buffer(buffer, now)` prunes stale entries in place.

Both node variants now call one implementation, removing ~92 lines of duplicated logic. New gtests (`test/test_data_processing.cpp`) assert the previously-untested branches:

- traffic-signal: non-UNKNOWN stored verbatim; first UNKNOWN stored as-is; UNKNOWN with a prior keeps the prior body and refreshes only the stamp (raw still mirrors the latest UNKNOWN).
- velocity buffer: stale-from-back removal, exact-threshold boundary retention (`<=`), future-stamp negative-time guard (no throw), empty-buffer no-op.

## Effects on system behavior

None. This is an internal-only, behavior-preserving extraction. No public node API, topics, services, parameters, or message types change. The extracted functions are byte-for-byte equivalent to the previous inline logic; the assignment of fresh `raw`/`last_observed` maps in `processTrafficSignals` is equivalent to the previous clear-then-rebuild (entries for group ids absent from the new message are dropped in both versions). The existing launch interface test still passes unchanged.

Refs: autowarefoundation/autoware_core#1096