### PR TITLE
test(autoware_point_types): cover memory.hpp layout helpers and mark them inline

### DIFF
--- a/common/autoware_point_types/CMakeLists.txt
+++ b/common/autoware_point_types/CMakeLists.txt
@@ -20,6 +20,17 @@ if(BUILD_TESTING)
   ament_target_dependencies(test_autoware_point_types
     point_cloud_msg_wrapper
   )
+
+  ament_add_ros_isolated_gtest(test_autoware_point_types_memory
+    test/test_memory.cpp
+  )
+  target_include_directories(test_autoware_point_types_memory
+    PRIVATE include
+  )
+  ament_target_dependencies(test_autoware_point_types_memory
+    point_cloud_msg_wrapper
+    sensor_msgs
+  )
 endif()
 
 autoware_ament_auto_package()

--- a/common/autoware_point_types/include/autoware/point_types/memory.hpp
+++ b/common/autoware_point_types/include/autoware/point_types/memory.hpp
@@ -25,7 +25,7 @@
 namespace autoware::point_types
 {
 
-bool is_data_layout_compatible_with_point_xyzi(
+inline bool is_data_layout_compatible_with_point_xyzi(
   const std::vector<sensor_msgs::msg::PointField> & fields)
 {
   using PointIndex = autoware::point_types::PointXYZIIndex;
@@ -58,12 +58,12 @@ bool is_data_layout_compatible_with_point_xyzi(
   return same_layout;
 }
 
-bool is_data_layout_compatible_with_point_xyzi(const sensor_msgs::msg::PointCloud2 & input)
+inline bool is_data_layout_compatible_with_point_xyzi(const sensor_msgs::msg::PointCloud2 & input)
 {
   return is_data_layout_compatible_with_point_xyzi(input.fields);
 }
 
-bool is_data_layout_compatible_with_point_xyzirc(
+inline bool is_data_layout_compatible_with_point_xyzirc(
   const std::vector<sensor_msgs::msg::PointField> & fields)
 {
   using PointIndex = autoware::point_types::PointXYZIRCIndex;
@@ -106,12 +106,12 @@ bool is_data_layout_compatible_with_point_xyzirc(
   return same_layout;
 }
 
-bool is_data_layout_compatible_with_point_xyzirc(const sensor_msgs::msg::PointCloud2 & input)
+inline bool is_data_layout_compatible_with_point_xyzirc(const sensor_msgs::msg::PointCloud2 & input)
 {
   return is_data_layout_compatible_with_point_xyzirc(input.fields);
 }
 
-bool is_data_layout_compatible_with_point_xyziradrt(
+inline bool is_data_layout_compatible_with_point_xyziradrt(
   const std::vector<sensor_msgs::msg::PointField> & fields)
 {
   using PointIndex = autoware::point_types::PointXYZIRADRTIndex;
@@ -169,12 +169,13 @@ bool is_data_layout_compatible_with_point_xyziradrt(
   return same_layout;
 }
 
-bool is_data_layout_compatible_with_point_xyziradrt(const sensor_msgs::msg::PointCloud2 & input)
+inline bool is_data_layout_compatible_with_point_xyziradrt(
+  const sensor_msgs::msg::PointCloud2 & input)
 {
   return is_data_layout_compatible_with_point_xyziradrt(input.fields);
 }
 
-bool is_data_layout_compatible_with_point_xyzircaedt(
+inline bool is_data_layout_compatible_with_point_xyzircaedt(
   const std::vector<sensor_msgs::msg::PointField> & fields)
 {
   using PointIndex = autoware::point_types::PointXYZIRCAEDTIndex;
@@ -237,12 +238,13 @@ bool is_data_layout_compatible_with_point_xyzircaedt(
   return same_layout;
 }
 
-bool is_data_layout_compatible_with_point_xyzircaedt(const sensor_msgs::msg::PointCloud2 & input)
+inline bool is_data_layout_compatible_with_point_xyzircaedt(
+  const sensor_msgs::msg::PointCloud2 & input)
 {
   return is_data_layout_compatible_with_point_xyzircaedt(input.fields);
 }
 
-std::vector<sensor_msgs::msg::PointField> create_fields_point_xyzi()
+inline std::vector<sensor_msgs::msg::PointField> create_fields_point_xyzi()
 {
   using PointIndex = autoware::point_types::PointXYZIIndex;
   using PointType = autoware::point_types::PointXYZI;
@@ -269,7 +271,7 @@ std::vector<sensor_msgs::msg::PointField> create_fields_point_xyzi()
   return fields;
 }
 
-std::vector<sensor_msgs::msg::PointField> create_fields_point_xyzirc()
+inline std::vector<sensor_msgs::msg::PointField> create_fields_point_xyzirc()
 {
   using PointIndex = autoware::point_types::PointXYZIRCIndex;
   using PointType = autoware::point_types::PointXYZIRC;
@@ -307,7 +309,7 @@ std::vector<sensor_msgs::msg::PointField> create_fields_point_xyzirc()
   return fields;
 }
 
-std::vector<sensor_msgs::msg::PointField> create_fields_point_xyziradrt()
+inline std::vector<sensor_msgs::msg::PointField> create_fields_point_xyziradrt()
 {
   using PointIndex = autoware::point_types::PointXYZIRADRTIndex;
   using PointType = autoware::point_types::PointXYZIRADRT;
@@ -360,7 +362,7 @@ std::vector<sensor_msgs::msg::PointField> create_fields_point_xyziradrt()
   return fields;
 }
 
-std::vector<sensor_msgs::msg::PointField> create_fields_point_xyzircaedt()
+inline std::vector<sensor_msgs::msg::PointField> create_fields_point_xyzircaedt()
 {
   using PointIndex = autoware::point_types::PointXYZIRCAEDTIndex;
   using PointType = autoware::point_types::PointXYZIRCAEDT;

--- a/common/autoware_point_types/package.xml
+++ b/common/autoware_point_types/package.xml
@@ -23,6 +23,7 @@
   <depend>ament_cmake_xmllint</depend>
   <depend>pcl_ros</depend>
   <depend>point_cloud_msg_wrapper</depend>
+  <depend>sensor_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/common/autoware_point_types/test/test_memory.cpp
+++ b/common/autoware_point_types/test/test_memory.cpp
@@ -1,0 +1,271 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/point_types/memory.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <vector>
+
+namespace
+{
+using autoware::point_types::create_fields_point_xyzi;
+using autoware::point_types::create_fields_point_xyziradrt;
+using autoware::point_types::create_fields_point_xyzirc;
+using autoware::point_types::create_fields_point_xyzircaedt;
+using autoware::point_types::is_data_layout_compatible_with_point_xyzi;
+using autoware::point_types::is_data_layout_compatible_with_point_xyziradrt;
+using autoware::point_types::is_data_layout_compatible_with_point_xyzirc;
+using autoware::point_types::is_data_layout_compatible_with_point_xyzircaedt;
+using sensor_msgs::msg::PointCloud2;
+using sensor_msgs::msg::PointField;
+}  // namespace
+
+//
+// create_fields_* exact contents
+//
+
+TEST(CreateFields, Xyzi)
+{
+  const auto fields = create_fields_point_xyzi();
+  ASSERT_EQ(fields.size(), 4U);
+
+  EXPECT_EQ(fields[0].name, "x");
+  EXPECT_EQ(fields[0].offset, offsetof(autoware::point_types::PointXYZI, x));
+  EXPECT_EQ(fields[0].datatype, PointField::FLOAT32);
+  EXPECT_EQ(fields[0].count, 1U);
+
+  EXPECT_EQ(fields[1].name, "y");
+  EXPECT_EQ(fields[1].datatype, PointField::FLOAT32);
+  EXPECT_EQ(fields[2].name, "z");
+  EXPECT_EQ(fields[2].datatype, PointField::FLOAT32);
+
+  EXPECT_EQ(fields[3].name, "intensity");
+  EXPECT_EQ(fields[3].offset, offsetof(autoware::point_types::PointXYZI, intensity));
+  EXPECT_EQ(fields[3].datatype, PointField::FLOAT32);
+  EXPECT_EQ(fields[3].count, 1U);
+}
+
+TEST(CreateFields, Xyzirc)
+{
+  const auto fields = create_fields_point_xyzirc();
+  ASSERT_EQ(fields.size(), 6U);
+
+  EXPECT_EQ(fields[3].name, "intensity");
+  EXPECT_EQ(fields[3].datatype, PointField::UINT8);
+  EXPECT_EQ(fields[4].name, "return_type");
+  EXPECT_EQ(fields[4].datatype, PointField::UINT8);
+  EXPECT_EQ(fields[5].name, "channel");
+  EXPECT_EQ(fields[5].datatype, PointField::UINT16);
+  EXPECT_EQ(fields[5].offset, offsetof(autoware::point_types::PointXYZIRC, channel));
+}
+
+TEST(CreateFields, Xyziradrt)
+{
+  const auto fields = create_fields_point_xyziradrt();
+  ASSERT_EQ(fields.size(), 9U);
+
+  EXPECT_EQ(fields[4].name, "ring");
+  EXPECT_EQ(fields[4].datatype, PointField::UINT16);
+  EXPECT_EQ(fields[5].name, "azimuth");
+  EXPECT_EQ(fields[5].datatype, PointField::FLOAT32);
+  EXPECT_EQ(fields[6].name, "distance");
+  EXPECT_EQ(fields[6].datatype, PointField::FLOAT32);
+  EXPECT_EQ(fields[7].name, "return_type");
+  EXPECT_EQ(fields[7].datatype, PointField::UINT8);
+  EXPECT_EQ(fields[8].name, "time_stamp");
+  EXPECT_EQ(fields[8].datatype, PointField::FLOAT64);
+  EXPECT_EQ(fields[8].offset, offsetof(autoware::point_types::PointXYZIRADRT, time_stamp));
+}
+
+TEST(CreateFields, Xyzircaedt)
+{
+  const auto fields = create_fields_point_xyzircaedt();
+  ASSERT_EQ(fields.size(), 10U);
+
+  EXPECT_EQ(fields[3].name, "intensity");
+  EXPECT_EQ(fields[3].datatype, PointField::UINT8);
+  EXPECT_EQ(fields[4].name, "return_type");
+  EXPECT_EQ(fields[4].datatype, PointField::UINT8);
+  EXPECT_EQ(fields[5].name, "channel");
+  EXPECT_EQ(fields[5].datatype, PointField::UINT16);
+  EXPECT_EQ(fields[6].name, "azimuth");
+  EXPECT_EQ(fields[6].datatype, PointField::FLOAT32);
+  EXPECT_EQ(fields[7].name, "elevation");
+  EXPECT_EQ(fields[7].datatype, PointField::FLOAT32);
+  EXPECT_EQ(fields[8].name, "distance");
+  EXPECT_EQ(fields[8].datatype, PointField::FLOAT32);
+  EXPECT_EQ(fields[9].name, "time_stamp");
+  EXPECT_EQ(fields[9].datatype, PointField::UINT32);
+  EXPECT_EQ(fields[9].offset, offsetof(autoware::point_types::PointXYZIRCAEDT, time_stamp));
+}
+
+//
+// Round-trip: a freshly-created field layout must be reported compatible
+//
+
+TEST(LayoutCompatibleRoundTrip, Xyzi)
+{
+  EXPECT_TRUE(is_data_layout_compatible_with_point_xyzi(create_fields_point_xyzi()));
+}
+
+TEST(LayoutCompatibleRoundTrip, Xyzirc)
+{
+  EXPECT_TRUE(is_data_layout_compatible_with_point_xyzirc(create_fields_point_xyzirc()));
+}
+
+TEST(LayoutCompatibleRoundTrip, Xyziradrt)
+{
+  EXPECT_TRUE(is_data_layout_compatible_with_point_xyziradrt(create_fields_point_xyziradrt()));
+}
+
+TEST(LayoutCompatibleRoundTrip, Xyzircaedt)
+{
+  EXPECT_TRUE(is_data_layout_compatible_with_point_xyzircaedt(create_fields_point_xyzircaedt()));
+}
+
+//
+// The four functions are type-specific: a layout for one type must not match another
+//
+
+TEST(LayoutCompatibleCrossType, MismatchedTypesReturnFalse)
+{
+  // xyzi layout has FLOAT32 intensity and only 4 fields -> not xyzirc/xyziradrt/xyzircaedt
+  EXPECT_FALSE(is_data_layout_compatible_with_point_xyzirc(create_fields_point_xyzi()));
+  EXPECT_FALSE(is_data_layout_compatible_with_point_xyziradrt(create_fields_point_xyzi()));
+  EXPECT_FALSE(is_data_layout_compatible_with_point_xyzircaedt(create_fields_point_xyzi()));
+
+  // xyzircaedt layout (10 fields, UINT8 intensity) -> not the others
+  EXPECT_FALSE(is_data_layout_compatible_with_point_xyziradrt(create_fields_point_xyzircaedt()));
+}
+
+//
+// PointCloud2 overloads forward to the std::vector<PointField> overloads
+//
+
+TEST(LayoutCompatiblePointCloud2Overload, ForwardsToFields)
+{
+  PointCloud2 cloud_xyzi;
+  cloud_xyzi.fields = create_fields_point_xyzi();
+  EXPECT_TRUE(is_data_layout_compatible_with_point_xyzi(cloud_xyzi));
+
+  PointCloud2 cloud_xyzirc;
+  cloud_xyzirc.fields = create_fields_point_xyzirc();
+  EXPECT_TRUE(is_data_layout_compatible_with_point_xyzirc(cloud_xyzirc));
+
+  PointCloud2 cloud_xyziradrt;
+  cloud_xyziradrt.fields = create_fields_point_xyziradrt();
+  EXPECT_TRUE(is_data_layout_compatible_with_point_xyziradrt(cloud_xyziradrt));
+
+  PointCloud2 cloud_xyzircaedt;
+  cloud_xyzircaedt.fields = create_fields_point_xyzircaedt();
+  EXPECT_TRUE(is_data_layout_compatible_with_point_xyzircaedt(cloud_xyzircaedt));
+
+  // empty cloud is not compatible with any
+  PointCloud2 empty;
+  EXPECT_FALSE(is_data_layout_compatible_with_point_xyzi(empty));
+  EXPECT_FALSE(is_data_layout_compatible_with_point_xyzirc(empty));
+  EXPECT_FALSE(is_data_layout_compatible_with_point_xyziradrt(empty));
+  EXPECT_FALSE(is_data_layout_compatible_with_point_xyzircaedt(empty));
+}
+
+//
+// Negative cases: a single corrupted field flips the result to false
+//
+
+TEST(LayoutCompatibleNegative, WrongName)
+{
+  auto fields = create_fields_point_xyzi();
+  fields[1].name = "Y";  // expected lowercase "y"
+  EXPECT_FALSE(is_data_layout_compatible_with_point_xyzi(fields));
+}
+
+TEST(LayoutCompatibleNegative, WrongOffset)
+{
+  auto fields = create_fields_point_xyzirc();
+  fields[2].offset = fields[2].offset + 1U;  // z offset perturbed
+  EXPECT_FALSE(is_data_layout_compatible_with_point_xyzirc(fields));
+}
+
+TEST(LayoutCompatibleNegative, WrongDatatype)
+{
+  auto fields = create_fields_point_xyziradrt();
+  fields[8].datatype = PointField::FLOAT32;  // time_stamp must be FLOAT64
+  EXPECT_FALSE(is_data_layout_compatible_with_point_xyziradrt(fields));
+}
+
+TEST(LayoutCompatibleNegative, WrongCount)
+{
+  auto fields = create_fields_point_xyzircaedt();
+  fields[0].count = 2U;  // x must have count 1
+  EXPECT_FALSE(is_data_layout_compatible_with_point_xyzircaedt(fields));
+}
+
+//
+// Field-count edge behavior. This pins the CURRENT contract, which intentionally
+// differs by type: xyzi/xyzirc/xyziradrt use a `size() < N` guard (extra trailing
+// fields are ignored and the cloud is still accepted), while xyzircaedt uses a
+// strict `size() != 10` guard (extra fields are rejected).
+//
+
+TEST(LayoutCompatibleFieldCount, TooFewFieldsRejected)
+{
+  {
+    auto fields = create_fields_point_xyzi();
+    fields.pop_back();  // 3 < 4
+    EXPECT_FALSE(is_data_layout_compatible_with_point_xyzi(fields));
+  }
+  {
+    auto fields = create_fields_point_xyzirc();
+    fields.pop_back();  // 5 < 6
+    EXPECT_FALSE(is_data_layout_compatible_with_point_xyzirc(fields));
+  }
+  {
+    auto fields = create_fields_point_xyziradrt();
+    fields.pop_back();  // 8 < 9
+    EXPECT_FALSE(is_data_layout_compatible_with_point_xyziradrt(fields));
+  }
+  {
+    auto fields = create_fields_point_xyzircaedt();
+    fields.pop_back();  // 9 != 10
+    EXPECT_FALSE(is_data_layout_compatible_with_point_xyzircaedt(fields));
+  }
+}
+
+TEST(LayoutCompatibleFieldCount, ExtraTrailingFieldsAcceptedExceptXyzircaedt)
+{
+  // For the `< N` guard variants, an extra trailing field is ignored -> still compatible.
+  {
+    auto fields = create_fields_point_xyzi();
+    fields.emplace_back();  // 5 fields, but only first 4 are checked
+    EXPECT_TRUE(is_data_layout_compatible_with_point_xyzi(fields));
+  }
+  {
+    auto fields = create_fields_point_xyzirc();
+    fields.emplace_back();
+    EXPECT_TRUE(is_data_layout_compatible_with_point_xyzirc(fields));
+  }
+  {
+    auto fields = create_fields_point_xyziradrt();
+    fields.emplace_back();
+    EXPECT_TRUE(is_data_layout_compatible_with_point_xyziradrt(fields));
+  }
+  // For the strict `!= 10` guard, an extra trailing field is rejected.
+  {
+    auto fields = create_fields_point_xyzircaedt();
+    fields.emplace_back();  // 11 != 10
+    EXPECT_FALSE(is_data_layout_compatible_with_point_xyzircaedt(fields));
+  }
+}


### PR DESCRIPTION
## What

`common/autoware_point_types/include/autoware/point_types/memory.hpp` (the layout-compatibility checks and `PointField` factories) had **zero test coverage**, and its free functions were defined **non-inline in a header** — an ODR hazard if the header is included in more than one translation unit. This is the package's only real logic.

This PR is additive and behavior-preserving:

- **Mark all `memory.hpp` free functions `inline`** — the eight `is_data_layout_compatible_with_point_*` overloads and the four `create_fields_point_*` factories. Removes the non-inline-function-in-header ODR risk. Signatures are unchanged, so the public API is preserved.
- **Add `test/test_memory.cpp`** (new isolated gtest `test_autoware_point_types_memory`) covering:
  - Round-trip: `is_data_layout_compatible_with_point_X(create_fields_point_X())` is true for all four point types.
  - Exact `create_fields_*` contents (field name / offset / datatype / count) for each type.
  - `PointCloud2` overload forwarding (and that an empty cloud is incompatible with every type).
  - Cross-type mismatch (a layout built for one type is rejected by the others).
  - Negative cases that assert a single corrupted field flips the result to `false`: wrong name, wrong offset, wrong datatype, wrong count.
  - Field-count edges (too-few rejected; extra-trailing behavior — see note below).
- **Add `sensor_msgs` as a direct `<depend>`** in `package.xml` (kept sorted): `memory.hpp` includes `sensor_msgs/msg/point_cloud2.hpp` and `sensor_msgs/msg/point_field.hpp` directly, and the new test target links it.

## Characterized (not changed) behavior

The four compatibility checks use **inconsistent field-count guards**: `xyzi`/`xyzirc`/`xyziradrt` use `size() < N` (extra trailing fields are ignored, cloud still accepted), while `xyzircaedt` uses a strict `size() != 10` (extra fields rejected). The `LayoutCompatibleFieldCount` tests pin this **existing** contract so the divergence is documented and any future change is a conscious one. No behavior is modified in this PR.

## Verification

Built and tested in the `autoware:core-devel-jazzy` container: `colcon build` + `colcon test` green, 6/6 test executables pass (36 subtests, 0 failures), and `clang-format --dry-run --Werror` + `ament_cpplint` clean on the changed files.

Refs: autowarefoundation/autoware_core#1096
