### PR TITLE
test(autoware_motion_velocity_obstacle_stop_module): unit-test stop-decision helpers and PathLengthBuffer

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/CMakeLists.txt
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/CMakeLists.txt
@@ -14,8 +14,10 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 if(BUILD_TESTING)
   # Add test executable
   ament_add_ros_isolated_gtest(test_${PROJECT_NAME}
+    test/test_decision_helpers.cpp
     test/test_obstacle_stop_module_outside_check.cpp
     test/test_parameters.cpp
+    test/test_path_length_buffer.cpp
     test/test_planning_factor.cpp
     test/test_types.cpp
     test/test_utils.cpp

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/decision_helpers.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/decision_helpers.hpp
@@ -1,0 +1,153 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DECISION_HELPERS_HPP_
+#define DECISION_HELPERS_HPP_
+
+#include "parameters.hpp"
+#include "type_alias.hpp"
+#include "types.hpp"
+
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
+
+#include <geometry_msgs/msg/point.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <optional>
+#include <vector>
+
+namespace autoware::motion_velocity_planner::obstacle_stop_internal
+{
+
+/// @brief Calculate the minimum distance required to stop from the given initial velocity.
+///
+/// Uses v^2 / (2 a) with the deceleration limit selected by the sign of the initial velocity:
+/// forward motion (initial_vel >= 0) uses min_acc, reverse motion uses max_acc.
+inline double calc_minimum_distance_to_stop(
+  const double initial_vel, const double max_acc, const double min_acc)
+{
+  if (initial_vel < 0.0) {
+    return -std::pow(initial_vel, 2) / 2.0 / max_acc;
+  }
+
+  return -std::pow(initial_vel, 2) / 2.0 / min_acc;
+}
+
+/// @brief Convert the object's constant-deceleration assumption into an equivalent
+/// constant-velocity estimation time, clamped to [0, estimation_time_horizon].
+inline double calc_estimation_time(
+  const PredictedObject & predicted_object, const ObstacleFilteringParam & obstacle_filtering_param)
+{
+  // convert constant deceleration to constant velocity
+  // In this feature, we are assuming the pedestrians will decelerate by specified value,
+  // hence the travel distance is derived as v^2/2a.
+  // However, to maintain the compatibility with the other objects,
+  // we have to capsulize this distance information as time with constant velocity assumption.
+  // Therefore here we return a value (v^2/2a) / v = v/2a as the equivalent estimation time.
+  const auto equivalent_estimation_time = [&]() {
+    if (
+      obstacle_filtering_param.outside_obstacle.deceleration <=
+      std::numeric_limits<double>::epsilon()) {
+      return std::numeric_limits<double>::infinity();
+    }
+    const auto & twist = predicted_object.kinematics.initial_twist_with_covariance.twist;
+    return std::hypot(twist.linear.x, twist.linear.y) * 0.5 /
+           obstacle_filtering_param.outside_obstacle.deceleration;
+  };
+  return std::clamp(
+    equivalent_estimation_time(), 0.0,
+    obstacle_filtering_param.outside_obstacle.estimation_time_horizon);
+}
+
+/// @brief Select the longitudinal bumper offset that matches the driving direction.
+inline double calc_x_offset_to_bumper(
+  const bool is_driving_forward, const VehicleInfo & vehicle_info)
+{
+  if (is_driving_forward) {
+    return vehicle_info.max_longitudinal_offset_m;
+  }
+  return vehicle_info.min_longitudinal_offset_m;
+}
+
+/// @brief Estimate the time for ego to reach the given collision point along the trajectory.
+inline double calc_time_to_reach_collision_point(
+  const Odometry & odometry, const geometry_msgs::msg::Point & collision_point,
+  const std::vector<TrajectoryPoint> & traj_points, const double x_offset_to_bumper,
+  const double margin_distance, const double min_velocity_to_reach_collision_point)
+{
+  const double dist_from_ego_to_obstacle =
+    std::abs(
+      autoware::motion_utils::calcSignedArcLength(
+        traj_points, odometry.pose.pose.position, collision_point) -
+      x_offset_to_bumper) -
+    margin_distance;
+  return dist_from_ego_to_obstacle /
+         std::max(min_velocity_to_reach_collision_point, std::abs(odometry.twist.twist.linear.x));
+}
+
+/// @brief Calculate the RSS braking distance for the given object class and longitudinal velocity.
+// TODO(takagi): refactor this function as same as obstacle_filtering_param
+inline double calc_braking_dist_along_trajectory(
+  const StopObstacleClassification::Type label, const double lon_vel, const RSSParam & rss_params)
+{
+  const double braking_acc = [&]() {
+    if (label == StopObstacleClassification::Type::POINTCLOUD) {
+      return rss_params.pointcloud_deceleration;
+    }
+    if (
+      label == StopObstacleClassification::Type::UNKNOWN ||
+      label == StopObstacleClassification::Type::PEDESTRIAN) {
+      return rss_params.no_wheel_objects_deceleration;
+    }
+    if (
+      label == StopObstacleClassification::Type::BICYCLE ||
+      label == StopObstacleClassification::Type::MOTORCYCLE) {
+      return rss_params.two_wheel_objects_deceleration;
+    }
+    return rss_params.vehicle_objects_deceleration;
+  }();
+  const double error_considered_vel = std::max(lon_vel + rss_params.velocity_offset, 0.0);
+  return error_considered_vel * error_considered_vel * 0.5 / -braking_acc;
+}
+
+/// @brief Build the polygon-generation parameters from the trimming, lateral-margin and velocity
+/// inputs.
+inline PolygonParam create_polygon_param(
+  const ObstacleFilteringParam::TrimTrajectoryParam & trim_trajectory_param,
+  const std::optional<double> ego_braking_distance,
+  const ObstacleFilteringParam::LateralMarginParam & lateral_margin_param,
+  const std::optional<double> object_velocity)
+{
+  PolygonParam p;
+  if (!trim_trajectory_param.enable_trimming || !ego_braking_distance.has_value()) {
+    p.trimming_length = std::nullopt;
+  } else {
+    p.trimming_length =
+      trim_trajectory_param.min_trajectory_length +
+      trim_trajectory_param.braking_distance_scale_factor * ego_braking_distance.value();
+  }
+  p.lateral_margin = lateral_margin_param.nominal_margin +
+                     (object_velocity > lateral_margin_param.is_moving_threshold_velocity
+                        ? lateral_margin_param.additional_is_moving_margin
+                        : lateral_margin_param.additional_is_stop_margin);
+  p.off_track_scale = lateral_margin_param.additional_wheel_off_track_scale;
+  return p;
+}
+
+}  // namespace autoware::motion_velocity_planner::obstacle_stop_internal
+
+#endif  // DECISION_HELPERS_HPP_

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
@@ -14,6 +14,8 @@
 
 #include "obstacle_stop_module.hpp"
 
+#include "decision_helpers.hpp"
+
 #include <autoware/motion_utils/distance/distance.hpp>
 #include <autoware/motion_utils/marker/virtual_wall_marker_creator.hpp>
 #include <autoware/motion_utils/trajectory/conversion.hpp>
@@ -41,40 +43,6 @@ using autoware_utils_rclcpp::get_or_declare_parameter;
 
 namespace
 {
-
-double calc_minimum_distance_to_stop(
-  const double initial_vel, const double max_acc, const double min_acc)
-{
-  if (initial_vel < 0.0) {
-    return -std::pow(initial_vel, 2) / 2.0 / max_acc;
-  }
-
-  return -std::pow(initial_vel, 2) / 2.0 / min_acc;
-}
-
-double calc_estimation_time(
-  const PredictedObject & predicted_object, const ObstacleFilteringParam & obstacle_filtering_param)
-{
-  // convert constant deceleration to constant velocity
-  // In this feature, we are assuming the pedestrians will decelerate by specified value,
-  // hence the travel distance is derived as v^2/2a.
-  // However, to maintain the compatibility with the other objects,
-  // we have to capsulize this distance information as time with constant velocity assumption.
-  // Therefore here we return a value (v^2/2a) / v = v/2a as the equivalent estimation time.
-  const auto equivalent_estimation_time = [&]() {
-    if (
-      obstacle_filtering_param.outside_obstacle.deceleration <=
-      std::numeric_limits<double>::epsilon()) {
-      return std::numeric_limits<double>::infinity();
-    }
-    const auto & twist = predicted_object.kinematics.initial_twist_with_covariance.twist;
-    return std::hypot(twist.linear.x, twist.linear.y) * 0.5 /
-           obstacle_filtering_param.outside_obstacle.deceleration;
-  };
-  return std::clamp(
-    equivalent_estimation_time(), 0.0,
-    obstacle_filtering_param.outside_obstacle.estimation_time_horizon);
-}
 
 autoware_utils_geometry::Point2d convert_point(const geometry_msgs::msg::Point & p)
 {
@@ -124,76 +92,14 @@ std::vector<PredictedPath> resample_highest_confidence_predicted_paths(
   return resampled_paths;
 }
 
-double calc_x_offset_to_bumper(const bool is_driving_forward, const VehicleInfo & vehicle_info)
-{
-  if (is_driving_forward) {
-    return vehicle_info.max_longitudinal_offset_m;
-  }
-  return vehicle_info.min_longitudinal_offset_m;
-}
-
-double calc_time_to_reach_collision_point(
-  const Odometry & odometry, const geometry_msgs::msg::Point & collision_point,
-  const std::vector<TrajectoryPoint> & traj_points, const double x_offset_to_bumper,
-  const double margin_distance, const double min_velocity_to_reach_collision_point)
-{
-  const double dist_from_ego_to_obstacle =
-    std::abs(
-      autoware::motion_utils::calcSignedArcLength(
-        traj_points, odometry.pose.pose.position, collision_point) -
-      x_offset_to_bumper) -
-    margin_distance;
-  return dist_from_ego_to_obstacle /
-         std::max(min_velocity_to_reach_collision_point, std::abs(odometry.twist.twist.linear.x));
-}
-
-// TODO(takagi): refactor this function as same as obstacle_filtering_param
-double calc_braking_dist_along_trajectory(
-  const StopObstacleClassification::Type label, const double lon_vel, const RSSParam & rss_params)
-{
-  const double braking_acc = [&]() {
-    if (label == StopObstacleClassification::Type::POINTCLOUD) {
-      return rss_params.pointcloud_deceleration;
-    }
-    if (
-      label == StopObstacleClassification::Type::UNKNOWN ||
-      label == StopObstacleClassification::Type::PEDESTRIAN) {
-      return rss_params.no_wheel_objects_deceleration;
-    }
-    if (
-      label == StopObstacleClassification::Type::BICYCLE ||
-      label == StopObstacleClassification::Type::MOTORCYCLE) {
-      return rss_params.two_wheel_objects_deceleration;
-    }
-    return rss_params.vehicle_objects_deceleration;
-  }();
-  const double error_considered_vel = std::max(lon_vel + rss_params.velocity_offset, 0.0);
-  return error_considered_vel * error_considered_vel * 0.5 / -braking_acc;
-}
-
-PolygonParam create_polygon_param(
-  const ObstacleFilteringParam::TrimTrajectoryParam & trim_trajectory_param,
-  const std::optional<double> ego_braking_distance,
-  const ObstacleFilteringParam::LateralMarginParam & lateral_margin_param,
-  const std::optional<double> object_velocity)
-{
-  PolygonParam p;
-  if (!trim_trajectory_param.enable_trimming || !ego_braking_distance.has_value()) {
-    p.trimming_length = std::nullopt;
-  } else {
-    p.trimming_length =
-      trim_trajectory_param.min_trajectory_length +
-      trim_trajectory_param.braking_distance_scale_factor * ego_braking_distance.value();
-  }
-  p.lateral_margin = lateral_margin_param.nominal_margin +
-                     (object_velocity > lateral_margin_param.is_moving_threshold_velocity
-                        ? lateral_margin_param.additional_is_moving_margin
-                        : lateral_margin_param.additional_is_stop_margin);
-  p.off_track_scale = lateral_margin_param.additional_wheel_off_track_scale;
-  return p;
-}
-
 }  // namespace
+
+using obstacle_stop_internal::calc_braking_dist_along_trajectory;
+using obstacle_stop_internal::calc_estimation_time;
+using obstacle_stop_internal::calc_minimum_distance_to_stop;
+using obstacle_stop_internal::calc_time_to_reach_collision_point;
+using obstacle_stop_internal::calc_x_offset_to_bumper;
+using obstacle_stop_internal::create_polygon_param;
 
 void ObstacleStopModule::init(rclcpp::Node & node, const std::string & module_name)
 {

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/path_length_buffer.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/path_length_buffer.hpp
@@ -15,7 +15,13 @@
 #pragma once
 
 #include "autoware_utils_geometry/geometry.hpp"
+#include "types.hpp"
 
+#include <rclcpp/time.hpp>
+
+#include <geometry_msgs/msg/point.hpp>
+
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <functional>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_decision_helpers.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_decision_helpers.cpp
@@ -1,0 +1,277 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "decision_helpers.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+#include <optional>
+#include <vector>
+
+namespace autoware::motion_velocity_planner::obstacle_stop_internal
+{
+
+TEST(CalcMinimumDistanceToStop, ForwardMotionUsesMinAcc)
+{
+  // initial_vel >= 0 -> uses min_acc branch: -v^2 / (2 * min_acc)
+  // -(2^2) / (2 * -1.0) = 2.0
+  EXPECT_DOUBLE_EQ(calc_minimum_distance_to_stop(2.0, 1.0, -1.0), 2.0);
+  // -(4^2) / (2 * -2.0) = 4.0
+  EXPECT_DOUBLE_EQ(calc_minimum_distance_to_stop(4.0, 1.0, -2.0), 4.0);
+}
+
+TEST(CalcMinimumDistanceToStop, ZeroVelocityUsesMinAcc)
+{
+  // initial_vel == 0 is not < 0, so the min_acc branch is taken and the result is 0.
+  EXPECT_DOUBLE_EQ(calc_minimum_distance_to_stop(0.0, 1.0, -1.0), 0.0);
+}
+
+TEST(CalcMinimumDistanceToStop, ReverseMotionUsesMaxAcc)
+{
+  // initial_vel < 0 -> uses max_acc branch: -v^2 / (2 * max_acc)
+  // -((-2)^2) / (2 * 1.0) = -2.0
+  EXPECT_DOUBLE_EQ(calc_minimum_distance_to_stop(-2.0, 1.0, -1.0), -2.0);
+}
+
+TEST(CalcEstimationTime, ZeroDecelerationReturnsHorizon)
+{
+  // deceleration <= epsilon -> equivalent time is infinity, clamped to the horizon.
+  PredictedObject predicted_object;
+  predicted_object.kinematics.initial_twist_with_covariance.twist.linear.x = 3.0;
+  predicted_object.kinematics.initial_twist_with_covariance.twist.linear.y = 0.0;
+
+  ObstacleFilteringParam param;
+  param.outside_obstacle.deceleration = 0.0;
+  param.outside_obstacle.estimation_time_horizon = 5.0;
+
+  EXPECT_DOUBLE_EQ(calc_estimation_time(predicted_object, param), 5.0);
+}
+
+TEST(CalcEstimationTime, NormalDecelerationConvertsToTime)
+{
+  // equivalent time = hypot(vx, vy) * 0.5 / deceleration, clamped to [0, horizon].
+  PredictedObject predicted_object;
+  predicted_object.kinematics.initial_twist_with_covariance.twist.linear.x = 3.0;
+  predicted_object.kinematics.initial_twist_with_covariance.twist.linear.y = 4.0;  // hypot = 5.0
+
+  ObstacleFilteringParam param;
+  param.outside_obstacle.deceleration = 2.5;
+  param.outside_obstacle.estimation_time_horizon = 10.0;
+
+  // 5.0 * 0.5 / 2.5 = 1.0
+  EXPECT_DOUBLE_EQ(calc_estimation_time(predicted_object, param), 1.0);
+}
+
+TEST(CalcEstimationTime, ClampsToHorizon)
+{
+  PredictedObject predicted_object;
+  predicted_object.kinematics.initial_twist_with_covariance.twist.linear.x = 100.0;
+  predicted_object.kinematics.initial_twist_with_covariance.twist.linear.y = 0.0;
+
+  ObstacleFilteringParam param;
+  param.outside_obstacle.deceleration = 1.0;
+  param.outside_obstacle.estimation_time_horizon = 2.0;
+
+  // 100 * 0.5 / 1.0 = 50.0, clamped to 2.0.
+  EXPECT_DOUBLE_EQ(calc_estimation_time(predicted_object, param), 2.0);
+}
+
+TEST(CalcXOffsetToBumper, SelectsOffsetByDrivingDirection)
+{
+  VehicleInfo vehicle_info;
+  vehicle_info.max_longitudinal_offset_m = 3.0;
+  vehicle_info.min_longitudinal_offset_m = -1.0;
+
+  EXPECT_DOUBLE_EQ(calc_x_offset_to_bumper(true, vehicle_info), 3.0);
+  EXPECT_DOUBLE_EQ(calc_x_offset_to_bumper(false, vehicle_info), -1.0);
+}
+
+TEST(CalcTimeToReachCollisionPoint, UsesArcLengthAndClampedVelocity)
+{
+  // Straight trajectory along +x from origin.
+  std::vector<TrajectoryPoint> traj_points;
+  for (size_t i = 0; i < 21; ++i) {
+    TrajectoryPoint p;
+    p.pose.position.x = static_cast<double>(i);
+    p.pose.position.y = 0.0;
+    traj_points.push_back(p);
+  }
+
+  Odometry odometry;
+  odometry.pose.pose.position.x = 0.0;
+  odometry.pose.pose.position.y = 0.0;
+  odometry.twist.twist.linear.x = 4.0;
+
+  geometry_msgs::msg::Point collision_point;
+  collision_point.x = 20.0;
+  collision_point.y = 0.0;
+
+  // dist = |arc_length(20) - x_offset(2)| - margin(0) = 18.0; vel = max(0.1, |4.0|) = 4.0
+  // 18.0 / 4.0 = 4.5
+  EXPECT_DOUBLE_EQ(
+    calc_time_to_reach_collision_point(odometry, collision_point, traj_points, 2.0, 0.0, 0.1), 4.5);
+}
+
+TEST(CalcTimeToReachCollisionPoint, ClampsVelocityToMinimum)
+{
+  std::vector<TrajectoryPoint> traj_points;
+  for (size_t i = 0; i < 21; ++i) {
+    TrajectoryPoint p;
+    p.pose.position.x = static_cast<double>(i);
+    p.pose.position.y = 0.0;
+    traj_points.push_back(p);
+  }
+
+  Odometry odometry;
+  odometry.pose.pose.position.x = 0.0;
+  odometry.pose.pose.position.y = 0.0;
+  odometry.twist.twist.linear.x = 0.0;  // below the minimum
+
+  geometry_msgs::msg::Point collision_point;
+  collision_point.x = 20.0;
+  collision_point.y = 0.0;
+
+  // dist = |20 - 2| - 0 = 18.0; vel = max(2.0, 0.0) = 2.0 -> 9.0
+  EXPECT_DOUBLE_EQ(
+    calc_time_to_reach_collision_point(odometry, collision_point, traj_points, 2.0, 0.0, 2.0), 9.0);
+}
+
+TEST(CalcBrakingDistAlongTrajectory, SelectsDecelerationByClass)
+{
+  RSSParam rss;
+  rss.pointcloud_deceleration = -1.0;
+  rss.no_wheel_objects_deceleration = -2.0;
+  rss.two_wheel_objects_deceleration = -4.0;
+  rss.vehicle_objects_deceleration = -5.0;
+  rss.velocity_offset = 0.0;
+
+  // braking_dist = error_vel^2 * 0.5 / -braking_acc, error_vel = max(lon_vel + offset, 0).
+  // POINTCLOUD: -braking_acc = 1.0 -> 10^2 * 0.5 / 1.0 = 50.0
+  EXPECT_DOUBLE_EQ(
+    calc_braking_dist_along_trajectory(StopObstacleClassification::Type::POINTCLOUD, 10.0, rss),
+    50.0);
+  // PEDESTRIAN -> no_wheel: -braking_acc = 2.0 -> 10^2 * 0.5 / 2.0 = 25.0
+  EXPECT_DOUBLE_EQ(
+    calc_braking_dist_along_trajectory(StopObstacleClassification::Type::PEDESTRIAN, 10.0, rss),
+    25.0);
+  // UNKNOWN -> no_wheel: same as pedestrian
+  EXPECT_DOUBLE_EQ(
+    calc_braking_dist_along_trajectory(StopObstacleClassification::Type::UNKNOWN, 10.0, rss), 25.0);
+  // BICYCLE -> two_wheel: -braking_acc = 4.0 -> 10^2 * 0.5 / 4.0 = 12.5
+  EXPECT_DOUBLE_EQ(
+    calc_braking_dist_along_trajectory(StopObstacleClassification::Type::BICYCLE, 10.0, rss), 12.5);
+  // MOTORCYCLE -> two_wheel: same
+  EXPECT_DOUBLE_EQ(
+    calc_braking_dist_along_trajectory(StopObstacleClassification::Type::MOTORCYCLE, 10.0, rss),
+    12.5);
+  // CAR -> vehicle: -braking_acc = 5.0 -> 10^2 * 0.5 / 5.0 = 10.0
+  EXPECT_DOUBLE_EQ(
+    calc_braking_dist_along_trajectory(StopObstacleClassification::Type::CAR, 10.0, rss), 10.0);
+}
+
+TEST(CalcBrakingDistAlongTrajectory, AppliesVelocityOffsetAndClampsToZero)
+{
+  RSSParam rss;
+  rss.vehicle_objects_deceleration = -5.0;
+  rss.velocity_offset = 1.0;
+
+  // error_vel = max(9.0 + 1.0, 0) = 10.0 -> 10^2 * 0.5 / 5.0 = 10.0
+  EXPECT_DOUBLE_EQ(
+    calc_braking_dist_along_trajectory(StopObstacleClassification::Type::CAR, 9.0, rss), 10.0);
+
+  // negative effective velocity is clamped to 0 -> braking_dist = 0
+  rss.velocity_offset = 0.0;
+  EXPECT_DOUBLE_EQ(
+    calc_braking_dist_along_trajectory(StopObstacleClassification::Type::CAR, -3.0, rss), 0.0);
+}
+
+TEST(CreatePolygonParam, TrimmingDisabledLeavesNullopt)
+{
+  ObstacleFilteringParam::TrimTrajectoryParam trim;
+  trim.enable_trimming = false;
+  trim.min_trajectory_length = 10.0;
+  trim.braking_distance_scale_factor = 2.0;
+
+  ObstacleFilteringParam::LateralMarginParam lateral;
+  lateral.nominal_margin = 1.0;
+  lateral.is_moving_threshold_velocity = 1.0;
+  lateral.additional_is_moving_margin = 0.5;
+  lateral.additional_is_stop_margin = 0.2;
+  lateral.additional_wheel_off_track_scale = 0.3;
+
+  const auto p = create_polygon_param(trim, 4.0, lateral, std::optional<double>(0.0));
+  EXPECT_FALSE(p.trimming_length.has_value());
+  // object_velocity (0.0) <= threshold (1.0) -> stop margin branch.
+  EXPECT_DOUBLE_EQ(p.lateral_margin, 1.0 + 0.2);
+  EXPECT_DOUBLE_EQ(p.off_track_scale, 0.3);
+}
+
+TEST(CreatePolygonParam, NoBrakingDistanceLeavesNullopt)
+{
+  ObstacleFilteringParam::TrimTrajectoryParam trim;
+  trim.enable_trimming = true;
+  trim.min_trajectory_length = 10.0;
+  trim.braking_distance_scale_factor = 2.0;
+
+  ObstacleFilteringParam::LateralMarginParam lateral;
+  lateral.nominal_margin = 1.0;
+  lateral.is_moving_threshold_velocity = 1.0;
+  lateral.additional_is_moving_margin = 0.5;
+  lateral.additional_is_stop_margin = 0.2;
+
+  const auto p = create_polygon_param(trim, std::nullopt, lateral, std::optional<double>(2.0));
+  EXPECT_FALSE(p.trimming_length.has_value());
+  // object_velocity (2.0) > threshold (1.0) -> moving margin branch.
+  EXPECT_DOUBLE_EQ(p.lateral_margin, 1.0 + 0.5);
+}
+
+TEST(CreatePolygonParam, TrimmingEnabledComputesLength)
+{
+  ObstacleFilteringParam::TrimTrajectoryParam trim;
+  trim.enable_trimming = true;
+  trim.min_trajectory_length = 10.0;
+  trim.braking_distance_scale_factor = 2.0;
+
+  ObstacleFilteringParam::LateralMarginParam lateral;
+  lateral.nominal_margin = 1.0;
+  lateral.is_moving_threshold_velocity = 1.0;
+  lateral.additional_is_moving_margin = 0.5;
+  lateral.additional_is_stop_margin = 0.2;
+
+  const auto p = create_polygon_param(trim, 4.0, lateral, std::optional<double>(2.0));
+  ASSERT_TRUE(p.trimming_length.has_value());
+  // 10.0 + 2.0 * 4.0 = 18.0
+  EXPECT_DOUBLE_EQ(p.trimming_length.value(), 18.0);
+}
+
+TEST(CreatePolygonParam, NulloptObjectVelocityUsesStopMargin)
+{
+  ObstacleFilteringParam::TrimTrajectoryParam trim;
+  trim.enable_trimming = false;
+
+  ObstacleFilteringParam::LateralMarginParam lateral;
+  lateral.nominal_margin = 1.0;
+  lateral.is_moving_threshold_velocity = 1.0;
+  lateral.additional_is_moving_margin = 0.5;
+  lateral.additional_is_stop_margin = 0.2;
+
+  // A nullopt object_velocity compares as not greater than the threshold, so the stop margin is
+  // used. This pins the existing std::optional comparison behavior.
+  const auto p = create_polygon_param(trim, std::nullopt, lateral, std::nullopt);
+  EXPECT_DOUBLE_EQ(p.lateral_margin, 1.0 + 0.2);
+}
+
+}  // namespace autoware::motion_velocity_planner::obstacle_stop_internal

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_path_length_buffer.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_path_length_buffer.cpp
@@ -1,0 +1,165 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "path_length_buffer.hpp"
+#include "types.hpp"
+
+#include <rclcpp/time.hpp>
+
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <optional>
+
+namespace autoware::motion_velocity_planner::obstacle_stop
+{
+namespace
+{
+
+// Identity-style stop-distance callback: the buffer recomputes each item's distance from its stored
+// stop_point, so encoding the distance in stop_point.x makes the synthetic timeline deterministic.
+std::function<double(const geometry_msgs::msg::Point &)> distance_from_x()
+{
+  return [](const geometry_msgs::msg::Point & p) { return p.x; };
+}
+
+geometry_msgs::msg::Point point_at(const double x)
+{
+  geometry_msgs::msg::Point p;
+  p.x = x;
+  return p;
+}
+
+StopObstacle make_stop_obstacle(const double desired_margin = 0.0)
+{
+  const rclcpp::Time stamp(0, 0, RCL_ROS_TIME);
+  const StopObstacleClassification classification(StopObstacleClassification::Type::POINTCLOUD);
+  PolygonParam polygon_param;
+  return StopObstacle(
+    stamp, classification, /*lon_velocity=*/0.0, /*collision_point=*/point_at(0.0),
+    /*dist_to_collide_on_decimated_traj=*/0.0, polygon_param, /*braking_dist=*/desired_margin);
+}
+
+rclcpp::Time t(const double seconds)
+{
+  return rclcpp::Time(static_cast<int64_t>(seconds * 1e9), RCL_ROS_TIME);
+}
+
+}  // namespace
+
+TEST(PathLengthBuffer, EmptyBufferHasNoActiveItem)
+{
+  PathLengthBuffer buffer(/*update_distance_threshold=*/1.0, /*min_off=*/0.5, /*min_on=*/1.0);
+  EXPECT_FALSE(buffer.get_nearest_active_item().has_value());
+}
+
+TEST(PathLengthBuffer, NulloptStopPointIsNoOp)
+{
+  PathLengthBuffer buffer(1.0, 0.5, 1.0);
+  buffer.update_buffer(std::nullopt, distance_from_x(), t(0.0), make_stop_obstacle(), 0.0);
+  EXPECT_FALSE(buffer.get_nearest_active_item().has_value());
+}
+
+TEST(PathLengthBuffer, ActivatesOnlyAfterMinOnDuration)
+{
+  PathLengthBuffer buffer(/*update_distance_threshold=*/1.0, /*min_off=*/10.0, /*min_on=*/1.0);
+
+  // First observation creates an inactive item; it is not yet returned.
+  buffer.update_buffer(point_at(10.0), distance_from_x(), t(0.0), make_stop_obstacle(), 0.0);
+  EXPECT_FALSE(buffer.get_nearest_active_item().has_value());
+
+  // Still within min_on_duration -> remains inactive.
+  buffer.update_buffer(point_at(10.0), distance_from_x(), t(0.5), make_stop_obstacle(), 0.0);
+  EXPECT_FALSE(buffer.get_nearest_active_item().has_value());
+
+  // Past min_on_duration -> becomes active.
+  buffer.update_buffer(point_at(10.0), distance_from_x(), t(2.0), make_stop_obstacle(), 0.0);
+  const auto item = buffer.get_nearest_active_item();
+  ASSERT_TRUE(item.has_value());
+  EXPECT_DOUBLE_EQ(item->stop_distance, 10.0);
+}
+
+TEST(PathLengthBuffer, EvictsActiveItemAfterMinOffDuration)
+{
+  PathLengthBuffer buffer(/*update_distance_threshold=*/1.0, /*min_off=*/0.5, /*min_on=*/1.0);
+
+  buffer.update_buffer(point_at(10.0), distance_from_x(), t(0.0), make_stop_obstacle(), 0.0);
+  // Activate the item (and reset its start_time to t=2.0).
+  buffer.update_buffer(point_at(10.0), distance_from_x(), t(2.0), make_stop_obstacle(), 0.0);
+  ASSERT_TRUE(buffer.get_nearest_active_item().has_value());
+
+  // A far-away stop point is not matched, so the active item is not refreshed; with elapsed time
+  // beyond min_off_duration it is evicted, and the new (inactive) item is not yet returned.
+  buffer.update_buffer(point_at(100.0), distance_from_x(), t(3.0), make_stop_obstacle(), 0.0);
+  EXPECT_FALSE(buffer.get_nearest_active_item().has_value());
+}
+
+TEST(PathLengthBuffer, EvictsInactiveItemBeyondUpdateDistanceThreshold)
+{
+  PathLengthBuffer buffer(/*update_distance_threshold=*/1.0, /*min_off=*/10.0, /*min_on=*/1.0);
+
+  buffer.update_buffer(point_at(10.0), distance_from_x(), t(0.0), make_stop_obstacle(), 0.0);
+  // |10 - 100| > update_distance_threshold while still inactive -> the first item is evicted and a
+  // new inactive item (distance 100) replaces it.
+  buffer.update_buffer(point_at(100.0), distance_from_x(), t(0.1), make_stop_obstacle(), 0.0);
+
+  // After enough time the surviving item activates; its distance proves the old item was evicted
+  // (otherwise the nearest active distance would be 10, not 100).
+  buffer.update_buffer(point_at(100.0), distance_from_x(), t(2.0), make_stop_obstacle(), 0.0);
+  const auto item = buffer.get_nearest_active_item();
+  ASSERT_TRUE(item.has_value());
+  EXPECT_DOUBLE_EQ(item->stop_distance, 100.0);
+}
+
+TEST(PathLengthBuffer, PrefersActiveItemOverNearerInactiveItem)
+{
+  PathLengthBuffer buffer(/*update_distance_threshold=*/1.0, /*min_off=*/10.0, /*min_on=*/1.0);
+
+  buffer.update_buffer(point_at(10.0), distance_from_x(), t(0.0), make_stop_obstacle(), 0.0);
+  // Re-observe the same item; it stays inactive because should_activate() requires the elapsed time
+  // to be strictly greater than min_on (1.0), and here it is exactly 1.0.
+  buffer.update_buffer(point_at(10.0), distance_from_x(), t(1.0), make_stop_obstacle(), 0.0);
+  // This update activates the distance-10 item (elapsed 2.0 > min_on) and appends a second, nearer
+  // (distance 5) but inactive item (|10 - 5| > threshold, so it is appended rather than merged).
+  buffer.update_buffer(point_at(5.0), distance_from_x(), t(2.0), make_stop_obstacle(), 0.0);
+
+  // The comparator must prefer the active item even though the inactive one is nearer.
+  const auto item = buffer.get_nearest_active_item();
+  ASSERT_TRUE(item.has_value());
+  EXPECT_DOUBLE_EQ(item->stop_distance, 10.0);
+}
+
+TEST(PathLengthBuffer, UpdatesNearestItemWhenRelativeDistancePositive)
+{
+  PathLengthBuffer buffer(/*update_distance_threshold=*/1.0, /*min_off=*/10.0, /*min_on=*/1.0);
+
+  buffer.update_buffer(point_at(10.0), distance_from_x(), t(0.0), make_stop_obstacle(0.1), 0.0);
+  // Re-observe the item at distance 10 with margin 0.1; it stays inactive because should_activate()
+  // requires the elapsed time to be strictly greater than min_on (1.0), and here it is exactly 1.0.
+  buffer.update_buffer(point_at(10.0), distance_from_x(), t(1.0), make_stop_obstacle(0.1), 0.0);
+
+  // New observation within threshold and nearer (rel_dist = 10 - 9.5 = 0.5 > 0). Elapsed 2.0 >
+  // min_on, so the item activates here and its stop_distance and determined obstacle/margin are
+  // refreshed.
+  buffer.update_buffer(point_at(9.5), distance_from_x(), t(2.0), make_stop_obstacle(0.9), 2.5);
+
+  const auto item = buffer.get_nearest_active_item();
+  ASSERT_TRUE(item.has_value());
+  EXPECT_DOUBLE_EQ(item->stop_distance, 9.5);
+  EXPECT_DOUBLE_EQ(item->determined_desired_stop_margin, 2.5);
+  ASSERT_TRUE(item->determined_stop_obstacle.braking_dist.has_value());
+  EXPECT_DOUBLE_EQ(item->determined_stop_obstacle.braking_dist.value(), 0.9);
+}
+
+}  // namespace autoware::motion_velocity_planner::obstacle_stop


### PR DESCRIPTION
## Description

Part of the autoware_core quality campaign (testability + coverage), one ROS package per PR.

Extracts the pure stop-decision helpers (`calc_minimum_distance_to_stop`, `calc_estimation_time`, `calc_x_offset_to_bumper`, `calc_time_to_reach_collision_point`, `calc_braking_dist_along_trajectory`, `create_polygon_param`) out of the anonymous namespace in `obstacle_stop_module.cpp` into a named internal-namespace header (`decision_helpers.hpp`, namespace `obstacle_stop_internal`) so the gtest binary can link against them, and adds value-asserting unit tests for every branch.

Also adds unit tests for the header-only `PathLengthBuffer` state machine (activation timing, active/inactive eviction, nearest-active comparator, positive-relative-distance update path), and makes `path_length_buffer.hpp` self-contained by including the headers it relies on (`types.hpp`, `rclcpp/time`, `geometry_msgs/point`, `<algorithm>`) instead of leaning on transitive includes.

## Related links

**Parent Issue:** autowarefoundation/autoware_core#1096

## How was this PR tested?

`colcon build` + `colcon test --packages-select autoware_motion_velocity_obstacle_stop_module` in the `autoware:core-devel-jazzy` container — new gtests pass.

## Notes for reviewers

The plugin's public API/ABI is unchanged: the extracted helpers are not part of `PluginModuleInterface`, and existing unqualified call sites keep working via using-declarations.

## Interface changes

None.

## Effects on system behavior

None. Pure refactor (move helpers to a linkable internal header) plus additive tests.
