### PR TITLE
refactor(autoware_perception_objects_converter): extract pure convert() and reuse autoware_utils_uuid

### DIFF
--- a/perception/autoware_perception_objects_converter/CMakeLists.txt
+++ b/perception/autoware_perception_objects_converter/CMakeLists.txt
@@ -18,6 +18,13 @@ rclcpp_components_register_node(detected_to_predicted_objects_converter
   EXECUTABLE detected_to_predicted_objects_converter_node
 )
 
+## Test
+if(BUILD_TESTING)
+  ament_auto_add_gtest(test_${PROJECT_NAME}
+    test/test_conversion.cpp
+  )
+endif()
+
 ## Install
 autoware_ament_auto_package(
   INSTALL_TO_SHARE

--- a/perception/autoware_perception_objects_converter/package.xml
+++ b/perception/autoware_perception_objects_converter/package.xml
@@ -14,7 +14,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_perception_msgs</depend>
-  <depend>boost</depend>
+  <depend>autoware_utils_uuid</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/perception/autoware_perception_objects_converter/src/conversion.hpp
+++ b/perception/autoware_perception_objects_converter/src/conversion.hpp
@@ -1,0 +1,88 @@
+// Copyright(c) 2025 AutoCore Technology (Nanjing) Co., Ltd. All rights reserved.
+//
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CONVERSION_HPP_
+#define CONVERSION_HPP_
+
+#include <autoware_utils_uuid/uuid_helper.hpp>
+
+#include <autoware_perception_msgs/msg/detected_object.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/predicted_object.hpp>
+#include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <unique_identifier_msgs/msg/uuid.hpp>
+
+#include <functional>
+
+namespace autoware::perception_objects_converter
+{
+/// \brief Type of the callable used to generate a fresh object id per converted object.
+using UuidGenerator = std::function<unique_identifier_msgs::msg::UUID()>;
+
+/// \brief Convert a single DetectedObject into a PredictedObject.
+///
+/// The mapping copies the existence probability, classification and shape, fills the
+/// initial pose from the detected kinematics, and only copies the initial twist when the
+/// detected kinematics report `has_twist`. Acceleration and predicted paths are left at their
+/// message defaults because they are not available in a DetectedObject. The object id is
+/// produced by the supplied \p generate_uuid callable.
+inline autoware_perception_msgs::msg::PredictedObject convert_object(
+  const autoware_perception_msgs::msg::DetectedObject & detected_object,
+  const UuidGenerator & generate_uuid)
+{
+  autoware_perception_msgs::msg::PredictedObject predicted_object;
+
+  predicted_object.object_id = generate_uuid();
+  predicted_object.existence_probability = detected_object.existence_probability;
+  predicted_object.classification = detected_object.classification;
+  predicted_object.shape = detected_object.shape;
+
+  predicted_object.kinematics.initial_pose_with_covariance =
+    detected_object.kinematics.pose_with_covariance;
+  if (detected_object.kinematics.has_twist) {
+    predicted_object.kinematics.initial_twist_with_covariance =
+      detected_object.kinematics.twist_with_covariance;
+  }
+  // Note: acceleration and predicted paths are left default; they are not available in a
+  // DetectedObject.
+
+  return predicted_object;
+}
+
+/// \brief Convert a DetectedObjects message into a PredictedObjects message.
+///
+/// The header is propagated unchanged and each detected object is converted via
+/// convert_object(). The output vector is reserved up front to avoid per-object reallocations.
+/// The \p generate_uuid callable is invoked once per output object to set its object id; whether
+/// those ids are unique or non-zero is the generator's responsibility, not enforced here. It
+/// defaults to autoware_utils_uuid::generate_uuid.
+inline autoware_perception_msgs::msg::PredictedObjects convert(
+  const autoware_perception_msgs::msg::DetectedObjects & detected_objects,
+  const UuidGenerator & generate_uuid = &autoware_utils_uuid::generate_uuid)
+{
+  autoware_perception_msgs::msg::PredictedObjects predicted_objects;
+  predicted_objects.header = detected_objects.header;
+  predicted_objects.objects.reserve(detected_objects.objects.size());
+
+  for (const auto & detected_object : detected_objects.objects) {
+    predicted_objects.objects.emplace_back(convert_object(detected_object, generate_uuid));
+  }
+
+  return predicted_objects;
+}
+}  // namespace autoware::perception_objects_converter
+
+#endif  // CONVERSION_HPP_

--- a/perception/autoware_perception_objects_converter/src/detected_to_predicted_objects_converter.cpp
+++ b/perception/autoware_perception_objects_converter/src/detected_to_predicted_objects_converter.cpp
@@ -16,12 +16,10 @@
 
 #include "detected_to_predicted_objects_converter.hpp"
 
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
+#include "conversion.hpp"
 
-#include <algorithm>
 #include <memory>
+#include <utility>
 
 namespace autoware::perception_objects_converter
 {
@@ -39,59 +37,13 @@ DetectedToPredictedObjectsConverter::DetectedToPredictedObjectsConverter(
     "output/predicted_objects", rclcpp::QoS{10});
 }
 
-// Convert Boost UUID to unique_identifier_msgs::msg::UUID
-unique_identifier_msgs::msg::UUID generateUUIDMsg()
-{
-  boost::uuids::random_generator gen;
-  boost::uuids::uuid uuid = gen();
-
-  unique_identifier_msgs::msg::UUID uuid_msg;
-  std::copy(uuid.begin(), uuid.end(), uuid_msg.uuid.begin());
-
-  return uuid_msg;
-}
-
 void DetectedToPredictedObjectsConverter::detected_objects_callback(
   const autoware_perception_msgs::msg::DetectedObjects::SharedPtr detected_objects_msg)
 {
-  auto predicted_objects_msg = std::make_unique<autoware_perception_msgs::msg::PredictedObjects>();
+  auto predicted_objects_msg = std::make_unique<autoware_perception_msgs::msg::PredictedObjects>(
+    convert(*detected_objects_msg));
 
-  // Copy header
-  predicted_objects_msg->header = detected_objects_msg->header;
-
-  // Convert each detected object to predicted object
-  for (const auto & detected_object : detected_objects_msg->objects) {
-    autoware_perception_msgs::msg::PredictedObject predicted_object;
-
-    // Generate UUID for the object using Boost
-    predicted_object.object_id = generateUUIDMsg();
-
-    // Copy fields from detected object
-    predicted_object.existence_probability = detected_object.existence_probability;
-    predicted_object.classification = detected_object.classification;
-    predicted_object.shape = detected_object.shape;
-
-    // Convert kinematics
-    autoware_perception_msgs::msg::PredictedObjectKinematics predicted_kinematics;
-    predicted_kinematics.initial_pose_with_covariance =
-      detected_object.kinematics.pose_with_covariance;
-
-    if (detected_object.kinematics.has_twist) {
-      predicted_kinematics.initial_twist_with_covariance =
-        detected_object.kinematics.twist_with_covariance;
-    }
-
-    // Note: Acceleration and predicted paths would typically be empty or set to default values
-    // as they are not available in the DetectedObject message
-
-    predicted_object.kinematics = predicted_kinematics;
-
-    // Add to objects array
-    predicted_objects_msg->objects.push_back(predicted_object);
-  }
-
-  // Publish the converted message
-  predicted_objects_pub_->publish(*predicted_objects_msg);
+  predicted_objects_pub_->publish(std::move(predicted_objects_msg));
 }
 }  // namespace autoware::perception_objects_converter
 

--- a/perception/autoware_perception_objects_converter/test/test_conversion.cpp
+++ b/perception/autoware_perception_objects_converter/test/test_conversion.cpp
@@ -1,0 +1,174 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/conversion.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <set>
+#include <vector>
+
+namespace
+{
+using autoware::perception_objects_converter::convert;
+using autoware::perception_objects_converter::convert_object;
+using autoware_perception_msgs::msg::DetectedObject;
+using autoware_perception_msgs::msg::DetectedObjects;
+using autoware_perception_msgs::msg::ObjectClassification;
+
+DetectedObject make_detected_object(const bool has_twist)
+{
+  DetectedObject object;
+  object.existence_probability = 0.75F;
+
+  ObjectClassification classification;
+  classification.label = ObjectClassification::CAR;
+  classification.probability = 0.9F;
+  object.classification.push_back(classification);
+
+  object.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
+  object.shape.dimensions.x = 4.0;
+  object.shape.dimensions.y = 1.8;
+  object.shape.dimensions.z = 1.5;
+
+  object.kinematics.pose_with_covariance.pose.position.x = 1.0;
+  object.kinematics.pose_with_covariance.pose.position.y = 2.0;
+  object.kinematics.pose_with_covariance.pose.position.z = 3.0;
+  object.kinematics.pose_with_covariance.pose.orientation.w = 1.0;
+
+  object.kinematics.has_twist = has_twist;
+  object.kinematics.twist_with_covariance.twist.linear.x = 5.0;
+  object.kinematics.twist_with_covariance.twist.angular.z = 0.5;
+
+  return object;
+}
+
+// Deterministic UUID generator so id assignment can be asserted without relying on randomness.
+autoware::perception_objects_converter::UuidGenerator make_counting_uuid_generator()
+{
+  auto counter = std::make_shared<uint8_t>(0);
+  return [counter]() {
+    unique_identifier_msgs::msg::UUID uuid;
+    uuid.uuid.fill(*counter);
+    ++(*counter);
+    return uuid;
+  };
+}
+}  // namespace
+
+TEST(ConversionTest, HeaderIsPropagated)
+{
+  DetectedObjects detected_objects;
+  detected_objects.header.frame_id = "map";
+  detected_objects.header.stamp.sec = 42;
+  detected_objects.header.stamp.nanosec = 7;
+
+  const auto predicted_objects = convert(detected_objects, make_counting_uuid_generator());
+
+  EXPECT_EQ(predicted_objects.header.frame_id, "map");
+  EXPECT_EQ(predicted_objects.header.stamp.sec, 42);
+  EXPECT_EQ(predicted_objects.header.stamp.nanosec, 7U);
+  EXPECT_TRUE(predicted_objects.objects.empty());
+}
+
+TEST(ConversionTest, FieldMappingIsCopiedExactly)
+{
+  const auto detected = make_detected_object(/*has_twist=*/true);
+
+  const auto predicted = convert_object(detected, make_counting_uuid_generator());
+
+  EXPECT_FLOAT_EQ(predicted.existence_probability, detected.existence_probability);
+
+  ASSERT_EQ(predicted.classification.size(), 1U);
+  EXPECT_EQ(predicted.classification[0].label, ObjectClassification::CAR);
+  EXPECT_FLOAT_EQ(predicted.classification[0].probability, 0.9F);
+
+  EXPECT_EQ(predicted.shape.type, autoware_perception_msgs::msg::Shape::BOUNDING_BOX);
+  EXPECT_DOUBLE_EQ(predicted.shape.dimensions.x, 4.0);
+  EXPECT_DOUBLE_EQ(predicted.shape.dimensions.y, 1.8);
+  EXPECT_DOUBLE_EQ(predicted.shape.dimensions.z, 1.5);
+
+  EXPECT_DOUBLE_EQ(predicted.kinematics.initial_pose_with_covariance.pose.position.x, 1.0);
+  EXPECT_DOUBLE_EQ(predicted.kinematics.initial_pose_with_covariance.pose.position.y, 2.0);
+  EXPECT_DOUBLE_EQ(predicted.kinematics.initial_pose_with_covariance.pose.position.z, 3.0);
+  EXPECT_DOUBLE_EQ(predicted.kinematics.initial_pose_with_covariance.pose.orientation.w, 1.0);
+}
+
+TEST(ConversionTest, TwistCopiedWhenHasTwistIsTrue)
+{
+  const auto detected = make_detected_object(/*has_twist=*/true);
+
+  const auto predicted = convert_object(detected, make_counting_uuid_generator());
+
+  EXPECT_DOUBLE_EQ(predicted.kinematics.initial_twist_with_covariance.twist.linear.x, 5.0);
+  EXPECT_DOUBLE_EQ(predicted.kinematics.initial_twist_with_covariance.twist.angular.z, 0.5);
+}
+
+TEST(ConversionTest, TwistLeftDefaultWhenHasTwistIsFalse)
+{
+  const auto detected = make_detected_object(/*has_twist=*/false);
+
+  const auto predicted = convert_object(detected, make_counting_uuid_generator());
+
+  // has_twist=false => twist must remain at the message default (all zeros), not the detected one.
+  EXPECT_DOUBLE_EQ(predicted.kinematics.initial_twist_with_covariance.twist.linear.x, 0.0);
+  EXPECT_DOUBLE_EQ(predicted.kinematics.initial_twist_with_covariance.twist.angular.z, 0.0);
+}
+
+TEST(ConversionTest, EveryObjectGetsADistinctUuid)
+{
+  DetectedObjects detected_objects;
+  detected_objects.objects.push_back(make_detected_object(/*has_twist=*/true));
+  detected_objects.objects.push_back(make_detected_object(/*has_twist=*/false));
+  detected_objects.objects.push_back(make_detected_object(/*has_twist=*/true));
+
+  const auto predicted_objects = convert(detected_objects, make_counting_uuid_generator());
+
+  ASSERT_EQ(predicted_objects.objects.size(), 3U);
+
+  std::set<std::array<uint8_t, 16>> seen;
+  for (const auto & object : predicted_objects.objects) {
+    seen.insert(object.object_id.uuid);
+  }
+  EXPECT_EQ(seen.size(), 3U) << "Each converted object must receive a distinct UUID";
+}
+
+TEST(ConversionTest, DefaultGeneratorProducesNonZeroDistinctUuids)
+{
+  DetectedObjects detected_objects;
+  detected_objects.objects.push_back(make_detected_object(/*has_twist=*/true));
+  detected_objects.objects.push_back(make_detected_object(/*has_twist=*/true));
+
+  // Exercise the production default generator (autoware_utils_uuid::generate_uuid).
+  const auto predicted_objects = convert(detected_objects);
+
+  ASSERT_EQ(predicted_objects.objects.size(), 2U);
+
+  const std::array<uint8_t, 16> zero_uuid{};
+  for (const auto & object : predicted_objects.objects) {
+    EXPECT_NE(object.object_id.uuid, zero_uuid) << "UUID must be non-zero";
+  }
+  EXPECT_NE(
+    predicted_objects.objects[0].object_id.uuid, predicted_objects.objects[1].object_id.uuid)
+    << "Distinct objects should receive distinct UUIDs";
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## What

Implements the recommended PR for `perception/autoware_perception_objects_converter` from the Core quality campaign backlog.

- Extract the `DetectedObject` -> `PredictedObject` mapping into a pure, ROS-free seam in a new internal header `src/conversion.hpp`:
  - `convert_object(const DetectedObject &, const UuidGenerator &)` maps a single object.
  - `convert(const DetectedObjects &, generate_uuid = autoware_utils_uuid::generate_uuid)` maps the whole message, propagates the header, and reserves the output vector.
  - The UUID source is an injectable `std::function` callable so tests can assert id assignment deterministically; it defaults to the production generator so node behavior is unchanged.
- Replace the bespoke `generateUUIDMsg()` (boost `random_generator` + `std::copy`, an external-linkage free function risking ODR/symbol collisions) with `autoware_utils_uuid::generate_uuid()`, drop the three `boost/uuid` includes, and swap the `boost` dependency for `autoware_utils_uuid` in `package.xml` (kept sorted).
- Reserve the output `objects` vector and `emplace_back` the converted objects (removing the per-object `push_back` copy and the intermediate `PredictedObjectKinematics` copy); publish via `std::move` of the `unique_ptr` for zero-copy intra-process delivery.
- The subscription callback now just take-converts-and-publishes.
- Add a gtest (`test/test_conversion.cpp`) covering header propagation, exact field mapping, both `has_twist` branches, distinct-UUID-per-object, and the production default generator (non-zero, distinct UUIDs).

## Why

The package re-implemented UUID generation already in `autoware_utils_uuid`, had no pure seam to unit test the field mapping, had zero functional tests, and copied each object unnecessarily on the per-object hot path. This is an ABI-neutral, behavior-preserving testability/dedup/perf cleanup.

## Verification

Built and tested in the `autoware:core-devel-jazzy` devel container: `colcon build` OK; `colcon test` 22 tests, 0 failures (6 new gtest cases + copyright/cppcheck/lint_cmake/xmllint). `ament_cpplint` and clang-format clean on all changed files.

Refs: autowarefoundation/autoware_core#1096
