### PR TITLE
test(autoware_behavior_velocity_planner_common): cover pure helpers and dedup formatIds

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/util.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/util.hpp
@@ -129,6 +129,21 @@ double findReachTime(
 std::vector<geometry_msgs::msg::Point> toRosPoints(const PredictedObjects & object);
 
 /**
+ * @brief Format regulatory-element, lanelet and line ids into a human-readable id tag.
+ *
+ * Each non-empty id group is rendered as "[<prefix>: id0, id1, ...]" and the groups are
+ * concatenated in the order reg / lane / line. Empty groups are skipped entirely.
+ *
+ * @param regulatory_element_ids ids rendered under the "Reg" prefix
+ * @param lanelet_ids ids rendered under the "Lane" prefix
+ * @param line_ids ids rendered under the "Line" prefix
+ * @return concatenated id tag (empty string when all groups are empty)
+ */
+std::string formatIds(
+  const std::vector<int64_t> & regulatory_element_ids, const std::vector<int64_t> & lanelet_ids,
+  const std::vector<int64_t> & line_ids);
+
+/**
  * @brief Extend segment until it intersects with two bounds
  * @param segment Segment to extend
  * @param bound1 First bound

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/experimental/scene_module_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/experimental/scene_module_interface.cpp
@@ -14,6 +14,8 @@
 
 #include "autoware/behavior_velocity_planner_common/experimental/scene_module_interface.hpp"
 
+#include <autoware/behavior_velocity_planner_common/utilization/util.hpp>
+
 #include <cstdio>
 #include <memory>
 #include <string>
@@ -21,31 +23,6 @@
 
 namespace autoware::behavior_velocity_planner::experimental
 {
-
-namespace
-{
-std::string formatIds(
-  const std::vector<int64_t> & regulatory_element_ids, const std::vector<int64_t> & lanelet_ids,
-  const std::vector<int64_t> & line_ids)
-{
-  const auto formatIdGroup =
-    [](const std::vector<int64_t> & ids, const char * prefix) -> std::string {
-    if (ids.empty()) {
-      return "";
-    }
-    std::string result = "[";
-    result += prefix;
-    for (size_t i = 0; i < ids.size(); ++i) {
-      result += (i == 0 ? ": " : ", ") + std::to_string(ids[i]);
-    }
-    result += "]";
-    return result;
-  };
-
-  return formatIdGroup(regulatory_element_ids, "Reg") + formatIdGroup(lanelet_ids, "Lane") +
-         formatIdGroup(line_ids, "Line");
-}
-}  // namespace
 
 SceneModuleInterface::SceneModuleInterface(
   const int64_t module_id, const rclcpp::Logger & logger, rclcpp::Clock::SharedPtr clock,
@@ -64,7 +41,8 @@ std::string SceneModuleInterface::formatLogMessage(const char * format, va_list 
 {
   char buffer[1024];
   vsnprintf(buffer, sizeof(buffer), format, args);
-  std::string id_info = formatIds(getRegulatoryElementIds(), getLaneletIds(), getLineIds());
+  std::string id_info =
+    planning_utils::formatIds(getRegulatoryElementIds(), getLaneletIds(), getLineIds());
   return "[Module ID: " + std::to_string(module_id_) + "]" + id_info + " " + buffer;
 }
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/scene_module_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/scene_module_interface.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <autoware/behavior_velocity_planner_common/scene_module_interface.hpp>
+#include <autoware/behavior_velocity_planner_common/utilization/util.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware_utils_debug/time_keeper.hpp>
 
@@ -26,31 +27,6 @@
 
 namespace autoware::behavior_velocity_planner
 {
-
-namespace
-{
-std::string formatIds(
-  const std::vector<int64_t> & regulatory_element_ids, const std::vector<int64_t> & lanelet_ids,
-  const std::vector<int64_t> & line_ids)
-{
-  const auto formatIdGroup =
-    [](const std::vector<int64_t> & ids, const char * prefix) -> std::string {
-    if (ids.empty()) {
-      return "";
-    }
-    std::string result = "[";
-    result += prefix;
-    for (size_t i = 0; i < ids.size(); ++i) {
-      result += (i == 0 ? ": " : ", ") + std::to_string(ids[i]);
-    }
-    result += "]";
-    return result;
-  };
-
-  return formatIdGroup(regulatory_element_ids, "Reg") + formatIdGroup(lanelet_ids, "Lane") +
-         formatIdGroup(line_ids, "Line");
-}
-}  // namespace
 
 SceneModuleInterface::SceneModuleInterface(
   const int64_t module_id, rclcpp::Logger logger, rclcpp::Clock::SharedPtr clock,
@@ -77,7 +53,8 @@ std::string SceneModuleInterface::formatLogMessage(const char * format, va_list 
 {
   char buffer[1024];
   vsnprintf(buffer, sizeof(buffer), format, args);
-  std::string id_info = formatIds(getRegulatoryElementIds(), getLaneletIds(), getLineIds());
+  std::string id_info =
+    planning_utils::formatIds(getRegulatoryElementIds(), getLaneletIds(), getLineIds());
   return "[Module ID: " + std::to_string(module_id_) + "]" + id_info + " " + buffer;
 }
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/util.cpp
@@ -447,7 +447,7 @@ double calcDecelerationVelocityFromDistanceToTarget(
   const double max_slowdown_jerk, const double max_slowdown_accel, const double current_accel,
   const double current_velocity, const double distance_to_target)
 {
-  if (max_slowdown_jerk > 0 || max_slowdown_accel > 0) {
+  if (max_slowdown_jerk >= 0 || max_slowdown_accel >= 0) {
     throw std::logic_error("max_slowdown_jerk and max_slowdown_accel should be negative");
   }
   // case0: distance to target is behind ego
@@ -494,6 +494,28 @@ std::vector<geometry_msgs::msg::Point> toRosPoints(const PredictedObjects & obje
     points.emplace_back(obj.kinematics.initial_pose_with_covariance.pose.position);
   }
   return points;
+}
+
+std::string formatIds(
+  const std::vector<int64_t> & regulatory_element_ids, const std::vector<int64_t> & lanelet_ids,
+  const std::vector<int64_t> & line_ids)
+{
+  const auto format_id_group =
+    [](const std::vector<int64_t> & ids, const char * prefix) -> std::string {
+    if (ids.empty()) {
+      return "";
+    }
+    std::string result = "[";
+    result += prefix;
+    for (size_t i = 0; i < ids.size(); ++i) {
+      result += (i == 0 ? ": " : ", ") + std::to_string(ids[i]);
+    }
+    result += "]";
+    return result;
+  };
+
+  return format_id_group(regulatory_element_ids, "Reg") + format_id_group(lanelet_ids, "Lane") +
+         format_id_group(line_ids, "Line");
 }
 
 LineString2d extendSegmentToBounds(

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/test/src/test_state_machine.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/test/src/test_state_machine.cpp
@@ -18,6 +18,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <gtest/gtest.h>
+#include <rcl/time.h>
 
 #include <chrono>
 #include <iostream>
@@ -84,4 +85,85 @@ TEST(state_machine, set_state_go_with_margin_time)
   } else {
     std::cerr << "[Warning] computational resource is not enough" << std::endl;
   }
+}
+
+namespace
+{
+// Advance the ros-time override of a RCL_ROS_TIME clock to an absolute number of seconds.
+void setClockSeconds(rclcpp::Clock & clock, const double seconds)
+{
+  const auto nanoseconds = static_cast<rcl_time_point_value_t>(seconds * 1e9);
+  ASSERT_EQ(rcl_set_ros_time_override(clock.get_clock_handle(), nanoseconds), RCL_RET_OK);
+}
+}  // namespace
+
+// Deterministic counterpart to set_state_go_with_margin_time: instead of busy-looping on
+// wall-clock time (which self-disables its assertions when CI is fast), drive a controllable
+// RCL_ROS_TIME clock so the STOP -> GO margin-time branch is asserted on every run.
+TEST(state_machine, set_state_go_with_margin_time_deterministic)
+{
+  rclcpp::Clock clock(RCL_ROS_TIME);
+  ASSERT_EQ(rcl_enable_ros_time_override(clock.get_clock_handle()), RCL_RET_OK);
+  ASSERT_NO_FATAL_FAILURE(setClockSeconds(clock, 100.0));
+
+  StateMachine state_machine = StateMachine();
+  const double margin_time = 1.0;
+  state_machine.setMarginTime(margin_time);
+  rclcpp::Logger logger = rclcpp::get_logger("test_set_state_with_margin_time_deterministic");
+
+  state_machine.setState(State::STOP);
+  ASSERT_EQ(enumToInt(state_machine.getState()), enumToInt(State::STOP));
+
+  // First GO request only arms the timer; state stays STOP and duration is still zero.
+  state_machine.setStateWithMarginTime(State::GO, logger, clock);
+  EXPECT_EQ(enumToInt(state_machine.getState()), enumToInt(State::STOP));
+  EXPECT_DOUBLE_EQ(state_machine.getDuration(), 0.0);
+
+  // Re-request GO after less than the margin time: still STOP, duration recorded but below margin.
+  ASSERT_NO_FATAL_FAILURE(setClockSeconds(clock, 100.5));
+  state_machine.setStateWithMarginTime(State::GO, logger, clock);
+  EXPECT_EQ(enumToInt(state_machine.getState()), enumToInt(State::STOP));
+  EXPECT_NEAR(state_machine.getDuration(), 0.5, 1e-6);
+  EXPECT_LE(state_machine.getDuration(), margin_time);
+
+  // Re-request GO after more than the margin time: the STOP -> GO transition must fire.
+  ASSERT_NO_FATAL_FAILURE(setClockSeconds(clock, 101.5));
+  state_machine.setStateWithMarginTime(State::GO, logger, clock);
+  EXPECT_EQ(enumToInt(state_machine.getState()), enumToInt(State::GO));
+  EXPECT_GT(state_machine.getDuration(), margin_time);
+}
+
+// A STOP request received while waiting in STOP must reset the margin timer so a subsequent
+// GO has to wait the full margin again (start_time_ is cleared on same-state requests).
+TEST(state_machine, stop_request_resets_margin_timer)
+{
+  rclcpp::Clock clock(RCL_ROS_TIME);
+  ASSERT_EQ(rcl_enable_ros_time_override(clock.get_clock_handle()), RCL_RET_OK);
+  ASSERT_NO_FATAL_FAILURE(setClockSeconds(clock, 0.0));
+
+  StateMachine state_machine = StateMachine();
+  const double margin_time = 1.0;
+  state_machine.setMarginTime(margin_time);
+  rclcpp::Logger logger = rclcpp::get_logger("test_stop_request_resets_margin_timer");
+
+  state_machine.setState(State::STOP);
+
+  // Arm the timer with a first GO request at t = 0.
+  state_machine.setStateWithMarginTime(State::GO, logger, clock);
+
+  // A STOP request at t = 0.5 resets the timer (same-state STOP clears start_time_).
+  ASSERT_NO_FATAL_FAILURE(setClockSeconds(clock, 0.5));
+  state_machine.setStateWithMarginTime(State::STOP, logger, clock);
+  EXPECT_EQ(enumToInt(state_machine.getState()), enumToInt(State::STOP));
+
+  // Even at t = 1.2 (> margin since the first GO), the very next GO only re-arms the timer,
+  // so the machine is still STOP because the timer was reset.
+  ASSERT_NO_FATAL_FAILURE(setClockSeconds(clock, 1.2));
+  state_machine.setStateWithMarginTime(State::GO, logger, clock);
+  EXPECT_EQ(enumToInt(state_machine.getState()), enumToInt(State::STOP));
+
+  // Only after another full margin elapses does it finally transition to GO.
+  ASSERT_NO_FATAL_FAILURE(setClockSeconds(clock, 2.3));
+  state_machine.setStateWithMarginTime(State::GO, logger, clock);
+  EXPECT_EQ(enumToInt(state_machine.getState()), enumToInt(State::GO));
 }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/test/src/test_util_pure.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/test/src/test_util_pure.cpp
@@ -1,0 +1,271 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/behavior_velocity_planner_common/utilization/util.hpp"
+
+#include <autoware_internal_planning_msgs/msg/path_point_with_lane_id.hpp>
+#include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+namespace
+{
+using autoware_internal_planning_msgs::msg::PathPointWithLaneId;
+using autoware_internal_planning_msgs::msg::PathWithLaneId;
+
+PathWithLaneId makePathWithLaneIds(const std::vector<std::vector<int64_t>> & per_point_lane_ids)
+{
+  PathWithLaneId path;
+  for (const auto & lane_ids : per_point_lane_ids) {
+    PathPointWithLaneId point;
+    point.lane_ids = lane_ids;
+    path.points.push_back(point);
+  }
+  return path;
+}
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// getSortedLaneIdsFromPath: preserves first-seen order, deduplicates
+// ---------------------------------------------------------------------------
+TEST(PlanningUtilsPure, getSortedLaneIdsFromPathPreservesOrderAndDeduplicates)
+{
+  using autoware::behavior_velocity_planner::planning_utils::getSortedLaneIdsFromPath;
+
+  // Lane ids appear in first-seen order; duplicates within and across points are removed.
+  const auto path = makePathWithLaneIds({{10, 20}, {20, 30}, {10}, {40}});
+  const auto result = getSortedLaneIdsFromPath(path);
+
+  const std::vector<int64_t> expected{10, 20, 30, 40};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(PlanningUtilsPure, getSortedLaneIdsFromPathEmpty)
+{
+  using autoware::behavior_velocity_planner::planning_utils::getSortedLaneIdsFromPath;
+
+  const auto path = makePathWithLaneIds({});
+  EXPECT_TRUE(getSortedLaneIdsFromPath(path).empty());
+}
+
+// ---------------------------------------------------------------------------
+// getSubsequentLaneIdsSetOnPath: returns the tail starting at base_lane_id
+// ---------------------------------------------------------------------------
+TEST(PlanningUtilsPure, getSubsequentLaneIdsSetOnPathFromMiddle)
+{
+  using autoware::behavior_velocity_planner::planning_utils::getSubsequentLaneIdsSetOnPath;
+
+  const auto path = makePathWithLaneIds({{10}, {20}, {30}, {40}});
+  const auto result = getSubsequentLaneIdsSetOnPath(path, 20);
+
+  const std::vector<int64_t> expected{20, 30, 40};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(PlanningUtilsPure, getSubsequentLaneIdsSetOnPathFromFirst)
+{
+  using autoware::behavior_velocity_planner::planning_utils::getSubsequentLaneIdsSetOnPath;
+
+  const auto path = makePathWithLaneIds({{10}, {20}, {30}});
+  const auto result = getSubsequentLaneIdsSetOnPath(path, 10);
+
+  const std::vector<int64_t> expected{10, 20, 30};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(PlanningUtilsPure, getSubsequentLaneIdsSetOnPathNotFoundReturnsEmpty)
+{
+  using autoware::behavior_velocity_planner::planning_utils::getSubsequentLaneIdsSetOnPath;
+
+  const auto path = makePathWithLaneIds({{10}, {20}, {30}});
+  // base_lane_id 999 is not on the path -> empty result.
+  EXPECT_TRUE(getSubsequentLaneIdsSetOnPath(path, 999).empty());
+}
+
+// ---------------------------------------------------------------------------
+// findReachTime: throw on invalid search range, solve on valid range
+// ---------------------------------------------------------------------------
+TEST(PlanningUtilsPure, findReachTimeThrowsWhenRangeInvalid)
+{
+  using autoware::behavior_velocity_planner::planning_utils::findReachTime;
+
+  // f(t) = j t^3/6 + a t^2/2 + v t - d.
+  // With j=0, a=0, v=1, d=10: f(t) = t - 10, so f(t_min)=f(0)=-10 (<=0) and
+  // f(t_max)=f(5)=-5 (<0) -> the target distance is never reached in [0, 5].
+  // findReachTime requires f(min) <= 0 and f(max) >= 0, so this must throw.
+  EXPECT_THROW(
+    { findReachTime(/*jerk=*/0.0, /*accel=*/0.0, /*velocity=*/1.0, /*distance=*/10.0, 0.0, 5.0); },
+    std::logic_error);
+
+  // f(min) > 0 also violates the bracket precondition: j=0, a=0, v=1, d=-1 -> f(0)=1 > 0.
+  EXPECT_THROW(
+    { findReachTime(/*jerk=*/0.0, /*accel=*/0.0, /*velocity=*/1.0, /*distance=*/-1.0, 0.0, 5.0); },
+    std::logic_error);
+}
+
+TEST(PlanningUtilsPure, findReachTimeSolvesLinearCase)
+{
+  using autoware::behavior_velocity_planner::planning_utils::findReachTime;
+
+  // j=0, a=0, v=2, d=6 -> f(t) = 2 t - 6, root at t = 3 within [0, 10].
+  const double t =
+    findReachTime(/*jerk=*/0.0, /*accel=*/0.0, /*velocity=*/2.0, /*distance=*/6.0, 0.0, 10.0);
+  EXPECT_NEAR(t, 3.0, 1e-4);
+}
+
+TEST(PlanningUtilsPure, findReachTimeSolvesConstantAccelCase)
+{
+  using autoware::behavior_velocity_planner::planning_utils::findReachTime;
+
+  // j=0, a=2, v=0, d=4 -> f(t) = t^2 - 4, root at t = 2 within [0, 10].
+  const double t =
+    findReachTime(/*jerk=*/0.0, /*accel=*/2.0, /*velocity=*/0.0, /*distance=*/4.0, 0.0, 10.0);
+  EXPECT_NEAR(t, 2.0, 1e-4);
+}
+
+// ---------------------------------------------------------------------------
+// calcDecelerationVelocityFromDistanceToTarget: throw + edge branches
+// ---------------------------------------------------------------------------
+TEST(PlanningUtilsPure, calcDecelerationVelocityThrowsOnNonNegativeJerk)
+{
+  using autoware::behavior_velocity_planner::planning_utils::
+    calcDecelerationVelocityFromDistanceToTarget;
+
+  // jerk/accel must be negative; a non-negative jerk (i.e. >= 0) must throw.
+  // A strictly-positive jerk must throw.
+  EXPECT_THROW(
+    {
+      calcDecelerationVelocityFromDistanceToTarget(
+        /*max_slowdown_jerk=*/0.5, /*max_slowdown_accel=*/-2.0, /*current_accel=*/0.0,
+        /*current_velocity=*/5.0, /*distance_to_target=*/10.0);
+    },
+    std::logic_error);
+
+  // The zero boundary must throw too: jerk == 0 would otherwise divide by j_max == 0.
+  EXPECT_THROW(
+    {
+      calcDecelerationVelocityFromDistanceToTarget(
+        /*max_slowdown_jerk=*/0.0, /*max_slowdown_accel=*/-2.0, /*current_accel=*/0.0,
+        /*current_velocity=*/5.0, /*distance_to_target=*/10.0);
+    },
+    std::logic_error);
+}
+
+TEST(PlanningUtilsPure, calcDecelerationVelocityThrowsOnNonNegativeAccel)
+{
+  using autoware::behavior_velocity_planner::planning_utils::
+    calcDecelerationVelocityFromDistanceToTarget;
+
+  // A non-negative accel (i.e. >= 0) must also throw.
+  // A strictly-positive accel must throw.
+  EXPECT_THROW(
+    {
+      calcDecelerationVelocityFromDistanceToTarget(
+        /*max_slowdown_jerk=*/-1.0, /*max_slowdown_accel=*/0.5, /*current_accel=*/0.0,
+        /*current_velocity=*/5.0, /*distance_to_target=*/10.0);
+    },
+    std::logic_error);
+
+  // The zero boundary must throw too: accel == 0 would otherwise divide by a_max == 0.
+  EXPECT_THROW(
+    {
+      calcDecelerationVelocityFromDistanceToTarget(
+        /*max_slowdown_jerk=*/-1.0, /*max_slowdown_accel=*/0.0, /*current_accel=*/0.0,
+        /*current_velocity=*/5.0, /*distance_to_target=*/10.0);
+    },
+    std::logic_error);
+}
+
+TEST(PlanningUtilsPure, calcDecelerationVelocityBehindEgoReturnsCurrentVelocity)
+{
+  using autoware::behavior_velocity_planner::planning_utils::
+    calcDecelerationVelocityFromDistanceToTarget;
+
+  // distance_to_target <= 0 -> target is behind ego -> current velocity is returned unchanged.
+  const double v = calcDecelerationVelocityFromDistanceToTarget(
+    /*max_slowdown_jerk=*/-1.0, /*max_slowdown_accel=*/-2.0, /*current_accel=*/1.0,
+    /*current_velocity=*/5.0, /*distance_to_target=*/-3.0);
+  EXPECT_DOUBLE_EQ(v, 5.0);
+}
+
+TEST(PlanningUtilsPure, calcDecelerationVelocityConstJerkBranch)
+{
+  using autoware::behavior_velocity_planner::planning_utils::
+    calcDecelerationVelocityFromDistanceToTarget;
+
+  // Matches the verified constant-jerk case from test_path_utilization.cpp:
+  // jerk=-1, accel=-2, current_accel=1, current_velocity=5, distance=8 -> v ~= 5.380.
+  // This exercises the d_const_acc_stop < 0 branch that calls findReachTime.
+  const double v = calcDecelerationVelocityFromDistanceToTarget(
+    /*max_slowdown_jerk=*/-1.0, /*max_slowdown_accel=*/-2.0, /*current_accel=*/1.0,
+    /*current_velocity=*/5.0, /*distance_to_target=*/8.0);
+  EXPECT_NEAR(v, 5.380, 1e-3);
+}
+
+TEST(PlanningUtilsPure, calcDecelerationVelocityAlreadyStoppingBranch)
+{
+  using autoware::behavior_velocity_planner::planning_utils::
+    calcDecelerationVelocityFromDistanceToTarget;
+
+  // Matches the verified "after stop" case from test_path_utilization.cpp:
+  // distance=24 is farther than the achievable stop distance -> discriminant_of_stop <= 0 -> 0.
+  const double v = calcDecelerationVelocityFromDistanceToTarget(
+    /*max_slowdown_jerk=*/-1.0, /*max_slowdown_accel=*/-2.0, /*current_accel=*/1.0,
+    /*current_velocity=*/5.0, /*distance_to_target=*/24.0);
+  EXPECT_DOUBLE_EQ(v, 0.0);
+}
+
+TEST(PlanningUtilsPure, calcDecelerationVelocityConstAccelBranch)
+{
+  using autoware::behavior_velocity_planner::planning_utils::
+    calcDecelerationVelocityFromDistanceToTarget;
+
+  // Matches the verified constant-accel case from test_path_utilization.cpp:
+  // distance=16 -> v ~= 2.872.
+  const double v = calcDecelerationVelocityFromDistanceToTarget(
+    /*max_slowdown_jerk=*/-1.0, /*max_slowdown_accel=*/-2.0, /*current_accel=*/1.0,
+    /*current_velocity=*/5.0, /*distance_to_target=*/16.0);
+  EXPECT_NEAR(v, 2.872, 1e-3);
+}
+
+// ---------------------------------------------------------------------------
+// formatIds: characterizes the now-shared helper used by both
+// (legacy + experimental) SceneModuleInterface log message builders
+// ---------------------------------------------------------------------------
+TEST(PlanningUtilsPure, formatIdsAllGroups)
+{
+  using autoware::behavior_velocity_planner::planning_utils::formatIds;
+
+  EXPECT_EQ(formatIds({1, 2}, {3}, {4, 5, 6}), "[Reg: 1, 2][Lane: 3][Line: 4, 5, 6]");
+}
+
+TEST(PlanningUtilsPure, formatIdsSkipsEmptyGroups)
+{
+  using autoware::behavior_velocity_planner::planning_utils::formatIds;
+
+  EXPECT_EQ(formatIds({}, {3}, {}), "[Lane: 3]");
+  EXPECT_EQ(formatIds({1}, {}, {}), "[Reg: 1]");
+  EXPECT_EQ(formatIds({}, {}, {9}), "[Line: 9]");
+}
+
+TEST(PlanningUtilsPure, formatIdsAllEmpty)
+{
+  using autoware::behavior_velocity_planner::planning_utils::formatIds;
+
+  EXPECT_EQ(formatIds({}, {}, {}), "");
+}


### PR DESCRIPTION
## What

Implements the recommended PR for `autoware_behavior_velocity_planner_common` from the refactor campaign backlog: add focused unit tests for under-covered pure algorithms and deterministically pin the StateMachine margin-time transition, while internally de-duplicating the verbatim `formatIds` helper across the two `SceneModuleInterface` translation units.

### De-duplication (additive, behavior-preserving)
- The byte-for-byte identical `formatIds` helper previously lived in an anonymous namespace in both `src/scene_module_interface.cpp` and `src/experimental/scene_module_interface.cpp`, so it was untestable and free to drift. It is now a single internal free function `planning_utils::formatIds` (declared in `utilization/util.hpp`, defined in `utilization/util.cpp`) called from both modules. No public class API changes; the log-message output is byte-for-byte identical and pinned by tests.

### New tests
- `test/src/test_util_pure.cpp` (new, node-free pure-function suite):
  - `getSortedLaneIdsFromPath` first-seen order + dedup, and empty path.
  - `getSubsequentLaneIdsSetOnPath` from middle / first element / not-found (empty result).
  - `findReachTime` invalid-search-range throw (`f(min)>0` and `f(max)<0` brackets) plus linear and constant-accel root solutions with exact expected times.
  - `calcDecelerationVelocityFromDistanceToTarget` non-negative jerk/accel throws, behind-ego pass-through, and the const-jerk / const-accel / already-stopping branches asserted with exact velocity values (matching the verified values in `test_path_utilization.cpp`).
  - `formatIds` output strings for all-groups, empty-group skipping, and all-empty.
- `test/src/test_state_machine.cpp` (extended): two deterministic tests drive a controllable `RCL_ROS_TIME` clock (via `rcl_enable_ros_time_override` / `rcl_set_ros_time_override`) to assert the STOP->GO margin-time transition and the same-state STOP timer reset on every run, instead of the existing wall-clock busy-loop whose assertions self-disable on fast CI (the original test is left in place).

## Verification

Built and tested in `autoware:core-devel-jazzy`:
- `colcon build --packages-select autoware_behavior_velocity_planner_common` — OK
- `colcon test` — 46 gtest cases pass; copyright / cppcheck / lint_cmake / xmllint all green.
- `clang-format` clean on all changed files.

Refs: autowarefoundation/autoware_core#1096


## Effects on system behavior

`calcDecelerationVelocityFromDistanceToTarget` now rejects `max_slowdown_jerk == 0` or `max_slowdown_accel == 0` by throwing `std::logic_error` (the guard was tightened from `> 0` to `>= 0`). Previously a zero value passed the guard and reached `(a_max - a0) / j_max` / `(...) / a_max`, dividing by zero and producing inf/nan. Both parameters are physical deceleration jerk/accel that the function already requires to be negative, so no realistic caller passes zero. New `EXPECT_THROW` cases pin the zero boundary (verified to fail under the old `> 0` guard).
