### PR TITLE
refactor(autoware_object_recognition_utils): make transform.hpp testable

### DIFF
--- a/common/autoware_object_recognition_utils/include/autoware/object_recognition_utils/transform.hpp
+++ b/common/autoware_object_recognition_utils/include/autoware/object_recognition_utils/transform.hpp
@@ -21,6 +21,7 @@
 #include <tf2_ros/transform_listener.hpp>
 
 #include <geometry_msgs/msg/transform.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/msg/point_field.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
@@ -29,9 +30,11 @@
 
 #include <string>
 
+namespace autoware::object_recognition_utils
+{
 namespace detail
 {
-[[maybe_unused]] inline boost::optional<geometry_msgs::msg::Transform> getTransform(
+inline boost::optional<geometry_msgs::msg::Transform> getTransform(
   const tf2_ros::Buffer & tf_buffer, const std::string & source_frame_id,
   const std::string & target_frame_id, const rclcpp::Time & time)
 {
@@ -46,7 +49,7 @@ namespace detail
   }
 }
 
-[[maybe_unused]] inline boost::optional<Eigen::Matrix4f> getTransformMatrix(
+inline boost::optional<Eigen::Matrix4f> getTransformMatrix(
   const std::string & in_target_frame, const std_msgs::msg::Header & in_cloud_header,
   const tf2_ros::Buffer & tf_buffer)
 {
@@ -62,10 +65,61 @@ namespace detail
     return boost::none;
   }
 }
+
+/// \brief Apply a resolved frame transform to every object in \p input_msg, writing the
+///        result into \p output_msg.
+/// \details Pure math: composes the per-object pose with \p tf_target2objects_world and rotates
+///          the pose covariance by the same transform. No TF buffer lookup happens here, so it is
+///          unit-testable with a hand-built transform.
+template <class T>
+void applyTransformToObjects(
+  const T & input_msg, const std::string & target_frame_id,
+  const tf2::Transform & tf_target2objects_world, T & output_msg)
+{
+  output_msg = input_msg;
+  output_msg.header.frame_id = target_frame_id;
+  for (auto & object : output_msg.objects) {
+    tf2::Transform tf_objects_world2objects;
+    auto & pose_with_cov = object.kinematics.pose_with_covariance;
+    tf2::fromMsg(pose_with_cov.pose, tf_objects_world2objects);
+    tf2::Transform tf_target2objects = tf_target2objects_world * tf_objects_world2objects;
+    // transform pose, frame difference and object pose
+    tf2::toMsg(tf_target2objects, pose_with_cov.pose);
+    // transform covariance, only the frame difference
+    pose_with_cov.covariance =
+      tf2::transformCovariance(pose_with_cov.covariance, tf_target2objects_world);
+  }
+}
+
+/// \brief Apply resolved frame transforms to every feature object in \p input_msg, writing the
+///        result into \p output_msg.
+/// \details Pure math: composes the per-object pose with \p tf_target2objects_world and transforms
+///          each cluster point cloud by \p tf_matrix. No TF buffer lookup happens here, so it is
+///          unit-testable with a hand-built transform.
+template <class T>
+void applyTransformToFeatureObjects(
+  const T & input_msg, const std::string & target_frame_id,
+  const tf2::Transform & tf_target2objects_world, const Eigen::Matrix4f & tf_matrix, T & output_msg)
+{
+  output_msg = input_msg;
+  output_msg.header.frame_id = target_frame_id;
+  for (auto & feature_object : output_msg.feature_objects) {
+    tf2::Transform tf_objects_world2objects;
+    // transform object
+    tf2::fromMsg(
+      feature_object.object.kinematics.pose_with_covariance.pose, tf_objects_world2objects);
+    tf2::Transform tf_target2objects = tf_target2objects_world * tf_objects_world2objects;
+    tf2::toMsg(tf_target2objects, feature_object.object.kinematics.pose_with_covariance.pose);
+
+    // transform cluster
+    sensor_msgs::msg::PointCloud2 transformed_cluster;
+    pcl_ros::transformPointCloud(tf_matrix, feature_object.feature.cluster, transformed_cluster);
+    transformed_cluster.header.frame_id = target_frame_id;
+    feature_object.feature.cluster = transformed_cluster;
+  }
+}
 }  // namespace detail
 
-namespace autoware::object_recognition_utils
-{
 template <class T>
 bool transformObjects(
   const T & input_msg, const std::string & target_frame_id, const tf2_ros::Buffer & tf_buffer,
@@ -75,6 +129,8 @@ bool transformObjects(
 
   // transform to world coordinate
   if (input_msg.header.frame_id != target_frame_id) {
+    // Set the target frame on the output up front, so a failed lookup still reports the requested
+    // frame on the (otherwise unused) output message, matching the original behavior.
     output_msg.header.frame_id = target_frame_id;
     tf2::Transform tf_target2objects_world;
     {
@@ -85,17 +141,8 @@ bool transformObjects(
       }
       tf2::fromMsg(*ros_target2objects_world, tf_target2objects_world);
     }
-    for (auto & object : output_msg.objects) {
-      tf2::Transform tf_objects_world2objects;
-      auto & pose_with_cov = object.kinematics.pose_with_covariance;
-      tf2::fromMsg(pose_with_cov.pose, tf_objects_world2objects);
-      tf2::Transform tf_target2objects = tf_target2objects_world * tf_objects_world2objects;
-      // transform pose, frame difference and object pose
-      tf2::toMsg(tf_target2objects, pose_with_cov.pose);
-      // transform covariance, only the frame difference
-      pose_with_cov.covariance =
-        tf2::transformCovariance(pose_with_cov.covariance, tf_target2objects_world);
-    }
+    detail::applyTransformToObjects(
+      input_msg, target_frame_id, tf_target2objects_world, output_msg);
   }
   return true;
 }
@@ -106,8 +153,10 @@ bool transformObjectsWithFeature(
 {
   output_msg = input_msg;
   if (input_msg.header.frame_id != target_frame_id) {
+    // Set the target frame on the output up front, so a failed lookup still reports the requested
+    // frame on the (otherwise unused) output message, matching the original behavior.
     output_msg.header.frame_id = target_frame_id;
-    tf2::Transform tf_target2objects_world = tf2::Transform::getIdentity();
+    tf2::Transform tf_target2objects_world;
     const auto ros_target2objects_world = detail::getTransform(
       tf_buffer, input_msg.header.frame_id, target_frame_id, input_msg.header.stamp);
     if (!ros_target2objects_world) {
@@ -120,22 +169,8 @@ bool transformObjectsWithFeature(
         rclcpp::get_logger("object_recognition_utils:"), "failed to get transformed matrix");
       return false;
     }
-    for (auto & feature_object : output_msg.feature_objects) {
-      tf2::Transform tf_objects_world2objects;
-      // transform object
-      tf2::fromMsg(
-        feature_object.object.kinematics.pose_with_covariance.pose, tf_objects_world2objects);
-      tf2::Transform tf_target2objects = tf_target2objects_world * tf_objects_world2objects;
-      tf2::toMsg(tf_target2objects, feature_object.object.kinematics.pose_with_covariance.pose);
-
-      // transform cluster
-      sensor_msgs::msg::PointCloud2 transformed_cluster;
-      pcl_ros::transformPointCloud(*tf_matrix, feature_object.feature.cluster, transformed_cluster);
-      transformed_cluster.header.frame_id = target_frame_id;
-      feature_object.feature.cluster = transformed_cluster;
-    }
-    output_msg.header.frame_id = target_frame_id;
-    return true;
+    detail::applyTransformToFeatureObjects(
+      input_msg, target_frame_id, tf_target2objects_world, *tf_matrix, output_msg);
   }
   return true;
 }

--- a/common/autoware_object_recognition_utils/package.xml
+++ b/common/autoware_object_recognition_utils/package.xml
@@ -24,6 +24,8 @@
   <depend>std_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_ros</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/common/autoware_object_recognition_utils/test/src/test_transform.cpp
+++ b/common/autoware_object_recognition_utils/test/src/test_transform.cpp
@@ -1,0 +1,195 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/object_recognition_utils/transform.hpp"
+
+#include <rclcpp/clock.hpp>
+
+#include <autoware_perception_msgs/msg/detected_object.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+
+#include <gtest/gtest.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2_ros/buffer.h>
+
+#include <cmath>
+#include <memory>
+#include <string>
+
+namespace
+{
+autoware_perception_msgs::msg::DetectedObject createObject(
+  const double x, const double y, const double z, const double yaw)
+{
+  autoware_perception_msgs::msg::DetectedObject object;
+  auto & pose = object.kinematics.pose_with_covariance.pose;
+  pose.position.x = x;
+  pose.position.y = y;
+  pose.position.z = z;
+  tf2::Quaternion q;
+  q.setRPY(0.0, 0.0, yaw);
+  pose.orientation = tf2::toMsg(q);
+  // identity covariance so transforms are easy to reason about
+  auto & cov = object.kinematics.pose_with_covariance.covariance;
+  for (size_t i = 0; i < 6; ++i) {
+    cov.at(i * 6 + i) = 1.0;
+  }
+  return object;
+}
+
+tf2::Transform makeTransform(const double x, const double y, const double z, const double yaw)
+{
+  tf2::Quaternion q;
+  q.setRPY(0.0, 0.0, yaw);
+  tf2::Transform t;
+  t.setOrigin(tf2::Vector3(x, y, z));
+  t.setRotation(q);
+  return t;
+}
+}  // namespace
+
+// transformObjects must pass the message through unchanged when the input frame already equals the
+// target frame (identity passthrough branch) and report success.
+TEST(transform, transformObjectsIdentityPassthrough)
+{
+  using autoware::object_recognition_utils::transformObjects;
+
+  autoware_perception_msgs::msg::DetectedObjects input;
+  input.header.frame_id = "map";
+  input.objects.push_back(createObject(1.0, 2.0, 3.0, 0.0));
+
+  tf2_ros::Buffer empty_buffer{std::make_shared<rclcpp::Clock>(RCL_ROS_TIME)};
+  autoware_perception_msgs::msg::DetectedObjects output;
+
+  // Same frame: no lookup needed, so the (empty) buffer is never queried.
+  EXPECT_TRUE(transformObjects(input, "map", empty_buffer, output));
+  ASSERT_EQ(output.objects.size(), 1U);
+  EXPECT_EQ(output.header.frame_id, "map");
+  EXPECT_DOUBLE_EQ(output.objects.at(0).kinematics.pose_with_covariance.pose.position.x, 1.0);
+  EXPECT_DOUBLE_EQ(output.objects.at(0).kinematics.pose_with_covariance.pose.position.y, 2.0);
+  EXPECT_DOUBLE_EQ(output.objects.at(0).kinematics.pose_with_covariance.pose.position.z, 3.0);
+}
+
+// transformObjects returns false when the buffer cannot resolve the requested transform.
+TEST(transform, transformObjectsMissingTransformReturnsFalse)
+{
+  using autoware::object_recognition_utils::transformObjects;
+
+  autoware_perception_msgs::msg::DetectedObjects input;
+  input.header.frame_id = "sensor";
+  input.objects.push_back(createObject(1.0, 2.0, 3.0, 0.0));
+
+  tf2_ros::Buffer empty_buffer{std::make_shared<rclcpp::Clock>(RCL_ROS_TIME)};
+  autoware_perception_msgs::msg::DetectedObjects output;
+
+  // Different frame + empty buffer => lookup fails => false.
+  EXPECT_FALSE(transformObjects(input, "map", empty_buffer, output));
+  // Failure-path contract (matches the original implementation): the target frame is written to the
+  // output header before the lookup, so it stays at the requested target frame on a failed lookup,
+  // while the (copied) objects are left untransformed.
+  EXPECT_EQ(output.header.frame_id, "map");
+  ASSERT_EQ(output.objects.size(), 1U);
+  const auto & pose = output.objects.at(0).kinematics.pose_with_covariance.pose;
+  EXPECT_DOUBLE_EQ(pose.position.x, 1.0);
+  EXPECT_DOUBLE_EQ(pose.position.y, 2.0);
+  EXPECT_DOUBLE_EQ(pose.position.z, 3.0);
+}
+
+// applyTransformToObjects must compose a pure translation onto each object's pose and rewrite the
+// header frame, leaving orientation and (translation-only) covariance untouched.
+TEST(transform, applyTransformToObjectsTranslationOnly)
+{
+  using autoware::object_recognition_utils::detail::applyTransformToObjects;
+
+  autoware_perception_msgs::msg::DetectedObjects input;
+  input.header.frame_id = "sensor";
+  input.objects.push_back(createObject(1.0, 2.0, 0.0, 0.0));
+
+  const auto tf_target2world = makeTransform(10.0, 20.0, 0.0, 0.0);
+
+  autoware_perception_msgs::msg::DetectedObjects output;
+  applyTransformToObjects(input, "map", tf_target2world, output);
+
+  ASSERT_EQ(output.objects.size(), 1U);
+  EXPECT_EQ(output.header.frame_id, "map");
+  const auto & pose = output.objects.at(0).kinematics.pose_with_covariance.pose;
+  EXPECT_NEAR(pose.position.x, 11.0, 1e-9);
+  EXPECT_NEAR(pose.position.y, 22.0, 1e-9);
+  EXPECT_NEAR(pose.position.z, 0.0, 1e-9);
+  // orientation unchanged for a pure translation
+  EXPECT_NEAR(pose.orientation.z, 0.0, 1e-9);
+  EXPECT_NEAR(pose.orientation.w, 1.0, 1e-9);
+  // a pure translation does not rotate covariance: diagonal stays 1.0
+  const auto & cov = output.objects.at(0).kinematics.pose_with_covariance.covariance;
+  EXPECT_NEAR(cov.at(0), 1.0, 1e-9);
+  EXPECT_NEAR(cov.at(7), 1.0, 1e-9);
+}
+
+// applyTransformToObjects must compose a 90-degree yaw rotation (about origin) onto each object's
+// pose: a point at (1, 0) maps to (0, 1) and the orientation accumulates the rotation.
+TEST(transform, applyTransformToObjectsRotation90)
+{
+  using autoware::object_recognition_utils::detail::applyTransformToObjects;
+
+  autoware_perception_msgs::msg::DetectedObjects input;
+  input.header.frame_id = "sensor";
+  input.objects.push_back(createObject(1.0, 0.0, 0.0, 0.0));
+
+  const double half_pi = M_PI / 2.0;
+  const auto tf_target2world = makeTransform(0.0, 0.0, 0.0, half_pi);
+
+  autoware_perception_msgs::msg::DetectedObjects output;
+  applyTransformToObjects(input, "map", tf_target2world, output);
+
+  ASSERT_EQ(output.objects.size(), 1U);
+  const auto & pose = output.objects.at(0).kinematics.pose_with_covariance.pose;
+  EXPECT_NEAR(pose.position.x, 0.0, 1e-9);
+  EXPECT_NEAR(pose.position.y, 1.0, 1e-9);
+  // orientation becomes a +90deg yaw: qz = sin(pi/4), qw = cos(pi/4)
+  EXPECT_NEAR(pose.orientation.z, std::sin(half_pi / 2.0), 1e-9);
+  EXPECT_NEAR(pose.orientation.w, std::cos(half_pi / 2.0), 1e-9);
+}
+
+// transformObjects wired through a live buffer with a known static transform must produce the same
+// result as applyTransformToObjects with the equivalent tf2::Transform.
+TEST(transform, transformObjectsAppliesBufferedTransform)
+{
+  using autoware::object_recognition_utils::transformObjects;
+
+  // Static transform: target("map") <- source("sensor") = translate (10, 20, 0)
+  geometry_msgs::msg::TransformStamped tf_stamped;
+  tf_stamped.header.frame_id = "map";
+  tf_stamped.child_frame_id = "sensor";
+  tf_stamped.transform.translation.x = 10.0;
+  tf_stamped.transform.translation.y = 20.0;
+  tf_stamped.transform.translation.z = 0.0;
+  tf_stamped.transform.rotation.w = 1.0;
+
+  tf2_ros::Buffer buffer{std::make_shared<rclcpp::Clock>(RCL_ROS_TIME)};
+  buffer.setTransform(tf_stamped, "test_authority", true);
+
+  autoware_perception_msgs::msg::DetectedObjects input;
+  input.header.frame_id = "sensor";
+  input.objects.push_back(createObject(1.0, 2.0, 0.0, 0.0));
+
+  autoware_perception_msgs::msg::DetectedObjects output;
+  ASSERT_TRUE(transformObjects(input, "map", buffer, output));
+  ASSERT_EQ(output.objects.size(), 1U);
+  EXPECT_EQ(output.header.frame_id, "map");
+  const auto & pose = output.objects.at(0).kinematics.pose_with_covariance.pose;
+  EXPECT_NEAR(pose.position.x, 11.0, 1e-9);
+  EXPECT_NEAR(pose.position.y, 22.0, 1e-9);
+  EXPECT_NEAR(pose.position.z, 0.0, 1e-9);
+}


### PR DESCRIPTION
## What

Refactor `transform.hpp` to add a testing seam and remove a global-namespace hazard, then add the previously-missing `test/src/test_transform.cpp`.

- Move the TF helpers `getTransform` / `getTransformMatrix` out of the **global** `namespace detail` and into `autoware::object_recognition_utils::detail`. They were previously leaking into `::detail` for every translation unit that includes the installed `object_recognition_utils.hpp`, an ODR / symbol-collision hazard with any other library that uses a global `detail` namespace. (The `[[maybe_unused]]` attributes are dropped because the helpers are now referenced by the wrappers in the same namespace.)
- Extract the per-object transform math into two pure helper templates,
  `detail::applyTransformToObjects` and `detail::applyTransformToFeatureObjects`,
  that take an already-resolved `tf2::Transform` (and `Eigen::Matrix4f`). `transformObjects` and `transformObjectsWithFeature` become thin lookup+apply wrappers. This makes the pose/covariance/cluster math unit-testable without a live `tf2_ros::Buffer`.
- Declare `tf2_geometry_msgs` and `tf2_ros` in `package.xml`: both are directly `#include`d by this public header (and the new test includes `<tf2_ros/buffer.h>`), but were previously resolved only transitively. This is dependency hygiene; no build behavior changes.

## Tests

Add `test/src/test_transform.cpp` (transform.hpp previously had zero coverage):

- `transformObjectsIdentityPassthrough` — input frame == target frame returns true and passes the message through unchanged (the buffer is never queried).
- `transformObjectsMissingTransformReturnsFalse` — different frame + empty buffer returns false; also pins the failure-path output contract (header keeps the requested target frame, objects left untransformed).
- `applyTransformToObjectsTranslationOnly` — pure translation composes onto each pose; orientation and (translation-only) covariance are untouched.
- `applyTransformToObjectsRotation90` — a 90-degree yaw maps (1,0) to (0,1) and accumulates the orientation.
- `transformObjectsAppliesBufferedTransform` — end-to-end lookup+apply through a live `tf2_ros::Buffer` seeded with a static transform.

## Compatibility

Public template API (`transformObjects`, `transformObjectsWithFeature`) signatures are unchanged. The change is behavior-preserving on **both** the success and failure paths: the `output_msg.header.frame_id = target_frame_id` assignment is kept before the TF lookup, so on a failed lookup the wrappers still return `false` with the output header set to the target frame, exactly as before. On the success path the transform math is unchanged (now relocated into the pure helper templates). No external consumer referenced the old global `::detail` helpers.

Refs: autowarefoundation/autoware_core#1096
