### PR TITLE
perf(autoware_euclidean_cluster_object_detector): eliminate hot-loop allocations in clustering

### DIFF
--- a/perception/autoware_euclidean_cluster_object_detector/lib/euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster_object_detector/lib/euclidean_cluster.cpp
@@ -64,6 +64,7 @@ bool EuclideanCluster::cluster(
   pcl::PointCloud<pcl::PointXYZ>::ConstPtr pointcloud_ptr(new pcl::PointCloud<pcl::PointXYZ>);
   if (!use_height_) {
     pcl::PointCloud<pcl::PointXYZ>::Ptr pointcloud_2d_ptr(new pcl::PointCloud<pcl::PointXYZ>);
+    pointcloud_2d_ptr->points.reserve(pointcloud->points.size());
     for (const auto & point : pointcloud->points) {
       pcl::PointXYZ point2d;
       point2d.x = point.x;
@@ -92,15 +93,18 @@ bool EuclideanCluster::cluster(
 
   // build output
   {
+    clusters.reserve(clusters.size() + cluster_indices.size());
     for (const auto & cluster : cluster_indices) {
-      pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_cluster(new pcl::PointCloud<pcl::PointXYZ>);
+      // Build the output cluster in place to avoid a heap allocation plus a full deep copy
+      // per cluster on every frame.
+      auto & cloud_cluster = clusters.emplace_back();
+      cloud_cluster.points.reserve(cluster.indices.size());
       for (const auto & point_idx : cluster.indices) {
-        cloud_cluster->points.push_back(pointcloud->points[point_idx]);
+        cloud_cluster.points.push_back(pointcloud->points[point_idx]);
       }
-      clusters.push_back(*cloud_cluster);
-      clusters.back().width = cloud_cluster->points.size();
-      clusters.back().height = 1;
-      clusters.back().is_dense = false;
+      cloud_cluster.width = cloud_cluster.points.size();
+      cloud_cluster.height = 1;
+      cloud_cluster.is_dense = false;
     }
   }
   return true;

--- a/perception/autoware_euclidean_cluster_object_detector/lib/voxel_grid_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster_object_detector/lib/voxel_grid_based_euclidean_cluster.cpp
@@ -110,12 +110,13 @@ bool VoxelGridBasedEuclideanCluster::cluster(
 
   // voxel is pressed 2d
   pcl::PointCloud<pcl::PointXYZ>::Ptr pointcloud_2d_ptr(new pcl::PointCloud<pcl::PointXYZ>);
+  pointcloud_2d_ptr->points.reserve(voxel_map_ptr->points.size());
   for (const auto & point : voxel_map_ptr->points) {
     pcl::PointXYZ point2d;
     point2d.x = point.x;
     point2d.y = point.y;
     point2d.z = 0.0;
-    pointcloud_2d_ptr->push_back(point2d);
+    pointcloud_2d_ptr->emplace_back(point2d);
   }
 
   // create tree
@@ -134,6 +135,7 @@ bool VoxelGridBasedEuclideanCluster::cluster(
 
   // create map to search cluster index from voxel grid index
   std::unordered_map</* voxel grid index */ int, /* cluster index */ int> map;
+  map.reserve(voxel_map_ptr->points.size());
   std::vector<sensor_msgs::msg::PointCloud2> temporary_clusters;  // no check about cluster size
   std::vector<size_t> clusters_data_size;
   temporary_clusters.resize(cluster_indices.size());
@@ -163,20 +165,22 @@ bool VoxelGridBasedEuclideanCluster::cluster(
     const int index =
       voxel_grid_.getCentroidIndexAt(voxel_grid_.getGridCoordinates(point.x, point.y, point.z));
 #pragma GCC diagnostic pop
-    if (map.find(index) != map.end()) {
-      auto & cluster_data_size = clusters_data_size.at(map[index]);
+    const auto map_itr = map.find(index);
+    if (map_itr != map.end()) {
+      const int cluster_idx = map_itr->second;
+      auto & cluster_data_size = clusters_data_size.at(cluster_idx);
       if (
         cluster_data_size >
         static_cast<std::size_t>(max_cluster_size_) * static_cast<std::size_t>(point_step)) {
         continue;
       }
+      auto & temporary_cluster_data = temporary_clusters.at(cluster_idx).data;
       std::memcpy(
-        &temporary_clusters.at(map[index]).data[cluster_data_size],
-        &pointcloud_msg->data[i * point_step], point_step);
+        &temporary_cluster_data[cluster_data_size], &pointcloud_msg->data[i * point_step],
+        point_step);
       cluster_data_size += point_step;
-      if (cluster_data_size == temporary_clusters.at(map[index]).data.size()) {
-        temporary_clusters.at(map[index])
-          .data.resize(temporary_clusters.at(map[index]).data.size() * 2);
+      if (cluster_data_size == temporary_cluster_data.size()) {
+        temporary_cluster_data.resize(temporary_cluster_data.size() * 2);
       }
     }
   }
@@ -219,7 +223,10 @@ bool VoxelGridBasedEuclideanCluster::cluster(
 
       objects.objects.push_back(object);
 
-      pcl::PointCloud<pcl::PointXYZ> cluster_point_cloud;
+      // Build the output cluster in place to avoid copying the whole point cloud into the
+      // output vector; reserve by the known point count to avoid repeated reallocation.
+      auto & cluster_point_cloud = clusters.emplace_back();
+      cluster_point_cloud.points.reserve(static_cast<size_t>(cluster_size));
 
       for (sensor_msgs::PointCloud2ConstIterator<float> iter_x(cluster, "x"), iter_y(cluster, "y"),
            iter_z(cluster, "z");
@@ -230,7 +237,6 @@ bool VoxelGridBasedEuclideanCluster::cluster(
         point.z = *iter_z;
         cluster_point_cloud.push_back(point);
       }
-      clusters.push_back(cluster_point_cloud);
     }
     objects.header = pointcloud_msg->header;
     // Publish the diagnostics summary.

--- a/perception/autoware_euclidean_cluster_object_detector/test/test_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster_object_detector/test/test_euclidean_cluster.cpp
@@ -130,6 +130,63 @@ TEST_F(EuclideanClusterTest, TestClusteringWithMinSizeFilter)
   EXPECT_EQ(clusters.size(), 0);  // No clusters should pass the size filter
 }
 
+// Characterization test: pin exact cluster membership and per-point coordinates so the
+// in-place output-building refactor (no 'new', no deep copy, reserve) is proven equivalent.
+TEST_F(EuclideanClusterTest, TestClusterMembershipAndPointValues)
+{
+  autoware::euclidean_cluster::EuclideanCluster cluster(true, 1, 100, 0.5);
+
+  std::vector<pcl::PointCloud<pcl::PointXYZ>> clusters;
+  ASSERT_TRUE(cluster.cluster(test_cloud_, clusters));
+  ASSERT_EQ(clusters.size(), 2u);
+
+  // Each output cluster must carry exactly 5 points and have the PointCloud2-style metadata
+  // (width == point count, height == 1, is_dense == false) set on it.
+  for (const auto & c : clusters) {
+    EXPECT_EQ(c.points.size(), 5u);
+    EXPECT_EQ(c.width, 5u);
+    EXPECT_EQ(c.height, 1u);
+    EXPECT_FALSE(c.is_dense);
+  }
+
+  // The two ground-truth clusters from SetUp(): near-origin and around (10,10,10).
+  // Collect every output point and verify each belongs to exactly one expected group,
+  // and that all 10 input points are reproduced verbatim (coordinates preserved).
+  size_t near_origin_count = 0;
+  size_t far_count = 0;
+  for (const auto & c : clusters) {
+    for (const auto & point : c.points) {
+      if (point.x < 1.0f) {
+        ++near_origin_count;
+        // near-origin points are i*0.1 for i in [0,5)
+        EXPECT_FLOAT_EQ(point.x, point.y);
+        EXPECT_FLOAT_EQ(point.y, point.z);
+      } else {
+        ++far_count;
+        // far points are 10 + i*0.1 for i in [5,10)
+        EXPECT_GE(point.x, 10.0f);
+        EXPECT_FLOAT_EQ(point.x, point.y);
+        EXPECT_FLOAT_EQ(point.y, point.z);
+      }
+    }
+  }
+  EXPECT_EQ(near_origin_count, 5u);
+  EXPECT_EQ(far_count, 5u);
+}
+
+// Characterization test for the previously-untested empty-input path of the implemented overload.
+TEST_F(EuclideanClusterTest, TestClusteringEmptyInput)
+{
+  autoware::euclidean_cluster::EuclideanCluster cluster(true, 1, 100, 0.5);
+
+  pcl::PointCloud<pcl::PointXYZ>::ConstPtr empty_cloud(new pcl::PointCloud<pcl::PointXYZ>);
+  std::vector<pcl::PointCloud<pcl::PointXYZ>> clusters;
+
+  bool result = cluster.cluster(empty_cloud, clusters);
+  EXPECT_TRUE(result);
+  EXPECT_EQ(clusters.size(), 0u);
+}
+
 TEST_F(EuclideanClusterTest, TestUnimplementedMethods)
 {
   autoware::euclidean_cluster::EuclideanCluster cluster(true, 1, 100, 0.5);

--- a/perception/autoware_euclidean_cluster_object_detector/test/test_voxel_grid_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster_object_detector/test/test_voxel_grid_based_euclidean_cluster.cpp
@@ -270,6 +270,59 @@ TEST(VoxelGridBasedEuclideanClusterTest, DiagnosticsInterface)
   EXPECT_TRUE(cluster->cluster(msg, objects, clusters));
 }
 
+// Characterization test: pin the exact relationship between the `objects` output and the
+// parallel `clusters` output so the map-lookup-caching and in-place cluster-building refactor
+// is proven behavior-preserving. The number of output clusters must stay in lockstep with the
+// number of detected objects (one cluster per object), and every extracted point must lie within
+// the originating voxel region (x,y in [0,0.3], z in [0,30]) along with the object centroid. The
+// per-cluster point count is governed by voxel grouping and is intentionally not asserted.
+TEST(VoxelGridBasedEuclideanClusterTest, ClusterOutputMatchesObjects)
+{
+  int nb_generated_points = 100;
+  sensor_msgs::msg::PointCloud2 pointcloud = generateClusterWithinVoxel(nb_generated_points);
+
+  const sensor_msgs::msg::PointCloud2::ConstSharedPtr pointcloud_msg =
+    std::make_shared<sensor_msgs::msg::PointCloud2>(pointcloud);
+  autoware_perception_msgs::msg::DetectedObjects output;
+  float tolerance = 0.7;
+  float voxel_leaf_size = 0.3;
+  int min_points_number_per_voxel = 1;
+  int min_cluster_size = 1;
+  int max_cluster_size = 100;
+  bool use_height = false;
+  auto cluster_ = std::make_shared<autoware::euclidean_cluster::VoxelGridBasedEuclideanCluster>(
+    use_height, min_cluster_size, max_cluster_size, tolerance, voxel_leaf_size,
+    min_points_number_per_voxel);
+
+  std::vector<pcl::PointCloud<pcl::PointXYZ>> clusters;
+  ASSERT_TRUE(cluster_->cluster(pointcloud_msg, output, clusters));
+
+  // Exactly one cluster, and the parallel outputs stay in lockstep.
+  ASSERT_EQ(output.objects.size(), 1u);
+  ASSERT_EQ(clusters.size(), output.objects.size());
+
+  // The single extracted cluster must be non-empty, and every point must lie inside the
+  // generated voxel region (x,y in [0,0.3], z in [0,30]). The exact count is governed by the
+  // voxel grouping rather than the raw point count, so it is not asserted here.
+  const auto & cluster_cloud = clusters.front();
+  EXPECT_GT(cluster_cloud.points.size(), 0u);
+  for (const auto & point : cluster_cloud.points) {
+    EXPECT_GE(point.x, 0.0f);
+    EXPECT_LE(point.x, 0.3f);
+    EXPECT_GE(point.y, 0.0f);
+    EXPECT_LE(point.y, 0.3f);
+    EXPECT_GE(point.z, 0.0f);
+    EXPECT_LE(point.z, 30.0f);
+  }
+
+  // The object centroid must also fall within the same region.
+  const auto & position = output.objects.front().kinematics.pose_with_covariance.pose.position;
+  EXPECT_GE(position.x, 0.0);
+  EXPECT_LE(position.x, 0.3);
+  EXPECT_GE(position.y, 0.0);
+  EXPECT_LE(position.y, 0.3);
+}
+
 // Test exceeding max_cluster_size case
 TEST(VoxelGridBasedEuclideanClusterTest, ExceedMaxClusterSize)
 {


### PR DESCRIPTION
## Description

Internal-only, behavior-preserving performance cleanup of the two PCL-based clustering routines (`EuclideanCluster::cluster` and `VoxelGridBasedEuclideanCluster::cluster`). The public `cluster()` API is unchanged.

Changes:
- **`EuclideanCluster::cluster` output building** (`lib/euclidean_cluster.cpp`): previously each cluster was built into a heap-allocated `pcl::PointCloud` via `new`, filled with un-reserved `push_back`, then deep-copied into the output vector via `clusters.push_back(*cloud_cluster)`. Now the cluster is `emplace_back`-ed directly into `clusters`, the point buffer is `reserve`d by `cluster.indices.size()`, and it is filled in place — dropping one heap allocation plus one full deep copy per cluster per frame. `clusters` itself is reserved up front.
- **2D-flatten loops** (`lib/euclidean_cluster.cpp`, `lib/voxel_grid_based_euclidean_cluster.cpp`): `reserve` the flattened cloud by the source point count to avoid repeated reallocation on the per-frame rebuild.
- **Voxel map lookups** (`lib/voxel_grid_based_euclidean_cluster.cpp`): the per-input-point body previously did `map.find(index)` and then probed `map[index]` several more times (re-hashing the same key). It now caches the cluster index from the single `find` iterator and binds a reference to the target buffer, and the `unordered_map` is `reserve`d to avoid rehashing during its per-frame rebuild.
- **Voxel output cluster building** (`lib/voxel_grid_based_euclidean_cluster.cpp`): the final `pcl::PointCloud` is `emplace_back`-ed into `clusters` and `reserve`d by the known cluster point count instead of being built in a local and copied via `push_back`.

## Tests

Characterization tests are added first (and verified GREEN against the un-refactored code) to pin the behavior the refactor must preserve:
- `EuclideanClusterTest.TestClusterMembershipAndPointValues` — asserts both clusters carry exactly 5 points, the PointCloud2-style metadata (`width`/`height`/`is_dense`), and that every output point's coordinates are reproduced verbatim and grouped into the correct ground-truth cluster.
- `EuclideanClusterTest.TestClusteringEmptyInput` — covers the previously-untested empty-input path of the implemented overload (returns `true`, zero clusters).
- `VoxelGridBasedEuclideanClusterTest.ClusterOutputMatchesObjects` — pins the `objects`/`clusters` lockstep relationship, non-empty extraction, per-point voxel-region containment, and centroid containment.

All package unit tests pass (23 tests, 0 failures) in the `autoware:core-devel-jazzy` container. The slow `test_nodes` launch test was not run locally (per fast-iteration guidance); the fork CI runs the full suite.

Refs: autowarefoundation/autoware_core#1096
