### PR TITLE
perf(autoware_interpolation): scalar spline-eval overloads remove per-knot vector allocations

### DIFF
--- a/common/autoware_interpolation/include/autoware/interpolation/spline_interpolation.hpp
+++ b/common/autoware_interpolation/include/autoware/interpolation/spline_interpolation.hpp
@@ -77,6 +77,24 @@ public:
   std::vector<double> getSplineInterpolatedQuadDiffValues(
     const std::vector<double> & query_keys) const;
 
+  //!< @brief get the value of spline interpolation at a single sampling point.
+  //!< @details Scalar counterpart of getSplineInterpolatedValues that evaluates a single
+  //            query key without allocating any intermediate std::vector. The query key is
+  //            not validated against the knot range; callers that need range checking should
+  //            clamp the key beforehand (this mirrors the per-key behavior of the vector
+  //            overload, whose get_index() clamps the segment index).
+  double getSplineInterpolatedValue(const double query_key) const;
+
+  //!< @brief get the 1st differential value of spline interpolation at a single sampling point.
+  //!< @details Scalar counterpart of getSplineInterpolatedDiffValues. See
+  //            getSplineInterpolatedValue for the validation/clamping contract.
+  double getSplineInterpolatedDiffValue(const double query_key) const;
+
+  //!< @brief get the 2nd differential value of spline interpolation at a single sampling point.
+  //!< @details Scalar counterpart of getSplineInterpolatedQuadDiffValues. See
+  //            getSplineInterpolatedValue for the validation/clamping contract.
+  double getSplineInterpolatedQuadDiffValue(const double query_key) const;
+
   size_t getSize() const { return base_keys_.size(); }
 
   //!< @brief Get the spline coefficients as a concatenated vector.

--- a/common/autoware_interpolation/include/autoware/interpolation/spline_interpolation_points_2d.hpp
+++ b/common/autoware_interpolation/include/autoware/interpolation/spline_interpolation_points_2d.hpp
@@ -62,6 +62,10 @@ public:
 
   geometry_msgs::msg::Point getSplineInterpolatedPointAt(const double s) const
   {
+    // NOTE: the vector overload is kept here to preserve the validateKeys() out-of-range
+    //       precondition (this entry point receives an unclamped s, unlike the internal
+    //       per-knot loops which clamp before evaluating and therefore use the scalar
+    //       allocation-free overloads).
     geometry_msgs::msg::Point point;
     point.x = spline_x_.getSplineInterpolatedValues({s}).at(0);
     point.y = spline_y_.getSplineInterpolatedValues({s}).at(0);

--- a/common/autoware_interpolation/src/spline_interpolation.cpp
+++ b/common/autoware_interpolation/src/spline_interpolation.cpp
@@ -193,19 +193,37 @@ void SplineInterpolation::calcSplineCoefficients(
   base_keys_ = base_keys;
 }
 
+double SplineInterpolation::getSplineInterpolatedValue(const double query_key) const
+{
+  const auto idx = get_index(query_key);
+  const auto dx = query_key - base_keys_[idx];
+  return a_[idx] * dx * dx * dx + b_[idx] * dx * dx + c_[idx] * dx + d_[idx];
+}
+
+double SplineInterpolation::getSplineInterpolatedDiffValue(const double query_key) const
+{
+  const auto idx = get_index(query_key);
+  const auto dx = query_key - base_keys_[idx];
+  return 3 * a_[idx] * dx * dx + 2 * b_[idx] * dx + c_[idx];
+}
+
+double SplineInterpolation::getSplineInterpolatedQuadDiffValue(const double query_key) const
+{
+  const auto idx = get_index(query_key);
+  const auto dx = query_key - base_keys_[idx];
+  return 6 * a_[idx] * dx + 2 * b_[idx];
+}
+
 std::vector<double> SplineInterpolation::getSplineInterpolatedValues(
   const std::vector<double> & query_keys) const
 {
   // throw exceptions for invalid arguments
-  const auto validated_query_keys = autoware::interpolation::validateKeys(base_keys_, query_keys);
+  autoware::interpolation::validateKeys(base_keys_, query_keys);
   std::vector<double> interpolated_values;
   interpolated_values.reserve(query_keys.size());
 
   for (const auto & key : query_keys) {
-    const auto idx = get_index(key);
-    const auto dx = key - base_keys_[idx];
-    interpolated_values.emplace_back(
-      a_[idx] * dx * dx * dx + b_[idx] * dx * dx + c_[idx] * dx + d_[idx]);
+    interpolated_values.emplace_back(getSplineInterpolatedValue(key));
   }
 
   return interpolated_values;
@@ -215,14 +233,12 @@ std::vector<double> SplineInterpolation::getSplineInterpolatedDiffValues(
   const std::vector<double> & query_keys) const
 {
   // throw exceptions for invalid arguments
-  const auto validated_query_keys = autoware::interpolation::validateKeys(base_keys_, query_keys);
+  autoware::interpolation::validateKeys(base_keys_, query_keys);
   std::vector<double> interpolated_diff_values;
   interpolated_diff_values.reserve(query_keys.size());
 
   for (const auto & key : query_keys) {
-    const auto idx = get_index(key);
-    const auto dx = key - base_keys_[idx];
-    interpolated_diff_values.emplace_back(3 * a_[idx] * dx * dx + 2 * b_[idx] * dx + c_[idx]);
+    interpolated_diff_values.emplace_back(getSplineInterpolatedDiffValue(key));
   }
 
   return interpolated_diff_values;
@@ -232,14 +248,12 @@ std::vector<double> SplineInterpolation::getSplineInterpolatedQuadDiffValues(
   const std::vector<double> & query_keys) const
 {
   // throw exceptions for invalid arguments
-  const auto validated_query_keys = autoware::interpolation::validateKeys(base_keys_, query_keys);
+  autoware::interpolation::validateKeys(base_keys_, query_keys);
   std::vector<double> interpolated_quad_diff_values;
   interpolated_quad_diff_values.reserve(query_keys.size());
 
   for (const auto & key : query_keys) {
-    const auto idx = get_index(key);
-    const auto dx = key - base_keys_[idx];
-    interpolated_quad_diff_values.emplace_back(6 * a_[idx] * dx + 2 * b_[idx]);
+    interpolated_quad_diff_values.emplace_back(getSplineInterpolatedQuadDiffValue(key));
   }
 
   return interpolated_quad_diff_values;

--- a/common/autoware_interpolation/src/spline_interpolation_points_2d.cpp
+++ b/common/autoware_interpolation/src/spline_interpolation_points_2d.cpp
@@ -151,9 +151,9 @@ geometry_msgs::msg::Point SplineInterpolationPoints2d::getSplineInterpolatedPoin
     whole_s = base_s_vec_.back();
   }
 
-  const double x = spline_x_.getSplineInterpolatedValues({whole_s}).at(0);
-  const double y = spline_y_.getSplineInterpolatedValues({whole_s}).at(0);
-  const double z = spline_z_.getSplineInterpolatedValues({whole_s}).at(0);
+  const double x = spline_x_.getSplineInterpolatedValue(whole_s);
+  const double y = spline_y_.getSplineInterpolatedValue(whole_s);
+  const double z = spline_z_.getSplineInterpolatedValue(whole_s);
 
   geometry_msgs::msg::Point geom_point;
   geom_point.x = x;
@@ -171,8 +171,8 @@ double SplineInterpolationPoints2d::getSplineInterpolatedYaw(const size_t idx, c
   const double whole_s =
     std::clamp(base_s_vec_.at(idx) + s, base_s_vec_.front(), base_s_vec_.back());
 
-  const double diff_x = spline_x_.getSplineInterpolatedDiffValues({whole_s}).at(0);
-  const double diff_y = spline_y_.getSplineInterpolatedDiffValues({whole_s}).at(0);
+  const double diff_x = spline_x_.getSplineInterpolatedDiffValue(whole_s);
+  const double diff_y = spline_y_.getSplineInterpolatedDiffValue(whole_s);
 
   return std::atan2(diff_y, diff_x);
 }
@@ -180,6 +180,7 @@ double SplineInterpolationPoints2d::getSplineInterpolatedYaw(const size_t idx, c
 std::vector<double> SplineInterpolationPoints2d::getSplineInterpolatedYaws() const
 {
   std::vector<double> yaw_vec;
+  yaw_vec.reserve(spline_x_.getSize());
   for (size_t i = 0; i < spline_x_.getSize(); ++i) {
     const double yaw = getSplineInterpolatedYaw(i, 0.0);
     yaw_vec.push_back(yaw);
@@ -197,11 +198,11 @@ double SplineInterpolationPoints2d::getSplineInterpolatedCurvature(
   const double whole_s =
     std::clamp(base_s_vec_.at(idx) + s, base_s_vec_.front(), base_s_vec_.back());
 
-  const double diff_x = spline_x_.getSplineInterpolatedDiffValues({whole_s}).at(0);
-  const double diff_y = spline_y_.getSplineInterpolatedDiffValues({whole_s}).at(0);
+  const double diff_x = spline_x_.getSplineInterpolatedDiffValue(whole_s);
+  const double diff_y = spline_y_.getSplineInterpolatedDiffValue(whole_s);
 
-  const double quad_diff_x = spline_x_.getSplineInterpolatedQuadDiffValues({whole_s}).at(0);
-  const double quad_diff_y = spline_y_.getSplineInterpolatedQuadDiffValues({whole_s}).at(0);
+  const double quad_diff_x = spline_x_.getSplineInterpolatedQuadDiffValue(whole_s);
+  const double quad_diff_y = spline_y_.getSplineInterpolatedQuadDiffValue(whole_s);
 
   return (diff_x * quad_diff_y - quad_diff_x * diff_y) /
          std::pow(std::pow(diff_x, 2) + std::pow(diff_y, 2), 1.5);
@@ -269,11 +270,11 @@ void SplineInterpolationPoints2d::updateCurvatureSpline()
   curvature_values.reserve(base_s_vec_.size());
 
   for (const auto & s : base_s_vec_) {
-    const double diff_x = spline_x_.getSplineInterpolatedDiffValues({s}).at(0);
-    const double diff_y = spline_y_.getSplineInterpolatedDiffValues({s}).at(0);
+    const double diff_x = spline_x_.getSplineInterpolatedDiffValue(s);
+    const double diff_y = spline_y_.getSplineInterpolatedDiffValue(s);
 
-    const double quad_diff_x = spline_x_.getSplineInterpolatedQuadDiffValues({s}).at(0);
-    const double quad_diff_y = spline_y_.getSplineInterpolatedQuadDiffValues({s}).at(0);
+    const double quad_diff_x = spline_x_.getSplineInterpolatedQuadDiffValue(s);
+    const double quad_diff_y = spline_y_.getSplineInterpolatedQuadDiffValue(s);
 
     const double denom = std::pow(diff_x, 2) + std::pow(diff_y, 2);
     if (denom < 1e-10) {
@@ -299,13 +300,13 @@ void SplineInterpolationPoints2d::extendLinearlyForward(
 
   // Get the end value and derivative from the last segment
   const double s_end = base_s_vec_.back();
-  const double x_end = spline_x_.getSplineInterpolatedValues({s_end}).at(0);
-  const double y_end = spline_y_.getSplineInterpolatedValues({s_end}).at(0);
-  const double z_end = spline_z_.getSplineInterpolatedValues({s_end}).at(0);
+  const double x_end = spline_x_.getSplineInterpolatedValue(s_end);
+  const double y_end = spline_y_.getSplineInterpolatedValue(s_end);
+  const double z_end = spline_z_.getSplineInterpolatedValue(s_end);
 
-  const double dx_ds = spline_x_.getSplineInterpolatedDiffValues({s_end}).at(0);
-  const double dy_ds = spline_y_.getSplineInterpolatedDiffValues({s_end}).at(0);
-  const double dz_ds = spline_z_.getSplineInterpolatedDiffValues({s_end}).at(0);
+  const double dx_ds = spline_x_.getSplineInterpolatedDiffValue(s_end);
+  const double dy_ds = spline_y_.getSplineInterpolatedDiffValue(s_end);
+  const double dz_ds = spline_z_.getSplineInterpolatedDiffValue(s_end);
 
   // Build extended knots and values
   std::vector<double> extended_s = base_s_vec_;
@@ -314,10 +315,13 @@ void SplineInterpolationPoints2d::extendLinearlyForward(
   std::vector<double> extended_z;
 
   // Get original values at existing knots
+  extended_x.reserve(target_n_knots);
+  extended_y.reserve(target_n_knots);
+  extended_z.reserve(target_n_knots);
   for (const auto & s : base_s_vec_) {
-    extended_x.push_back(spline_x_.getSplineInterpolatedValues({s}).at(0));
-    extended_y.push_back(spline_y_.getSplineInterpolatedValues({s}).at(0));
-    extended_z.push_back(spline_z_.getSplineInterpolatedValues({s}).at(0));
+    extended_x.push_back(spline_x_.getSplineInterpolatedValue(s));
+    extended_y.push_back(spline_y_.getSplineInterpolatedValue(s));
+    extended_z.push_back(spline_z_.getSplineInterpolatedValue(s));
   }
 
   // Add extended knots and linearly extrapolated values
@@ -348,8 +352,8 @@ std::pair<double, double> SplineInterpolationPoints2d::projectPointOntoSpline(
   const auto & knots = spline_x_.getKnots();
   double min_dist = std::numeric_limits<double>::max();
   for (const auto & s_knot : knots) {
-    double dx = spline_x_.getSplineInterpolatedValues({s_knot}).at(0) - x_i;
-    double dy = spline_y_.getSplineInterpolatedValues({s_knot}).at(0) - y_i;
+    double dx = spline_x_.getSplineInterpolatedValue(s_knot) - x_i;
+    double dy = spline_y_.getSplineInterpolatedValue(s_knot) - y_i;
     double dist = std::hypot(dx, dy);
     if (dist < min_dist) {
       min_dist = dist;
@@ -359,14 +363,14 @@ std::pair<double, double> SplineInterpolationPoints2d::projectPointOntoSpline(
 
   // Newton iteration with proper second derivative
   for (int iter = 0; iter < max_iter; ++iter) {
-    const double x_s = spline_x_.getSplineInterpolatedValues({s}).at(0);
-    const double y_s = spline_y_.getSplineInterpolatedValues({s}).at(0);
+    const double x_s = spline_x_.getSplineInterpolatedValue(s);
+    const double y_s = spline_y_.getSplineInterpolatedValue(s);
 
-    const double dx_ds = spline_x_.getSplineInterpolatedDiffValues({s}).at(0);
-    const double dy_ds = spline_y_.getSplineInterpolatedDiffValues({s}).at(0);
+    const double dx_ds = spline_x_.getSplineInterpolatedDiffValue(s);
+    const double dy_ds = spline_y_.getSplineInterpolatedDiffValue(s);
 
-    const double d2x_ds2 = spline_x_.getSplineInterpolatedQuadDiffValues({s}).at(0);
-    const double d2y_ds2 = spline_y_.getSplineInterpolatedQuadDiffValues({s}).at(0);
+    const double d2x_ds2 = spline_x_.getSplineInterpolatedQuadDiffValue(s);
+    const double d2y_ds2 = spline_y_.getSplineInterpolatedQuadDiffValue(s);
 
     // f'(s) = d/ds[||p(s) - p_i||^2] = 2[(x_s - x_i)·dx_ds + (y_s - y_i)·dy_ds]
     const double df_ds = (x_s - x_i) * dx_ds + (y_s - y_i) * dy_ds;
@@ -394,8 +398,8 @@ std::pair<double, double> SplineInterpolationPoints2d::projectPointOntoSpline(
   }
 
   // Compute cross-track error eY
-  double x_s = spline_x_.getSplineInterpolatedValues({s}).at(0);
-  double y_s = spline_y_.getSplineInterpolatedValues({s}).at(0);
+  double x_s = spline_x_.getSplineInterpolatedValue(s);
+  double y_s = spline_y_.getSplineInterpolatedValue(s);
   double psi_s = getSplineInterpolatedYaw(0, s);
 
   double eY = -(x_i - x_s) * std::sin(psi_s) + (y_i - y_s) * std::cos(psi_s);

--- a/common/autoware_interpolation/test/src/test_spline_interpolation_scalar.cpp
+++ b/common/autoware_interpolation/test/src/test_spline_interpolation_scalar.cpp
@@ -1,0 +1,83 @@
+// Copyright 2026 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/interpolation/spline_interpolation.hpp"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+using autoware::interpolation::SplineInterpolation;
+
+// The scalar overloads must return exactly what the vector overloads return for the
+// same query key. They are the per-knot allocation-free evaluation seam that the
+// SplineInterpolationPoints2d per-knot loops route through.
+TEST(spline_interpolation_scalar, value_matches_vector_overload)
+{
+  const std::vector<double> base_keys{-1.5, 1.0, 5.0, 10.0, 15.0, 20.0};
+  const std::vector<double> base_values{-1.2, 0.5, 1.0, 1.2, 2.0, 1.0};
+  const std::vector<double> query_keys{-1.5, 0.0, 8.0, 12.0, 18.0, 20.0};
+
+  const SplineInterpolation s(base_keys, base_values);
+
+  const auto vector_values = s.getSplineInterpolatedValues(query_keys);
+  for (size_t i = 0; i < query_keys.size(); ++i) {
+    EXPECT_DOUBLE_EQ(s.getSplineInterpolatedValue(query_keys.at(i)), vector_values.at(i));
+  }
+}
+
+TEST(spline_interpolation_scalar, diff_value_matches_vector_overload)
+{
+  const std::vector<double> base_keys{-1.5, 1.0, 5.0, 10.0, 15.0, 20.0};
+  const std::vector<double> base_values{-1.2, 0.5, 1.0, 1.2, 2.0, 1.0};
+  const std::vector<double> query_keys{-1.5, 0.0, 8.0, 12.0, 18.0, 20.0};
+
+  const SplineInterpolation s(base_keys, base_values);
+
+  const auto vector_values = s.getSplineInterpolatedDiffValues(query_keys);
+  for (size_t i = 0; i < query_keys.size(); ++i) {
+    EXPECT_DOUBLE_EQ(s.getSplineInterpolatedDiffValue(query_keys.at(i)), vector_values.at(i));
+  }
+}
+
+TEST(spline_interpolation_scalar, quad_diff_value_matches_vector_overload)
+{
+  const std::vector<double> base_keys{-1.5, 1.0, 5.0, 10.0, 15.0, 20.0};
+  const std::vector<double> base_values{-1.2, 0.5, 1.0, 1.2, 2.0, 1.0};
+  const std::vector<double> query_keys{-1.5, 0.0, 8.0, 12.0, 18.0, 20.0};
+
+  const SplineInterpolation s(base_keys, base_values);
+
+  const auto vector_values = s.getSplineInterpolatedQuadDiffValues(query_keys);
+  for (size_t i = 0; i < query_keys.size(); ++i) {
+    EXPECT_DOUBLE_EQ(s.getSplineInterpolatedQuadDiffValue(query_keys.at(i)), vector_values.at(i));
+  }
+}
+
+// Single-segment (n == 2) evaluation: the scalar overload clamps the segment index via
+// get_index() and evaluates the cubic in place, matching the vector overload's per-key math.
+TEST(spline_interpolation_scalar, value_at_two_knot_segment)
+{
+  const std::vector<double> base_keys{0.0, 2.0};
+  const std::vector<double> base_values{0.0, 4.0};
+  const SplineInterpolation s(base_keys, base_values);
+
+  // n == 2 path: c_[0] = (4-0)/(2-0) = 2, d_[0] = 0 -> value = 2 * dx
+  EXPECT_DOUBLE_EQ(s.getSplineInterpolatedValue(0.0), 0.0);
+  EXPECT_DOUBLE_EQ(s.getSplineInterpolatedValue(1.0), 2.0);
+  EXPECT_DOUBLE_EQ(s.getSplineInterpolatedValue(2.0), 4.0);
+  // first derivative is the constant slope, second derivative is zero on this segment
+  EXPECT_DOUBLE_EQ(s.getSplineInterpolatedDiffValue(1.0), 2.0);
+  EXPECT_DOUBLE_EQ(s.getSplineInterpolatedQuadDiffValue(1.0), 0.0);
+}


### PR DESCRIPTION
## What

Eliminate the O(N) single-element `std::vector` allocations in the per-knot evaluation loops of `SplineInterpolationPoints2d`, and drop the dead `validated_query_keys` copies in the three `SplineInterpolation` vector getters.

- Add scalar evaluation overloads to `SplineInterpolation` (additive public API):
  - `double getSplineInterpolatedValue(double)`
  - `double getSplineInterpolatedDiffValue(double)`
  - `double getSplineInterpolatedQuadDiffValue(double)`
  Each evaluates a single key in place (`get_index` + Horner), no heap allocation.
- Route the per-knot / per-iteration loops in `SplineInterpolationPoints2d` through the scalar overloads instead of constructing a fresh `{s}` vector and calling `.at(0)`: `getSplineInterpolatedPoint`, `getSplineInterpolatedYaw`, `getSplineInterpolatedCurvature`, `updateCurvatureSpline`, `extendLinearlyForward` (end value/derivative + the per-knot value loop), and `projectPointOntoSpline` (coarse search, Newton iteration, final cross-track-error computation).
- The existing vector overloads `getSplineInterpolatedValues/DiffValues/QuadDiffValues` now delegate to the scalar overloads, removing the duplicated cubic/derivative arithmetic.
- Drop the dead `validated_query_keys` copies: the cropped result of `validateKeys()` was never read (the loops iterate the original `query_keys`), so the call is kept only for its throwing precondition side effect and the unused full-length copy of `query_keys` is no longer allocated.
- Add `reserve()` to `getSplineInterpolatedYaws` and the three `extendLinearlyForward` extension vectors.

## Why

For an N-knot spline, evaluating yaw/curvature/projection/extension previously cost O(N) heap allocations (one input vector + one output vector per scalar evaluation, 2-6 times per knot). The scalar overloads remove these allocations on hot paths with no public API break.

## Behavior preservation

The scalar overloads reproduce the exact per-key arithmetic of the vector loop bodies. Every per-knot call site already clamps the key into `[base_s_vec_.front(), base_s_vec_.back()]` before evaluating, so dropping the per-call `validateKeys()` (which never threw for in-range keys) changes nothing. The public `getSplineInterpolatedPointAt` entry point intentionally keeps the vector overload to preserve its `validateKeys()` out-of-range precondition (it receives an unclamped `s`).

Note: the plan's wording referred to these scalar overloads as "private" / an "internal-only refactor"; they are implemented as additive public methods so they can be unit-tested directly. This preserves the existing public API (no signature altered) and is the only deviation from the plan's phrasing.

## Tests

New `test/src/test_spline_interpolation_scalar.cpp` (picked up by the existing `GLOB_RECURSE` in CMakeLists.txt) asserts the scalar overloads return bit-exact (`EXPECT_DOUBLE_EQ`) the same values as the vector overloads across value/diff/quad-diff, plus a single-segment (`n == 2`) numeric check. All 31 gtests pass; build + lint green in the core-devel-jazzy container.

Refs: autowarefoundation/autoware_core#1096
