### PR TITLE
perf(autoware_path_generator): make goal-connection closest-point fallback lazy and hoist path length

### DIFF
--- a/planning/autoware_path_generator/src/utils.cpp
+++ b/planning/autoware_path_generator/src/utils.cpp
@@ -727,13 +727,15 @@ experimental::trajectory::Trajectory<PathPointWithLaneId> connect_path_to_goal(
     pre_goal_lanelet = *prev_lanelet;
   }
 
+  // Evaluate the unconstrained closest-point search lazily: only fall back to it when the
+  // constrained search fails, instead of always running both via value_or.
+  const auto s_pre_goal_constrained = autoware::experimental::trajectory::closest_with_constraint(
+    path, pre_goal_pose, [&](const PathPointWithLaneId & point) {
+      return exists(point.lane_ids, pre_goal_lanelet.id());
+    });
   const auto s_pre_goal =
-    autoware::experimental::trajectory::closest_with_constraint(
-      path, pre_goal_pose,
-      [&](const PathPointWithLaneId & point) {
-        return exists(point.lane_ids, pre_goal_lanelet.id());
-      })
-      .value_or(autoware::experimental::trajectory::closest(path, pre_goal_pose));
+    s_pre_goal_constrained ? *s_pre_goal_constrained
+                           : autoware::experimental::trajectory::closest(path, pre_goal_pose);
 
   PathPointWithLaneId pre_goal;
   pre_goal.lane_ids = {pre_goal_lanelet.id()};
@@ -788,7 +790,8 @@ bool is_path_inside_lanelets(
   const experimental::trajectory::Trajectory<PathPointWithLaneId> & path,
   const lanelet::ConstLanelets & lanelets)
 {
-  for (double s = 0.0; s < path.length(); s += 0.1) {
+  const auto path_length = path.length();
+  for (double s = 0.0; s < path_length; s += 0.1) {
     const auto point = path.compute(s);
     if (!is_pose_inside_lanelets(point.point.pose, lanelets)) {
       return false;

--- a/planning/autoware_path_generator/test/test_path_cut.cpp
+++ b/planning/autoware_path_generator/test/test_path_cut.cpp
@@ -156,10 +156,38 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_F(UtilsTest, getFirstSelfIntersectionArcLength)
 {
+  constexpr auto epsilon = 1e-3;
+
   {  // line string is empty
     const auto result = utils::get_first_self_intersection_arc_length(lanelet::BasicLineString2d{});
 
     ASSERT_FALSE(result);
+  }
+
+  {  // line string has fewer than 3 points
+    const auto result =
+      utils::get_first_self_intersection_arc_length(lanelet::BasicLineString2d{{0.0, 0.0}});
+
+    ASSERT_FALSE(result);
+  }
+
+  {  // line string does not self-intersect
+    const auto result = utils::get_first_self_intersection_arc_length(
+      lanelet::BasicLineString2d{{0.0, 0.0}, {1.0, 0.0}, {2.0, 0.0}, {3.0, 0.0}});
+
+    ASSERT_FALSE(result);
+  }
+
+  {  // line string self-intersects
+    // Outward path (0,0)->(4,0)->(4,2)->(2,2), then return segment (2,2)->(2,-1) crosses the first
+    // segment (0,0)->(4,0) at (2,0). Arc length of the crossing is measured along the first three
+    // segments (4 + 2 + 2 = 8) plus the offset along the latter segment from (2,2) to (2,0) = 2,
+    // giving 10.
+    const auto result = utils::get_first_self_intersection_arc_length(
+      lanelet::BasicLineString2d{{0.0, 0.0}, {4.0, 0.0}, {4.0, 2.0}, {2.0, 2.0}, {2.0, -1.0}});
+
+    ASSERT_TRUE(result.has_value());
+    ASSERT_NEAR(*result, 10.0, epsilon);  // NOLINT(bugprone-unchecked-optional-access)
   }
 }
 


### PR DESCRIPTION
## Description

Part of the autoware_core quality campaign (performance + coverage), one ROS package per PR.

Two behavior-preserving performance fixes in the per-cycle goal-connection path:

- In `connect_path_to_goal`, the unconstrained `trajectory::closest()` search was always evaluated as the `value_or` argument of the constrained search, so it ran even on the common happy path where the constrained search already succeeded. Replaced `value_or` with an explicit branch so the unconstrained scan runs **only** when the constrained search fails.
- In `is_path_inside_lanelets`, hoisted `path.length()` out of the sampling loop so the trajectory length is computed once instead of on every 0.1 m step. This function is invoked repeatedly inside the per-cycle goal-connection retry loop, so the redundant work compounds.

Adds a direct unit test for `get_first_self_intersection_arc_length` that feeds a hand-built self-crossing line string with a known expected arc length, covering the nested-loop arc-length accumulation and the cross-iteration return path that was previously exercised only indirectly.

## Related links

**Parent Issue:** autowarefoundation/autoware_core#1096

## How was this PR tested?

`colcon build` + `colcon test --packages-select autoware_path_generator` in the `autoware:core-devel-jazzy` container — existing suite + the new arc-length test pass.

## Notes for reviewers

Both changes preserve outputs; only the evaluation strategy / loop invariants change.

## Interface changes

None.

## Effects on system behavior

None. Same path output; the unconstrained closest-point fallback is now computed lazily and `path.length()` is hoisted, reducing redundant per-cycle work.
