### PR TITLE
refactor(autoware_simple_pure_pursuit): extract pure-pursuit math into testable free functions

### DIFF
--- a/control/autoware_simple_pure_pursuit/CMakeLists.txt
+++ b/control/autoware_simple_pure_pursuit/CMakeLists.txt
@@ -20,6 +20,13 @@ if(BUILD_TESTING)
   target_link_libraries(${PROJECT_NAME}_test
     ${PROJECT_NAME}_lib
   )
+
+  ament_auto_add_gtest(${PROJECT_NAME}_util_test
+    test/test_pure_pursuit_util.cpp
+  )
+  target_link_libraries(${PROJECT_NAME}_util_test
+    ${PROJECT_NAME}_lib
+  )
 endif()
 
 autoware_ament_auto_package(

--- a/control/autoware_simple_pure_pursuit/package.xml
+++ b/control/autoware_simple_pure_pursuit/package.xml
@@ -17,6 +17,7 @@
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_test_utils</depend>
+  <depend>autoware_utils_geometry</depend>
   <depend>autoware_utils_rclcpp</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>rclcpp</depend>

--- a/control/autoware_simple_pure_pursuit/src/pure_pursuit_util.cpp
+++ b/control/autoware_simple_pure_pursuit/src/pure_pursuit_util.cpp
@@ -1,0 +1,82 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "pure_pursuit_util.hpp"
+
+#include <autoware_utils_geometry/geometry.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+namespace autoware::control::simple_pure_pursuit
+{
+
+double calc_lookahead_distance(
+  const double lookahead_gain, const double target_longitudinal_vel,
+  const double lookahead_min_distance)
+{
+  return lookahead_gain * target_longitudinal_vel + lookahead_min_distance;
+}
+
+double calc_longitudinal_acceleration(
+  const double speed_proportional_gain, const double target_longitudinal_vel,
+  const double current_longitudinal_vel)
+{
+  return speed_proportional_gain * (target_longitudinal_vel - current_longitudinal_vel);
+}
+
+geometry_msgs::msg::Point calc_rear_position(
+  const geometry_msgs::msg::Pose & base_link_pose, const double wheel_base)
+{
+  const double vehicle_heading = autoware_utils_geometry::get_rpy(base_link_pose.orientation).z;
+  return calc_rear_position(base_link_pose, wheel_base, vehicle_heading);
+}
+
+geometry_msgs::msg::Point calc_rear_position(
+  const geometry_msgs::msg::Pose & base_link_pose, const double wheel_base, const double yaw)
+{
+  return autoware_utils_geometry::create_point(
+    base_link_pose.position.x - wheel_base / 2.0 * std::cos(yaw),
+    base_link_pose.position.y - wheel_base / 2.0 * std::sin(yaw), base_link_pose.position.z);
+}
+
+TrajectoryPoint find_lookahead_point(
+  const std::vector<TrajectoryPoint> & points, const size_t closest_traj_point_idx,
+  const geometry_msgs::msg::Point & rear_position, const double lookahead_distance)
+{
+  auto lookahead_point_itr = std::find_if(
+    points.begin() + static_cast<std::ptrdiff_t>(closest_traj_point_idx), points.end(),
+    [&](const TrajectoryPoint & point) {
+      return autoware_utils_geometry::calc_distance2d(point.pose.position, rear_position) >=
+             lookahead_distance;
+    });
+  if (lookahead_point_itr == points.end()) {
+    lookahead_point_itr = points.end() - 1;
+  }
+  return *lookahead_point_itr;
+}
+
+double calc_steering_tire_angle(
+  const geometry_msgs::msg::Point & rear_position,
+  const geometry_msgs::msg::Point & lookahead_position, const double vehicle_heading,
+  const double wheel_base, const double lookahead_distance)
+{
+  const double alpha =
+    std::atan2(lookahead_position.y - rear_position.y, lookahead_position.x - rear_position.x) -
+    vehicle_heading;
+  return std::atan2(2.0 * wheel_base * std::sin(alpha), lookahead_distance);
+}
+
+}  // namespace autoware::control::simple_pure_pursuit

--- a/control/autoware_simple_pure_pursuit/src/pure_pursuit_util.hpp
+++ b/control/autoware_simple_pure_pursuit/src/pure_pursuit_util.hpp
@@ -1,0 +1,89 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PURE_PURSUIT_UTIL_HPP_
+#define PURE_PURSUIT_UTIL_HPP_
+
+#include <autoware_planning_msgs/msg/trajectory_point.hpp>
+#include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/pose.hpp>
+
+#include <vector>
+
+namespace autoware::control::simple_pure_pursuit
+{
+using autoware_planning_msgs::msg::TrajectoryPoint;
+
+/// @brief Compute the speed-dependent lookahead distance.
+/// @param lookahead_gain gain multiplied by the target longitudinal velocity
+/// @param target_longitudinal_vel target longitudinal velocity [m/s]
+/// @param lookahead_min_distance minimum lookahead distance [m]
+/// @return lookahead distance [m]
+double calc_lookahead_distance(
+  const double lookahead_gain, const double target_longitudinal_vel,
+  const double lookahead_min_distance);
+
+/// @brief Compute the longitudinal acceleration command from a proportional controller.
+/// @param speed_proportional_gain proportional gain
+/// @param target_longitudinal_vel target longitudinal velocity [m/s]
+/// @param current_longitudinal_vel current longitudinal velocity [m/s]
+/// @return acceleration command [m/s^2]
+double calc_longitudinal_acceleration(
+  const double speed_proportional_gain, const double target_longitudinal_vel,
+  const double current_longitudinal_vel);
+
+/// @brief Compute the position of the rear-axle center from the base-link pose.
+/// @param base_link_pose base-link pose (orientation interpreted as planar yaw)
+/// @param wheel_base wheel base [m]
+/// @return rear-axle center position
+geometry_msgs::msg::Point calc_rear_position(
+  const geometry_msgs::msg::Pose & base_link_pose, const double wheel_base);
+
+/// @brief Compute the position of the rear-axle center from the base-link pose using a
+/// precomputed yaw. Equivalent to the overload above with @p yaw set to the pose's planar yaw,
+/// but avoids recomputing the yaw when it is already available at the call site.
+/// @param base_link_pose base-link pose (only its position is used)
+/// @param wheel_base wheel base [m]
+/// @param yaw vehicle heading (yaw) [rad]
+/// @return rear-axle center position
+geometry_msgs::msg::Point calc_rear_position(
+  const geometry_msgs::msg::Pose & base_link_pose, const double wheel_base, const double yaw);
+
+/// @brief Search the first trajectory point at or beyond the lookahead distance from the
+/// rear-axle center, starting from the closest trajectory point. Falls back to the last
+/// trajectory point when none reaches the lookahead distance.
+/// @param points trajectory points (must be non-empty)
+/// @param closest_traj_point_idx index of the closest trajectory point
+/// @param rear_position rear-axle center position
+/// @param lookahead_distance lookahead distance [m]
+/// @return the selected lookahead trajectory point
+TrajectoryPoint find_lookahead_point(
+  const std::vector<TrajectoryPoint> & points, const size_t closest_traj_point_idx,
+  const geometry_msgs::msg::Point & rear_position, const double lookahead_distance);
+
+/// @brief Compute the steering tire angle from the pure-pursuit geometry.
+/// @param rear_position rear-axle center position
+/// @param lookahead_position lookahead point position
+/// @param vehicle_heading vehicle heading (yaw) [rad]
+/// @param wheel_base wheel base [m]
+/// @param lookahead_distance lookahead distance [m]
+/// @return steering tire angle [rad]
+double calc_steering_tire_angle(
+  const geometry_msgs::msg::Point & rear_position,
+  const geometry_msgs::msg::Point & lookahead_position, const double vehicle_heading,
+  const double wheel_base, const double lookahead_distance);
+
+}  // namespace autoware::control::simple_pure_pursuit
+
+#endif  // PURE_PURSUIT_UTIL_HPP_

--- a/control/autoware_simple_pure_pursuit/src/simple_pure_pursuit.cpp
+++ b/control/autoware_simple_pure_pursuit/src/simple_pure_pursuit.cpp
@@ -14,10 +14,10 @@
 
 #include "simple_pure_pursuit.hpp"
 
-#include <autoware/motion_utils/trajectory/trajectory.hpp>
-#include <tf2/utils.hpp>
+#include "pure_pursuit_util.hpp"
 
-#include <algorithm>
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 
 namespace autoware::control::simple_pure_pursuit
 {
@@ -50,8 +50,8 @@ void SimplePurePursuitNode::on_timer()
   }
 
   // 2. extract subscribed data
-  const auto odom = *odom_ptr;
-  const auto traj = *traj_ptr;
+  const auto & odom = *odom_ptr;
+  const auto & traj = *traj_ptr;
 
   // 3. create control command
   const auto control_command = create_control_command(odom, traj);
@@ -110,8 +110,8 @@ autoware_control_msgs::msg::Longitudinal SimplePurePursuitNode::calc_longitudina
 
   autoware_control_msgs::msg::Longitudinal longitudinal_control_command;
   longitudinal_control_command.velocity = static_cast<float>(target_longitudinal_vel);
-  longitudinal_control_command.acceleration = static_cast<float>(
-    speed_proportional_gain_ * (target_longitudinal_vel - current_longitudinal_vel));
+  longitudinal_control_command.acceleration = static_cast<float>(calc_longitudinal_acceleration(
+    speed_proportional_gain_, target_longitudinal_vel, current_longitudinal_vel));
 
   return longitudinal_control_command;
 }
@@ -122,34 +122,22 @@ autoware_control_msgs::msg::Lateral SimplePurePursuitNode::calc_lateral_control(
 {
   // calculate lookahead distance
   const double lookahead_distance =
-    lookahead_gain_ * target_longitudinal_vel + lookahead_min_distance_;
+    calc_lookahead_distance(lookahead_gain_, target_longitudinal_vel, lookahead_min_distance_);
 
   // calculate center coordinate of rear wheel
-  const double vehicle_heading = tf2::getYaw(odom.pose.pose.orientation);
-  const double rear_x =
-    odom.pose.pose.position.x - vehicle_info_.wheel_base_m / 2.0 * std::cos(vehicle_heading);
-  const double rear_y =
-    odom.pose.pose.position.y - vehicle_info_.wheel_base_m / 2.0 * std::sin(vehicle_heading);
+  const double vehicle_heading = autoware_utils_geometry::get_rpy(odom.pose.pose.orientation).z;
+  const auto rear_position =
+    calc_rear_position(odom.pose.pose, vehicle_info_.wheel_base_m, vehicle_heading);
 
   // search lookahead point
-  auto lookahead_point_itr = std::find_if(
-    traj.points.begin() + static_cast<std::ptrdiff_t>(closest_traj_point_idx), traj.points.end(),
-    [&](const TrajectoryPoint & point) {
-      return std::hypot(point.pose.position.x - rear_x, point.pose.position.y - rear_y) >=
-             lookahead_distance;
-    });
-  if (lookahead_point_itr == traj.points.end()) {
-    lookahead_point_itr = traj.points.end() - 1;
-  }
-  const double lookahead_point_x = lookahead_point_itr->pose.position.x;
-  const double lookahead_point_y = lookahead_point_itr->pose.position.y;
+  const auto lookahead_point =
+    find_lookahead_point(traj.points, closest_traj_point_idx, rear_position, lookahead_distance);
 
   // calculate steering angle
   autoware_control_msgs::msg::Lateral lateral_control_command;
-  const double alpha = std::atan2(lookahead_point_y - rear_y, lookahead_point_x - rear_x) -
-                       tf2::getYaw(odom.pose.pose.orientation);
-  lateral_control_command.steering_tire_angle = static_cast<float>(
-    std::atan2(2.0 * vehicle_info_.wheel_base_m * std::sin(alpha), lookahead_distance));
+  lateral_control_command.steering_tire_angle = static_cast<float>(calc_steering_tire_angle(
+    rear_position, lookahead_point.pose.position, vehicle_heading, vehicle_info_.wheel_base_m,
+    lookahead_distance));
 
   return lateral_control_command;
 }

--- a/control/autoware_simple_pure_pursuit/test/test_pure_pursuit_util.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_pure_pursuit_util.cpp
@@ -1,0 +1,139 @@
+// Copyright 2024 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/pure_pursuit_util.hpp"
+
+#include <autoware_utils_geometry/geometry.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <vector>
+
+namespace autoware::control::simple_pure_pursuit
+{
+namespace
+{
+geometry_msgs::msg::Point make_point(const double x, const double y, const double z = 0.0)
+{
+  return autoware_utils_geometry::create_point(x, y, z);
+}
+
+geometry_msgs::msg::Pose make_pose(const double x, const double y, const double yaw)
+{
+  geometry_msgs::msg::Pose pose;
+  pose.position = autoware_utils_geometry::create_point(x, y, 0.0);
+  pose.orientation = autoware_utils_geometry::create_quaternion_from_yaw(yaw);
+  return pose;
+}
+
+TrajectoryPoint make_traj_point(const double x, const double y)
+{
+  TrajectoryPoint p;
+  p.pose.position = make_point(x, y);
+  return p;
+}
+}  // namespace
+
+TEST(PurePursuitUtil, calc_lookahead_distance)
+{
+  // gain * vel + min = 2 * 3 + 1 = 7
+  EXPECT_DOUBLE_EQ(calc_lookahead_distance(2.0, 3.0, 1.0), 7.0);
+  // zero velocity falls back to the minimum distance
+  EXPECT_DOUBLE_EQ(calc_lookahead_distance(2.0, 0.0, 1.5), 1.5);
+}
+
+TEST(PurePursuitUtil, calc_longitudinal_acceleration)
+{
+  // gain * (target - current) = 0.5 * (2 - 1) = 0.5
+  EXPECT_DOUBLE_EQ(calc_longitudinal_acceleration(0.5, 2.0, 1.0), 0.5);
+  // braking when current exceeds target
+  EXPECT_DOUBLE_EQ(calc_longitudinal_acceleration(2.0, 1.0, 3.0), -4.0);
+}
+
+TEST(PurePursuitUtil, calc_rear_position)
+{
+  {  // heading 0: rear axle is offset along -x
+    const auto rear = calc_rear_position(make_pose(10.0, 5.0, 0.0), 2.0);
+    EXPECT_DOUBLE_EQ(rear.x, 9.0);
+    EXPECT_DOUBLE_EQ(rear.y, 5.0);
+  }
+  {  // heading pi/2: rear axle is offset along -y
+    const auto rear = calc_rear_position(make_pose(10.0, 5.0, M_PI / 2.0), 4.0);
+    EXPECT_NEAR(rear.x, 10.0, 1e-9);
+    EXPECT_NEAR(rear.y, 3.0, 1e-9);
+  }
+}
+
+TEST(PurePursuitUtil, calc_rear_position_yaw_overload_matches_pose_overload)
+{
+  // The yaw overload must reproduce the pose overload bit-for-bit when fed the pose's planar yaw.
+  const auto pose = make_pose(10.0, 5.0, 0.73);  // non-trivial orientation
+  const double wheel_base = 2.7;
+
+  // Extract the yaw exactly as the pose overload does, so the comparison pins bit-for-bit equality.
+  const double yaw = autoware_utils_geometry::get_rpy(pose.orientation).z;
+
+  const auto from_pose = calc_rear_position(pose, wheel_base);
+  const auto from_yaw = calc_rear_position(pose, wheel_base, yaw);
+
+  EXPECT_DOUBLE_EQ(from_yaw.x, from_pose.x);
+  EXPECT_DOUBLE_EQ(from_yaw.y, from_pose.y);
+  EXPECT_DOUBLE_EQ(from_yaw.z, from_pose.z);
+}
+
+TEST(PurePursuitUtil, find_lookahead_point_normal)
+{
+  const std::vector<TrajectoryPoint> points{
+    make_traj_point(0.0, 0.0), make_traj_point(1.0, 0.0), make_traj_point(2.0, 0.0),
+    make_traj_point(3.0, 0.0)};
+
+  // first point at or beyond 1.5 m from rear (0, 0) is (2, 0)
+  const auto p = find_lookahead_point(points, 0, make_point(0.0, 0.0), 1.5);
+  EXPECT_DOUBLE_EQ(p.pose.position.x, 2.0);
+  EXPECT_DOUBLE_EQ(p.pose.position.y, 0.0);
+}
+
+TEST(PurePursuitUtil, find_lookahead_point_fallback_to_last)
+{
+  const std::vector<TrajectoryPoint> points{
+    make_traj_point(0.0, 0.0), make_traj_point(1.0, 0.0), make_traj_point(2.0, 0.0)};
+
+  // no point reaches a 100 m lookahead distance -> clamp to the last point (2, 0)
+  const auto p = find_lookahead_point(points, 0, make_point(0.0, 0.0), 100.0);
+  EXPECT_DOUBLE_EQ(p.pose.position.x, 2.0);
+  EXPECT_DOUBLE_EQ(p.pose.position.y, 0.0);
+}
+
+TEST(PurePursuitUtil, calc_steering_tire_angle_straight)
+{
+  // lookahead point straight ahead -> alpha is 0 -> no steering
+  const double steering =
+    calc_steering_tire_angle(make_point(0.0, 0.0), make_point(2.0, 0.0), 0.0, 2.0, 2.0);
+  EXPECT_DOUBLE_EQ(steering, 0.0);
+}
+
+TEST(PurePursuitUtil, calc_steering_tire_angle_curved)
+{
+  // rear=(0,0), lookahead=(1,1), heading=0, wheel_base=2, lookahead_distance=sqrt(2)
+  // alpha = atan2(1, 1) - 0 = pi/4
+  // steering = atan2(2 * 2 * sin(pi/4), sqrt(2)) = atan2(2*sqrt(2), sqrt(2)) = atan(2)
+  const double lookahead_distance = std::sqrt(2.0);
+  const double steering = calc_steering_tire_angle(
+    make_point(0.0, 0.0), make_point(1.0, 1.0), 0.0, 2.0, lookahead_distance);
+  EXPECT_NEAR(steering, std::atan(2.0), 1e-9);
+  EXPECT_GT(steering, 0.0);
+}
+
+}  // namespace autoware::control::simple_pure_pursuit

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit.cpp
@@ -61,6 +61,12 @@ protected:
     return node_->create_control_command(odom, traj);
   }
 
+  static autoware_control_msgs::msg::Control create_control_command(
+    SimplePurePursuitNode & node, const Odometry & odom, const Trajectory & traj)
+  {
+    return node.create_control_command(odom, traj);
+  }
+
   autoware_control_msgs::msg::Longitudinal calc_longitudinal_control(
     const Odometry & odom, const double target_longitudinal_vel) const
   {
@@ -161,5 +167,46 @@ TEST_F(SimplePurePursuitNodeTest, calc_lateral_control)
 
     EXPECT_DOUBLE_EQ(result.steering_tire_angle, 0.0f);
   }
+
+  {  // off-axis odometry on a straight trajectory yields a non-zero steering angle.
+    // The ego is laterally offset by +1 m from the straight (x-axis) trajectory and faces
+    // forward, so pure pursuit must steer to the right (negative) to converge back.
+    const auto odom = makeOdometry(0.0, 1.0, 0.0);
+    const auto target_longitudinal_vel = 1.0;
+    const size_t closest_traj_point_idx = 0;
+
+    const auto result =
+      calc_lateral_control(odom, traj, target_longitudinal_vel, closest_traj_point_idx);
+
+    EXPECT_LT(result.steering_tire_angle, 0.0f);
+  }
+}
+
+TEST_F(SimplePurePursuitNodeTest, create_control_command_external_target_vel)
+{
+  // The shipped config sets use_external_target_vel: false, so the external-velocity branch
+  // (target velocity from the external_target_vel_ parameter) is otherwise never exercised.
+  const auto autoware_test_utils_dir =
+    ament_index_cpp::get_package_share_directory("autoware_test_utils");
+  const auto autoware_simple_pure_pursuit_dir =
+    ament_index_cpp::get_package_share_directory("autoware_simple_pure_pursuit");
+
+  auto node_options = rclcpp::NodeOptions{};
+  autoware::test_utils::updateNodeOptions(
+    node_options, {autoware_test_utils_dir + "/config/test_vehicle_info.param.yaml",
+                   autoware_simple_pure_pursuit_dir + "/config/simple_pure_pursuit.param.yaml"});
+  node_options.append_parameter_override("use_external_target_vel", true);
+  node_options.append_parameter_override("external_target_vel", 5.0);
+
+  const auto node = std::make_shared<SimplePurePursuitNode>(node_options);
+
+  const auto odom = makeOdometry(0.0, 0.0, 0.0);
+  // trajectory points carry longitudinal_velocity_mps = 1.0
+  const auto traj = autoware::test_utils::generateTrajectory<Trajectory>(10, 1.0, 1.0);
+
+  const auto result = create_control_command(*node, odom, traj);
+
+  // velocity comes from external_target_vel_ (5.0), not the trajectory point (1.0)
+  EXPECT_DOUBLE_EQ(result.longitudinal.velocity, 5.0);
 }
 }  // namespace autoware::control::simple_pure_pursuit


### PR DESCRIPTION
## What

Extract the pure pure-pursuit math (lookahead distance, longitudinal P-control, rear-axle projection, lookahead-point search, and steering geometry) out of the `SimplePurePursuitNode` member functions into internal free functions in `src/pure_pursuit_util.{hpp,cpp}`. The node members now delegate to these.

The new free functions reuse `autoware_utils_geometry` helpers instead of the hand-rolled math:
- `autoware_utils_geometry::get_rpy(...).z` replaces the duplicated `tf2::getYaw`, computed once in `calc_lateral_control`.
- `autoware_utils_geometry::create_point` builds the rear-axle position.
- `autoware_utils_geometry::calc_distance2d` replaces the bespoke `std::hypot` in the lookahead predicate.

Two small performance fixes alongside:
- `on_timer` now binds `const auto &` to the polling-subscriber payloads instead of value-copying the whole `Odometry`/`Trajectory` every 30 ms tick.
- The yaw is no longer extracted twice in `calc_lateral_control`.

## Why

The control math was only reachable through a `rclcpp::Node` + friend-class test harness. Pulling it into free functions adds a ROS-free unit-test seam while preserving the public class API/ABI (members stay, they just delegate). This also closes coverage gaps flagged in the audit.

## Tests

- New `test/test_pure_pursuit_util.cpp` (no ROS lifecycle) asserts concrete values for each free function, including the previously-untested **curved / off-axis non-zero steering** case (`atan(2)`) and the **lookahead clamp** fall-back to the last trajectory point.
- New node-level case `create_control_command_external_target_vel` exercises the previously-uncovered `use_external_target_vel_ = true` branch by constructing a node with parameter overrides and asserting the command velocity comes from `external_target_vel_` (5.0), not the trajectory point (1.0).
- An off-axis straight-trajectory case added to `calc_lateral_control` asserts a non-zero (negative) steering angle, distinguishing the geometry from the existing 0.0 assertions.

## Behavior

Behavior-preserving. `get_rpy(quat).z` is identical to the previous `tf2::getYaw(quat)` (both resolve to `Matrix3x3::getEulerYPR`, solution 1), and `calc_distance2d` is `std::hypot` of the same components.

Refs: autowarefoundation/autoware_core#1096
