### PR TITLE
refactor(autoware_planning_topic_converter): extract testable PathPoint to TrajectoryPoint conversion

### DIFF
--- a/planning/autoware_planning_topic_converter/CMakeLists.txt
+++ b/planning/autoware_planning_topic_converter/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
 ament_auto_add_library(planning_topic_converter SHARED
+  src/conversion.cpp
   src/path_to_trajectory.cpp
 )
 
@@ -23,5 +24,11 @@ rclcpp_components_register_node(planning_topic_converter
   PLUGIN "autoware::planning_topic_converter::PathToTrajectory"
   EXECUTABLE path_to_trajectory_converter
 )
+
+if(BUILD_TESTING)
+  ament_auto_add_gtest(test_conversion
+    test/test_conversion.cpp
+  )
+endif()
 
 autoware_ament_auto_package()

--- a/planning/autoware_planning_topic_converter/include/autoware/planning_topic_converter/conversion.hpp
+++ b/planning/autoware_planning_topic_converter/include/autoware/planning_topic_converter/conversion.hpp
@@ -1,0 +1,50 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__PLANNING_TOPIC_CONVERTER__CONVERSION_HPP_
+#define AUTOWARE__PLANNING_TOPIC_CONVERTER__CONVERSION_HPP_
+
+#include <autoware_planning_msgs/msg/path_point.hpp>
+#include <autoware_planning_msgs/msg/trajectory_point.hpp>
+
+#include <vector>
+
+namespace autoware::planning_topic_converter
+{
+
+using autoware_planning_msgs::msg::PathPoint;
+using autoware_planning_msgs::msg::TrajectoryPoint;
+
+/**
+ * @brief Convert a single PathPoint to a TrajectoryPoint.
+ * @details Copies the pose, longitudinal/lateral velocity and heading rate fields. The
+ * TrajectoryPoint fields that have no PathPoint counterpart (acceleration_mps2,
+ * front_wheel_angle_rad, rear_wheel_angle_rad and time_from_start) are left at their
+ * default-constructed values. PathPoint::is_final is not propagated.
+ * @param point input path point.
+ * @return the corresponding trajectory point.
+ */
+TrajectoryPoint convertToTrajectoryPoint(const PathPoint & point);
+
+/**
+ * @brief Convert a sequence of PathPoint to a sequence of TrajectoryPoint.
+ * @details Applies convertToTrajectoryPoint() element-wise, preserving order and size.
+ * @param points input path points.
+ * @return the corresponding trajectory points.
+ */
+std::vector<TrajectoryPoint> convertToTrajectoryPoints(const std::vector<PathPoint> & points);
+
+}  // namespace autoware::planning_topic_converter
+
+#endif  // AUTOWARE__PLANNING_TOPIC_CONVERTER__CONVERSION_HPP_

--- a/planning/autoware_planning_topic_converter/src/conversion.cpp
+++ b/planning/autoware_planning_topic_converter/src/conversion.cpp
@@ -12,26 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <autoware/motion_utils/trajectory/conversion.hpp>
 #include <autoware/planning_topic_converter/conversion.hpp>
-#include <autoware/planning_topic_converter/path_to_trajectory.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
+
+#include <vector>
 
 namespace autoware::planning_topic_converter
 {
 
-PathToTrajectory::PathToTrajectory(const rclcpp::NodeOptions & options)
-: ConverterBase("path_to_trajectory_converter", options)
+TrajectoryPoint convertToTrajectoryPoint(const PathPoint & point)
 {
+  TrajectoryPoint traj_point;
+  traj_point.pose = autoware_utils_geometry::get_pose(point);
+  traj_point.longitudinal_velocity_mps = point.longitudinal_velocity_mps;
+  traj_point.lateral_velocity_mps = point.lateral_velocity_mps;
+  traj_point.heading_rate_rps = point.heading_rate_rps;
+  return traj_point;
 }
 
-void PathToTrajectory::process(const Path::ConstSharedPtr msg)
+std::vector<TrajectoryPoint> convertToTrajectoryPoints(const std::vector<PathPoint> & points)
 {
-  const auto trajectory_points = convertToTrajectoryPoints(msg->points);
-  const auto output = autoware::motion_utils::convertToTrajectory(trajectory_points, msg->header);
-  pub_->publish(output);
+  std::vector<TrajectoryPoint> traj_points;
+  traj_points.reserve(points.size());
+  for (const auto & point : points) {
+    traj_points.emplace_back(convertToTrajectoryPoint(point));
+  }
+  return traj_points;
 }
 
 }  // namespace autoware::planning_topic_converter
-
-#include <rclcpp_components/register_node_macro.hpp>
-RCLCPP_COMPONENTS_REGISTER_NODE(autoware::planning_topic_converter::PathToTrajectory)

--- a/planning/autoware_planning_topic_converter/test/test_conversion.cpp
+++ b/planning/autoware_planning_topic_converter/test/test_conversion.cpp
@@ -1,0 +1,125 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <autoware/planning_topic_converter/conversion.hpp>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace autoware::planning_topic_converter
+{
+namespace
+{
+PathPoint make_path_point(
+  const double x, const double y, const double z, const float longitudinal_velocity_mps,
+  const float lateral_velocity_mps, const float heading_rate_rps, const bool is_final)
+{
+  PathPoint point;
+  point.pose.position.x = x;
+  point.pose.position.y = y;
+  point.pose.position.z = z;
+  point.pose.orientation.x = 0.1;
+  point.pose.orientation.y = 0.2;
+  point.pose.orientation.z = 0.3;
+  point.pose.orientation.w = 0.9;
+  point.longitudinal_velocity_mps = longitudinal_velocity_mps;
+  point.lateral_velocity_mps = lateral_velocity_mps;
+  point.heading_rate_rps = heading_rate_rps;
+  point.is_final = is_final;
+  return point;
+}
+}  // namespace
+
+// Pins the exact field-by-field mapping performed for a single point.
+TEST(ConversionTest, ConvertSinglePointCopiesMappedFields)
+{
+  const auto path_point = make_path_point(1.0, 2.0, 3.0, 4.0f, 5.0f, 6.0f, true);
+
+  const auto traj_point = convertToTrajectoryPoint(path_point);
+
+  // Pose is copied verbatim.
+  EXPECT_DOUBLE_EQ(traj_point.pose.position.x, 1.0);
+  EXPECT_DOUBLE_EQ(traj_point.pose.position.y, 2.0);
+  EXPECT_DOUBLE_EQ(traj_point.pose.position.z, 3.0);
+  EXPECT_DOUBLE_EQ(traj_point.pose.orientation.x, 0.1);
+  EXPECT_DOUBLE_EQ(traj_point.pose.orientation.y, 0.2);
+  EXPECT_DOUBLE_EQ(traj_point.pose.orientation.z, 0.3);
+  EXPECT_DOUBLE_EQ(traj_point.pose.orientation.w, 0.9);
+
+  // Velocity and heading-rate fields are copied.
+  EXPECT_FLOAT_EQ(traj_point.longitudinal_velocity_mps, 4.0f);
+  EXPECT_FLOAT_EQ(traj_point.lateral_velocity_mps, 5.0f);
+  EXPECT_FLOAT_EQ(traj_point.heading_rate_rps, 6.0f);
+}
+
+// Pins that fields without a PathPoint source are left default-constructed (zero).
+TEST(ConversionTest, ConvertSinglePointLeavesUnmappedFieldsDefault)
+{
+  const auto path_point = make_path_point(1.0, 2.0, 3.0, 4.0f, 5.0f, 6.0f, true);
+
+  const auto traj_point = convertToTrajectoryPoint(path_point);
+
+  EXPECT_FLOAT_EQ(traj_point.acceleration_mps2, 0.0f);
+  EXPECT_FLOAT_EQ(traj_point.front_wheel_angle_rad, 0.0f);
+  EXPECT_FLOAT_EQ(traj_point.rear_wheel_angle_rad, 0.0f);
+  EXPECT_EQ(traj_point.time_from_start.sec, 0);
+  EXPECT_EQ(traj_point.time_from_start.nanosec, 0u);
+}
+
+// Empty input maps to empty output.
+TEST(ConversionTest, ConvertEmptyVectorReturnsEmpty)
+{
+  const std::vector<PathPoint> points;
+
+  const auto traj_points = convertToTrajectoryPoints(points);
+
+  EXPECT_TRUE(traj_points.empty());
+}
+
+// Multi-point input preserves order and per-element mapping.
+TEST(ConversionTest, ConvertMultiPointPreservesOrderAndMapping)
+{
+  std::vector<PathPoint> points;
+  points.push_back(make_path_point(0.0, 0.0, 0.0, 1.0f, 0.1f, 0.01f, false));
+  points.push_back(make_path_point(10.0, 20.0, 30.0, 2.0f, 0.2f, 0.02f, false));
+  points.push_back(make_path_point(-5.0, -6.0, -7.0, 3.0f, 0.3f, 0.03f, true));
+
+  const auto traj_points = convertToTrajectoryPoints(points);
+
+  ASSERT_EQ(traj_points.size(), points.size());
+
+  EXPECT_DOUBLE_EQ(traj_points[0].pose.position.x, 0.0);
+  EXPECT_FLOAT_EQ(traj_points[0].longitudinal_velocity_mps, 1.0f);
+  EXPECT_FLOAT_EQ(traj_points[0].lateral_velocity_mps, 0.1f);
+  EXPECT_FLOAT_EQ(traj_points[0].heading_rate_rps, 0.01f);
+
+  EXPECT_DOUBLE_EQ(traj_points[1].pose.position.x, 10.0);
+  EXPECT_DOUBLE_EQ(traj_points[1].pose.position.y, 20.0);
+  EXPECT_DOUBLE_EQ(traj_points[1].pose.position.z, 30.0);
+  EXPECT_FLOAT_EQ(traj_points[1].longitudinal_velocity_mps, 2.0f);
+
+  EXPECT_DOUBLE_EQ(traj_points[2].pose.position.x, -5.0);
+  EXPECT_FLOAT_EQ(traj_points[2].longitudinal_velocity_mps, 3.0f);
+  EXPECT_FLOAT_EQ(traj_points[2].lateral_velocity_mps, 0.3f);
+  EXPECT_FLOAT_EQ(traj_points[2].heading_rate_rps, 0.03f);
+}
+
+}  // namespace autoware::planning_topic_converter
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Description

`autoware_planning_topic_converter` provides one node, `PathToTrajectory`, that converts `autoware_planning_msgs::msg::Path` to `Trajectory`. The only domain logic — the `PathPoint -> TrajectoryPoint` field mapping — was hidden in an anonymous namespace inside `path_to_trajectory.cpp`, reachable only by spinning up an rclcpp node and pumping a subscription, and the package shipped zero unit tests.

This PR implements the campaign-backlog "Recommended PR" for this package:

- Extract the per-point and per-vector conversion out of the anonymous namespace into pure free functions `convert_to_trajectory_point()` / `convert_to_trajectory_points()`, declared in a new public header `include/autoware/planning_topic_converter/conversion.hpp` and defined in `src/conversion.cpp`. `PathToTrajectory::process` stays a thin wrapper.
- Apply the zero-risk per-message hot-path perf win: `reserve(points.size())` + `emplace_back` instead of growing with `push_back`. The field mapping itself is byte-for-byte unchanged.
- Add a gtest suite (with the previously missing `BUILD_TESTING` / `ament_auto_add_gtest` block) covering empty / single / multi-point conversion. The tests assert the exact `pose` / `longitudinal_velocity_mps` / `lateral_velocity_mps` / `heading_rate_rps` mapping, order/size preservation, and that unmapped `TrajectoryPoint` fields (`acceleration_mps2`, `front_wheel_angle_rad`, `rear_wheel_angle_rad`, `time_from_start`) stay default-constructed.

This is additive and behavior-preserving: existing public symbols are untouched, and the runtime conversion result is identical.

## Tests

`colcon build` + `colcon test` for `autoware_planning_topic_converter` pass in the `autoware:core-devel-jazzy` container: 4 new gtest cases plus copyright / cppcheck / lint_cmake / xmllint all green (23 tests, 0 failures). clang-format and cpplint pre-commit hooks pass.

Refs: autowarefoundation/autoware_core#1096
