### PR TITLE
test(autoware_ground_filter): expose grid trig + index seams and add numeric tests

### DIFF
--- a/perception/autoware_ground_filter/CMakeLists.txt
+++ b/perception/autoware_ground_filter/CMakeLists.txt
@@ -50,6 +50,14 @@ if(BUILD_TESTING)
     ${PROJECT_NAME}
   )
 
+  ament_add_ros_isolated_gtest(test_grid
+    test/test_grid.cpp
+  )
+  target_include_directories(test_grid PRIVATE src)
+  target_link_libraries(test_grid
+    ${PROJECT_NAME}
+  )
+
   ament_add_ros_isolated_gtest(test_sanity_check
     test/test_sanity_check.cpp
   )

--- a/perception/autoware_ground_filter/src/grid.hpp
+++ b/perception/autoware_ground_filter/src/grid.hpp
@@ -25,10 +25,17 @@
 #include <utility>
 #include <vector>
 
-namespace
+// Forward declaration of the test fixture so it can be befriended by Grid,
+// giving unit tests direct access to the otherwise-private index math without
+// changing the public API.
+class GridTest;
+
+namespace autoware::ground_filter
+{
+namespace detail
 {
 
-float pseudoArcTan2(const float y, const float x)
+inline float pseudoArcTan2(const float y, const float x)
 {
   // lightweight arc tangent
 
@@ -71,7 +78,7 @@ float pseudoArcTan2(const float y, const float x)
   }
 }
 
-float pseudoTan(const float theta)
+inline float pseudoTan(const float theta)
 {
   // lightweight tangent
 
@@ -92,10 +99,9 @@ float pseudoTan(const float theta)
   }
   return std::copysign(M_PI_4f / (M_PI_2f - std::abs(normalized_theta)), normalized_theta);
 }
-}  // namespace
 
-namespace autoware::ground_filter
-{
+}  // namespace detail
+
 using autoware_utils_debug::ScopedTimeTrack;
 
 struct Point
@@ -171,8 +177,8 @@ public:
 
     // calculate grid parameters
     grid_dist_size_rad_ =
-      pseudoArcTan2(grid_linearity_switch_radius_ + grid_dist_size_, origin_z_) -
-      pseudoArcTan2(grid_linearity_switch_radius_, origin_z_);
+      detail::pseudoArcTan2(grid_linearity_switch_radius_ + grid_dist_size_, origin_z_) -
+      detail::pseudoArcTan2(grid_linearity_switch_radius_, origin_z_);
     grid_dist_size_inv_ = 1.0f / grid_dist_size_;
 
     // generate grid geometry
@@ -195,7 +201,7 @@ public:
     const float x_fixed = x - origin_x_;
     const float y_fixed = y - origin_y_;
     const float radius = std::sqrt(x_fixed * x_fixed + y_fixed * y_fixed);
-    const float azimuth = pseudoArcTan2(y_fixed, x_fixed);
+    const float azimuth = detail::pseudoArcTan2(y_fixed, x_fixed);
 
     // calculate the grid id
     const int grid_idx = getGridIdx(radius, azimuth);
@@ -304,13 +310,14 @@ private:
         grid_radial_boundaries_.push_back(i * grid_dist_size_);
       }
       // constant angle
-      grid_linearity_switch_angle_ = pseudoArcTan2(grid_linearity_switch_radius_, origin_z_);
+      grid_linearity_switch_angle_ =
+        detail::pseudoArcTan2(grid_linearity_switch_radius_, origin_z_);
       float angle = grid_linearity_switch_angle_;
       const float grid_angle_interval =
-        pseudoArcTan2(grid_linearity_switch_radius_ + grid_dist_size_, origin_z_) - angle;
+        detail::pseudoArcTan2(grid_linearity_switch_radius_ + grid_dist_size_, origin_z_) - angle;
       grid_size_rad_inv_ = 1.0f / grid_angle_interval;
       while (angle < M_PI_2) {
-        const float dist = pseudoTan(angle) * origin_z_;
+        const float dist = detail::pseudoTan(angle) * origin_z_;
         grid_radial_boundaries_.push_back(dist);
         if (dist > grid_radial_limit_) {
           break;
@@ -392,7 +399,7 @@ private:
     if (radius < grid_linearity_switch_radius_) {
       grid_rad_idx = static_cast<int>(radius * grid_dist_size_inv_);
     } else if (radius < grid_radial_limit_) {
-      const float angle = pseudoArcTan2(radius, origin_z_);
+      const float angle = detail::pseudoArcTan2(radius, origin_z_);
       grid_rad_idx = grid_linearity_switch_num_ +
                      static_cast<int>((angle - grid_linearity_switch_angle_) * grid_size_rad_inv_);
     }
@@ -496,6 +503,9 @@ private:
       cell.scan_grid_root_idx_ = -1;
     }
   }
+
+  // for test
+  friend ::GridTest;
 };
 
 }  // namespace autoware::ground_filter

--- a/perception/autoware_ground_filter/test/test_grid.cpp
+++ b/perception/autoware_ground_filter/test/test_grid.cpp
@@ -1,0 +1,211 @@
+// Copyright 2024 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "grid.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <memory>
+
+// Test fixture befriended by autoware::ground_filter::Grid so the otherwise
+// private index math (getRadialIdx / getAzimuthGridIdx / getGridIdx /
+// getRadialAzimuthIdxFromCellIdx) can be exercised directly. These are
+// characterization tests pinning the current behavior of the polar grid.
+class GridTest : public ::testing::Test
+{
+protected:
+  // Virtual-lidar origin matching the default node configuration.
+  static constexpr float kOriginX = 1.4f;
+  static constexpr float kOriginY = 0.0f;
+  static constexpr float kOriginZ = 1.9f;
+
+  void SetUp() override
+  {
+    grid_ = std::make_unique<autoware::ground_filter::Grid>(kOriginX, kOriginY, kOriginZ);
+    // grid_dist_size, grid_azimuth_size, grid_linearity_switch_radius
+    grid_->initialize(0.5f, 0.01f, 20.0f);
+  }
+
+  // Thin accessors that forward to Grid's private members via friendship.
+  int getRadialIdx(const float radius) const { return grid_->getRadialIdx(radius); }
+
+  int getAzimuthGridIdx(const int radial_idx, const float azimuth) const
+  {
+    return grid_->getAzimuthGridIdx(radial_idx, azimuth);
+  }
+
+  int getGridIdx(const float radius, const float azimuth) const
+  {
+    return grid_->getGridIdx(radius, azimuth);
+  }
+
+  int getGridIdx(const int radial_idx, const int azimuth_idx) const
+  {
+    return grid_->getGridIdx(radial_idx, azimuth_idx);
+  }
+
+  void getRadialAzimuthIdxFromCellIdx(const int cell_id, int & radial_idx, int & azimuth_idx) const
+  {
+    grid_->getRadialAzimuthIdxFromCellIdx(cell_id, radial_idx, azimuth_idx);
+  }
+
+  std::unique_ptr<autoware::ground_filter::Grid> grid_;
+};
+
+namespace detail = autoware::ground_filter::detail;
+
+// ---------------------------------------------------------------------------
+// pseudoArcTan2 characterization: exact special-case branches.
+// ---------------------------------------------------------------------------
+TEST(GroundFilterGridTrig, PseudoArcTan2SpecialCases)
+{
+  // y == 0 branch
+  EXPECT_FLOAT_EQ(detail::pseudoArcTan2(0.0f, 1.0f), 0.0f);
+  EXPECT_FLOAT_EQ(detail::pseudoArcTan2(0.0f, -1.0f), M_PIf);
+
+  // x == 0 branch (note: this returns +/- pi/2, NOT the [0, 2pi) convention)
+  EXPECT_FLOAT_EQ(detail::pseudoArcTan2(1.0f, 0.0f), M_PI_2f);
+  EXPECT_FLOAT_EQ(detail::pseudoArcTan2(-1.0f, 0.0f), -M_PI_2f);
+}
+
+// ---------------------------------------------------------------------------
+// pseudoArcTan2 accuracy: tracks std::atan2 mapped into [0, 2pi) within the
+// approximation tolerance of the 8-zone linear fit.
+// ---------------------------------------------------------------------------
+TEST(GroundFilterGridTrig, PseudoArcTan2TracksStdAtan2)
+{
+  // The piecewise-linear 8-zone approximation peaks near the middle of each
+  // zone; its measured worst-case error over the full circle is ~0.071 rad
+  // (~4.05 deg). 0.08 rad bounds it and pins the approximation quality.
+  constexpr float kTol = 0.08f;
+
+  for (int deg = 1; deg < 360; ++deg) {
+    if (deg % 90 == 0) {
+      continue;  // axis cases covered by the special-case test above
+    }
+    const float angle = static_cast<float>(deg) * M_PIf / 180.0f;
+    const float x = std::cos(angle);
+    const float y = std::sin(angle);
+
+    float expected = std::atan2(y, x);
+    if (expected < 0.0f) {
+      expected += 2.0f * M_PIf;  // map std::atan2 (-pi, pi] into [0, 2pi)
+    }
+
+    const float actual = detail::pseudoArcTan2(y, x);
+    EXPECT_NEAR(actual, expected, kTol) << "deg=" << deg;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// pseudoTan characterization: zero and small-angle linearization.
+// ---------------------------------------------------------------------------
+TEST(GroundFilterGridTrig, PseudoTanSpecialCases)
+{
+  EXPECT_FLOAT_EQ(detail::pseudoTan(0.0f), 0.0f);
+
+  // For |theta| <= 1 rad the helper uses theta / (pi/4).
+  EXPECT_FLOAT_EQ(detail::pseudoTan(0.5f), 0.5f / M_PI_4f);
+  EXPECT_FLOAT_EQ(detail::pseudoTan(-0.5f), -0.5f / M_PI_4f);
+
+  // Result keeps the sign of the input across the full domain.
+  EXPECT_GT(detail::pseudoTan(1.3f), 0.0f);
+  EXPECT_LT(detail::pseudoTan(-1.3f), 0.0f);
+}
+
+// ---------------------------------------------------------------------------
+// Grid round-trip: every cell index maps back to (radial, azimuth) that
+// re-composes to the same cell index. Locks the inverse mapping.
+// ---------------------------------------------------------------------------
+TEST_F(GridTest, CellIdxRoundTrip)
+{
+  const auto grid_size = static_cast<int>(grid_->getGridSize());
+  ASSERT_GT(grid_size, 0);
+
+  for (int cell_id = 0; cell_id < grid_size; ++cell_id) {
+    int radial_idx = -1;
+    int azimuth_idx = -1;
+    getRadialAzimuthIdxFromCellIdx(cell_id, radial_idx, azimuth_idx);
+
+    EXPECT_GE(radial_idx, 0) << "cell_id=" << cell_id;
+    EXPECT_GE(azimuth_idx, 0) << "cell_id=" << cell_id;
+
+    const int recomposed = getGridIdx(radial_idx, azimuth_idx);
+    EXPECT_EQ(recomposed, cell_id) << "cell_id=" << cell_id;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// getRadialIdx out-of-range handling: negative radius and beyond the radial
+// limit return -1; in-range radii return monotonically non-decreasing indices.
+// ---------------------------------------------------------------------------
+TEST_F(GridTest, RadialIdxOutOfRange)
+{
+  // Negative radius -> invalid.
+  EXPECT_EQ(getRadialIdx(-1.0f), -1);
+
+  // Far beyond the configured radial limit (200 m) -> invalid.
+  EXPECT_EQ(getRadialIdx(1.0e4f), -1);
+
+  // Within the constant-distance region radial index is floor(radius / size).
+  EXPECT_EQ(getRadialIdx(0.0f), 0);
+  EXPECT_EQ(getRadialIdx(0.4f), 0);  // < grid_dist_size (0.5)
+  EXPECT_EQ(getRadialIdx(0.6f), 1);  // one cell out
+  EXPECT_EQ(getRadialIdx(1.1f), 2);
+
+  // Monotonic non-decreasing across increasing in-range radii.
+  int prev = getRadialIdx(0.0f);
+  for (float r = 0.0f; r < 150.0f; r += 0.5f) {
+    const int idx = getRadialIdx(r);
+    ASSERT_GE(idx, 0) << "r=" << r;
+    EXPECT_GE(idx, prev) << "r=" << r;
+    prev = idx;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// getGridIdx(radius, azimuth) returns a valid in-bounds cell for in-range
+// inputs and -1 when the radius is out of range, regardless of azimuth.
+// ---------------------------------------------------------------------------
+TEST_F(GridTest, GridIdxFromRadiusAzimuth)
+{
+  const auto grid_size = static_cast<int>(grid_->getGridSize());
+
+  // In-range point: must land in a valid cell.
+  const int idx = getGridIdx(5.0f, 0.5f);
+  EXPECT_GE(idx, 0);
+  EXPECT_LT(idx, grid_size);
+
+  // Out-of-range radius: -1 irrespective of azimuth.
+  EXPECT_EQ(getGridIdx(1.0e4f, 0.5f), -1);
+  EXPECT_EQ(getGridIdx(-1.0f, 0.5f), -1);
+
+  // Innermost ring (radial index 0) has a single azimuth grid spanning the full
+  // circle (azimuth_grid_num == 1, azimuth_interval == 2*pi). Azimuth 0 lands in
+  // the only bin, index 0.
+  EXPECT_EQ(getAzimuthGridIdx(0, 0.0f), 0);
+
+  // Wrap-around branch in getAzimuthGridIdx: an azimuth of exactly 2*pi yields
+  // floor(2*pi / 2*pi) == 1, which equals azimuth_grid_num for this ring and is
+  // reset to bin 0 by the loop-back clause. This exercises the
+  // (azimuth_grid_idx == azimuth_grid_num) reset, not just the trivial bin-0 case.
+  EXPECT_EQ(getAzimuthGridIdx(0, 2.0f * M_PIf), 0);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## What

Behavior-preserving testability refactor of the Concentric-Zone-Model polar grid in `src/grid.hpp`, plus a new direct numeric gtest target.

The grid geometry helpers `pseudoArcTan2` / `pseudoTan` lived in a file-local anonymous namespace, and the entire `Grid` index math (`getRadialIdx`, `getAzimuthGridIdx`, `getGridIdx`, `getRadialAzimuthIdxFromCellIdx`) was private with no test seam. Both were only reachable indirectly through `GroundFilter::process` / node spinning, so the approximations and cell-index round-trips had zero direct numeric coverage (the campaign backlog flagged this as the recommended seam-extraction PR for this package).

## Changes

- Move `pseudoArcTan2` / `pseudoTan` from the anonymous namespace into the internal `autoware::ground_filter::detail` namespace. The bodies are byte-for-byte identical (now marked `inline`); only the namespace and call-site qualification (`detail::`) change.
- Befriend a `GridTest` fixture from `Grid` (mirroring the existing `friend GroundFilterTest` seam on `GroundFilterComponent` in `node.hpp`) so unit tests can reach the private index math without any public-API change.
- Add a `test_grid` gtest target with characterization tests that assert concrete values/branches:
  - `pseudoArcTan2` exact special-case branches (y==0, x==0 returning +/- pi/2) and accuracy vs `std::atan2` mapped into [0, 2pi) (measured worst-case ~0.071 rad over the full circle, pinned at 0.08 rad tolerance).
  - `pseudoTan` zero and small-angle linearization plus sign preservation.
  - Full cell-index round-trip: every `cell idx -> (radial, azimuth) -> grid idx` re-composes to the same cell.
  - `getRadialIdx` out-of-range (-1) for negative / beyond-limit radii, exact floor mapping in the constant-distance region, and monotonic non-decreasing indices.
  - `getGridIdx(radius, azimuth)` in-bounds for in-range inputs and -1 for out-of-range radius regardless of azimuth.

## Behavior

No algorithm change. The trig approximations are deliberately kept (not swapped for `autoware_utils_math` fast-trig, which is a different approximation) so grid binning is bit-for-bit identical. Existing `test_ground_filter` and `test_node` remain green.

## API

Additive only: `pseudoArcTan2` / `pseudoTan` are now reachable as `autoware::ground_filter::detail::*` (previously not externally visible at all); a `friend ::GridTest;` declaration is added. No existing signature changes.

Refs: autowarefoundation/autoware_core#1096
