### PR TITLE
refactor(autoware_behavior_velocity_stop_line_module): share stop-line state machine and stop-point logic

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/CMakeLists.txt
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/CMakeLists.txt
@@ -6,6 +6,7 @@ autoware_package()
 pluginlib_export_plugin_description_file(autoware_behavior_velocity_planner plugins.xml)
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/stop_line_util.cpp
   src/debug.cpp
   src/manager.cpp
   src/scene.cpp
@@ -16,6 +17,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 if(BUILD_TESTING)
   ament_add_ros_isolated_gtest(test_${PROJECT_NAME}
     test/test_scene.cpp
+    test/test_stop_line_util.cpp
     test/test_node_interface.cpp
   )
   target_link_libraries(test_${PROJECT_NAME}

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/experimental/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/experimental/scene.cpp
@@ -14,29 +14,15 @@
 
 #include "scene.hpp"
 
-#include <autoware/trajectory/utils/closest.hpp>
-#include <autoware/trajectory/utils/crossed.hpp>
+#include "../stop_line_util.hpp"
 
 #include <memory>
-#include <set>
+#include <optional>
 #include <utility>
 #include <vector>
 
 namespace autoware::behavior_velocity_planner::experimental
 {
-
-namespace
-{
-bool hasIntersection(const std::set<lanelet::Id> & a, const std::set<lanelet::Id> & b)
-{
-  for (const auto & id : a) {
-    if (b.find(id) != b.end()) {
-      return true;
-    }
-  }
-  return false;
-}
-}  // namespace
 
 StopLineModule::StopLineModule(
   const int64_t module_id,                                                //
@@ -98,99 +84,53 @@ std::pair<double, std::optional<double>> StopLineModule::getEgoAndStopPoint(
   const std::vector<geometry_msgs::msg::Point> & right_bound,
   const geometry_msgs::msg::Pose & ego_pose, const PlannerData & planner_data) const
 {
-  const double ego_s = autoware::experimental::trajectory::closest(path, ego_pose);
-  std::optional<double> stop_point_s;
-
-  switch (state_) {
-    case State::APPROACH: {
-      const double base_link2front = planner_data.vehicle_info_.max_longitudinal_offset_m;
-      const LineString2d stop_line = planning_utils::extendSegmentToBounds(
-        lanelet::utils::to2D(stop_line_).basicLineString(), left_bound, right_bound);
-
-      lanelet::Ids connected_lanelet_ids;
-
-      if (planner_data.route_handler_) {
-        connected_lanelet_ids =
-          planning_utils::collectConnectedLaneIds(linked_lanelet_id_, planner_data.route_handler_);
-      } else {
-        connected_lanelet_ids = {linked_lanelet_id_};
-      }
-
-      // Calculate intersection with stop line
-      const auto trajectory_stop_line_intersection =
-        autoware::experimental::trajectory::crossed_with_constraint(
-          path, stop_line,
-          [&](const autoware_internal_planning_msgs::msg::PathPointWithLaneId & point) {
-            return hasIntersection(
-              {connected_lanelet_ids.begin(), connected_lanelet_ids.end()},
-              {point.lane_ids.begin(), point.lane_ids.end()});
-          });
-
-      // If no collision found, do nothing
-      if (trajectory_stop_line_intersection.size() == 0) {
-        stop_point_s = std::nullopt;
-        break;
-      }
-
-      stop_point_s =
-        trajectory_stop_line_intersection.at(0) -
-        (base_link2front + planner_param_.stop_margin);  // consider vehicle length and stop margin
-
-      if (*stop_point_s < 0.0) {
-        stop_point_s = std::nullopt;
-      }
-      break;
-    }
-
-    case State::STOPPED: {
-      stop_point_s = ego_s;
-      break;
-    }
-
-    case State::START: {
-      stop_point_s = std::nullopt;
-      break;
-    }
+  lanelet::Ids connected_lanelet_ids;
+  if (planner_data.route_handler_) {
+    connected_lanelet_ids =
+      planning_utils::collectConnectedLaneIds(linked_lanelet_id_, planner_data.route_handler_);
+  } else {
+    connected_lanelet_ids = {linked_lanelet_id_};
   }
-  return {ego_s, stop_point_s};
+
+  return stop_line_utils::compute_ego_and_stop_point(
+    path, left_bound, right_bound, stop_line_, ego_pose, state_, connected_lanelet_ids,
+    planner_data.vehicle_info_.max_longitudinal_offset_m, planner_param_.stop_margin);
 }
 
 void StopLineModule::updateStateAndStoppedTime(
   const rclcpp::Time & now, const double & distance_to_stop_point, const bool & is_vehicle_stopped)
 {
-  switch (state_) {
-    case State::APPROACH: {
-      if (distance_to_stop_point < planner_param_.hold_stop_margin_distance && is_vehicle_stopped) {
-        state_ = State::STOPPED;
-        stopped_time_ = now;
-        logInfo("State transition: APPROACH -> STOPPED | Distance: %.2fm", distance_to_stop_point);
-        if (distance_to_stop_point < 0.0) {
-          logWarn("Vehicle stopped after stop line | Distance: %.2fm", distance_to_stop_point);
-        }
-      } else {
-        logInfoThrottle(10000, "State: APPROACH | Distance: %.2fm", distance_to_stop_point);
+  const auto result = stop_line_utils::advance_state(
+    state_, stopped_time_, now, distance_to_stop_point, is_vehicle_stopped,
+    planner_param_.hold_stop_margin_distance, planner_param_.required_stop_duration_sec);
+
+  switch (result.transition) {
+    case stop_line_utils::StateTransition::APPROACH_TO_STOPPED: {
+      logInfo("State transition: APPROACH -> STOPPED | Distance: %.2fm", distance_to_stop_point);
+      if (distance_to_stop_point < 0.0) {
+        logWarn("Vehicle stopped after stop line | Distance: %.2fm", distance_to_stop_point);
       }
       break;
     }
-    case State::STOPPED: {
-      if (!stopped_time_.has_value()) {
-        logWarn("stopped_time_ has no value in STOPPED state");
-        stopped_time_ = now;
-        break;
-      }
-      double stop_duration = (now - *stopped_time_).seconds();
-      if (stop_duration > planner_param_.required_stop_duration_sec) {
-        state_ = State::START;
-        stopped_time_.reset();
-        logInfo("State transition: STOPPED -> START | Duration: %.2fs", stop_duration);
-      } else {
-        logInfoThrottle(
-          5000, "State: STOPPED | Distance: %.2fm | Duration: %.2fs", distance_to_stop_point,
-          stop_duration);
-      }
+    case stop_line_utils::StateTransition::APPROACH_STAY: {
+      logInfoThrottle(10000, "State: APPROACH | Distance: %.2fm", distance_to_stop_point);
       break;
     }
-    case State::START: {
+    case stop_line_utils::StateTransition::STOPPED_TIME_RECOVERY: {
+      logWarn("stopped_time_ has no value in STOPPED state");
+      break;
+    }
+    case stop_line_utils::StateTransition::STOPPED_TO_START: {
+      logInfo("State transition: STOPPED -> START | Duration: %.2fs", result.stop_duration);
+      break;
+    }
+    case stop_line_utils::StateTransition::STOPPED_STAY: {
+      logInfoThrottle(
+        5000, "State: STOPPED | Distance: %.2fm | Duration: %.2fs", distance_to_stop_point,
+        result.stop_duration);
+      break;
+    }
+    case stop_line_utils::StateTransition::START: {
       logDebug("State: START | Distance: %.2fm", distance_to_stop_point);
       break;
     }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/experimental/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/experimental/scene.hpp
@@ -17,6 +17,8 @@
 
 #define EIGEN_MPL2_ONLY
 
+#include "../stop_line_util.hpp"
+
 #include <autoware/behavior_velocity_planner_common/experimental/scene_module_interface.hpp>
 
 #include <memory>
@@ -30,7 +32,7 @@ class StopLineModule : public SceneModuleInterface
 public:
   using StopLineWithLaneId = std::pair<lanelet::ConstLineString3d, int64_t>;
 
-  enum class State { APPROACH, STOPPED, START };
+  using State = stop_line_utils::State;
 
   struct DebugData
   {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.cpp
@@ -15,8 +15,7 @@
 #include "scene.hpp"
 
 #include "autoware/behavior_velocity_planner_common/utilization/util.hpp"
-#include "autoware/trajectory/utils/closest.hpp"
-#include "autoware/trajectory/utils/crossed.hpp"
+#include "stop_line_util.hpp"
 
 #include <autoware/route_handler/route_handler.hpp>
 #include <rclcpp/logging.hpp>
@@ -29,21 +28,10 @@
 #include <cstdarg>
 #include <memory>
 #include <optional>
-#include <set>
 #include <utility>
 
 namespace autoware::behavior_velocity_planner
 {
-
-bool hasIntersection(const std::set<lanelet::Id> & a, const std::set<lanelet::Id> & b)
-{
-  for (const auto & id : a) {
-    if (b.find(id) != b.end()) {
-      return true;
-    }
-  }
-  return false;
-}
 
 StopLineModule::StopLineModule(
   const int64_t module_id,                                                //
@@ -113,100 +101,55 @@ std::pair<double, std::optional<double>> StopLineModule::getEgoAndStopPoint(
   const Trajectory & trajectory, const PathWithLaneId & path,
   const geometry_msgs::msg::Pose & ego_pose, const State & state) const
 {
-  const double ego_s = autoware::experimental::trajectory::closest(trajectory, ego_pose);
-  std::optional<double> stop_point_s;
-
-  switch (state) {
-    case State::APPROACH: {
-      const double base_link2front = planner_data_->vehicle_info_.max_longitudinal_offset_m;
-      const LineString2d stop_line = planning_utils::extendSegmentToBounds(
-        lanelet::utils::to2D(stop_line_).basicLineString(), path.left_bound, path.right_bound);
-
-      lanelet::Ids connected_lanelet_ids;
-
-      if (planner_data_->route_handler_) {
-        connected_lanelet_ids = planning_utils::collectConnectedLaneIds(
-          linked_lanelet_id_, planner_data_->route_handler_);
-      } else {
-        connected_lanelet_ids = {linked_lanelet_id_};
-      }
-
-      // Calculate intersection with stop line
-      const auto trajectory_stop_line_intersection =
-        autoware::experimental::trajectory::crossed_with_constraint(
-          trajectory, stop_line,
-          [&](const autoware_internal_planning_msgs::msg::PathPointWithLaneId & point) {
-            return hasIntersection(
-              {connected_lanelet_ids.begin(), connected_lanelet_ids.end()},
-              {point.lane_ids.begin(), point.lane_ids.end()});
-          });
-
-      // If no collision found, do nothing
-      if (trajectory_stop_line_intersection.size() == 0) {
-        stop_point_s = std::nullopt;
-        break;
-      }
-
-      stop_point_s =
-        trajectory_stop_line_intersection.at(0) -
-        (base_link2front + planner_param_.stop_margin);  // consider vehicle length and stop margin
-
-      if (*stop_point_s < 0.0) {
-        stop_point_s = std::nullopt;
-      }
-      break;
-    }
-
-    case State::STOPPED: {
-      stop_point_s = ego_s;
-      break;
-    }
-
-    case State::START: {
-      stop_point_s = std::nullopt;
-      break;
-    }
+  lanelet::Ids connected_lanelet_ids;
+  if (planner_data_->route_handler_) {
+    connected_lanelet_ids =
+      planning_utils::collectConnectedLaneIds(linked_lanelet_id_, planner_data_->route_handler_);
+  } else {
+    connected_lanelet_ids = {linked_lanelet_id_};
   }
-  return {ego_s, stop_point_s};
+
+  return stop_line_utils::compute_ego_and_stop_point(
+    trajectory, path.left_bound, path.right_bound, stop_line_, ego_pose, state,
+    connected_lanelet_ids, planner_data_->vehicle_info_.max_longitudinal_offset_m,
+    planner_param_.stop_margin);
 }
 
 void StopLineModule::updateStateAndStoppedTime(
   State * state, std::optional<rclcpp::Time> * stopped_time, const rclcpp::Time & now,
   const double & distance_to_stop_point, const bool & is_vehicle_stopped) const
 {
-  switch (*state) {
-    case State::APPROACH: {
-      if (distance_to_stop_point < planner_param_.hold_stop_margin_distance && is_vehicle_stopped) {
-        *state = State::STOPPED;
-        *stopped_time = now;
-        logInfo("State transition: APPROACH -> STOPPED | Distance: %.2fm", distance_to_stop_point);
-        if (distance_to_stop_point < 0.0) {
-          logWarn("Vehicle stopped after stop line | Distance: %.2fm", distance_to_stop_point);
-        }
-      } else {
-        logInfoThrottle(10000, "State: APPROACH | Distance: %.2fm", distance_to_stop_point);
+  const auto result = stop_line_utils::advance_state(
+    *state, *stopped_time, now, distance_to_stop_point, is_vehicle_stopped,
+    planner_param_.hold_stop_margin_distance, planner_param_.required_stop_duration_sec);
+
+  switch (result.transition) {
+    case stop_line_utils::StateTransition::APPROACH_TO_STOPPED: {
+      logInfo("State transition: APPROACH -> STOPPED | Distance: %.2fm", distance_to_stop_point);
+      if (distance_to_stop_point < 0.0) {
+        logWarn("Vehicle stopped after stop line | Distance: %.2fm", distance_to_stop_point);
       }
       break;
     }
-    case State::STOPPED: {
-      if (!stopped_time->has_value()) {
-        logWarn("stopped_time has no value in STOPPED state");
-        *stopped_time = now;
-        break;
-      }
-      double stop_duration = (now - **stopped_time).seconds();
-      if (stop_duration > planner_param_.required_stop_duration_sec) {
-        *state = State::START;
-        stopped_time->reset();
-        logInfo("State transition: STOPPED -> START | Duration: %.2fs", stop_duration);
-      } else {
-        logInfoThrottle(
-          5000, "State: STOPPED | Distance: %.2fm | Duration: %.2fs", distance_to_stop_point,
-          stop_duration);
-      }
+    case stop_line_utils::StateTransition::APPROACH_STAY: {
+      logInfoThrottle(10000, "State: APPROACH | Distance: %.2fm", distance_to_stop_point);
       break;
     }
-    case State::START: {
+    case stop_line_utils::StateTransition::STOPPED_TIME_RECOVERY: {
+      logWarn("stopped_time has no value in STOPPED state");
+      break;
+    }
+    case stop_line_utils::StateTransition::STOPPED_TO_START: {
+      logInfo("State transition: STOPPED -> START | Duration: %.2fs", result.stop_duration);
+      break;
+    }
+    case stop_line_utils::StateTransition::STOPPED_STAY: {
+      logInfoThrottle(
+        5000, "State: STOPPED | Distance: %.2fm | Duration: %.2fs", distance_to_stop_point,
+        result.stop_duration);
+      break;
+    }
+    case stop_line_utils::StateTransition::START: {
       logDebug("State: START | Distance: %.2fm", distance_to_stop_point);
       break;
     }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.hpp
@@ -19,6 +19,7 @@
 #include "autoware/behavior_velocity_planner_common/scene_module_interface.hpp"
 #include "autoware/behavior_velocity_planner_common/utilization/util.hpp"
 #include "autoware/trajectory/path_point_with_lane_id.hpp"
+#include "stop_line_util.hpp"
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -41,9 +42,8 @@ class StopLineModule : public SceneModuleInterface
 {
 public:
   using StopLineWithLaneId = std::pair<lanelet::ConstLineString3d, int64_t>;
-  using Trajectory = autoware::experimental::trajectory::Trajectory<
-    autoware_internal_planning_msgs::msg::PathPointWithLaneId>;
-  enum class State { APPROACH, STOPPED, START };
+  using Trajectory = stop_line_utils::Trajectory;
+  using State = stop_line_utils::State;
 
   struct DebugData
   {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/stop_line_util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/stop_line_util.cpp
@@ -1,0 +1,126 @@
+// Copyright 2025 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "stop_line_util.hpp"
+
+#include "autoware/trajectory/utils/closest.hpp"
+#include "autoware/trajectory/utils/crossed.hpp"
+
+#include <lanelet2_core/primitives/Lanelet.h>
+
+#include <algorithm>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace autoware::behavior_velocity_planner::stop_line_utils
+{
+
+bool has_intersection(
+  const lanelet::Ids & connected_lanelet_ids, const std::vector<int64_t> & point_lane_ids)
+{
+  return std::any_of(
+    point_lane_ids.begin(), point_lane_ids.end(), [&connected_lanelet_ids](const int64_t id) {
+      return std::find(connected_lanelet_ids.begin(), connected_lanelet_ids.end(), id) !=
+             connected_lanelet_ids.end();
+    });
+}
+
+std::pair<double, std::optional<double>> compute_ego_and_stop_point(
+  const Trajectory & trajectory, const std::vector<geometry_msgs::msg::Point> & left_bound,
+  const std::vector<geometry_msgs::msg::Point> & right_bound,
+  const lanelet::ConstLineString3d & stop_line, const geometry_msgs::msg::Pose & ego_pose,
+  const State & state, const lanelet::Ids & connected_lanelet_ids, const double base_link2front,
+  const double stop_margin)
+{
+  const double ego_s = autoware::experimental::trajectory::closest(trajectory, ego_pose);
+  std::optional<double> stop_point_s;
+
+  switch (state) {
+    case State::APPROACH: {
+      const LineString2d extended_stop_line = planning_utils::extendSegmentToBounds(
+        lanelet::utils::to2D(stop_line).basicLineString(), left_bound, right_bound);
+
+      // Calculate intersection with stop line
+      const auto trajectory_stop_line_intersection =
+        autoware::experimental::trajectory::crossed_with_constraint(
+          trajectory, extended_stop_line,
+          [&connected_lanelet_ids](
+            const autoware_internal_planning_msgs::msg::PathPointWithLaneId & point) {
+            return has_intersection(connected_lanelet_ids, point.lane_ids);
+          });
+
+      // If no collision found, do nothing
+      if (trajectory_stop_line_intersection.size() == 0) {
+        stop_point_s = std::nullopt;
+        break;
+      }
+
+      stop_point_s = trajectory_stop_line_intersection.at(0) -
+                     (base_link2front + stop_margin);  // consider vehicle length and stop margin
+
+      if (*stop_point_s < 0.0) {
+        stop_point_s = std::nullopt;
+      }
+      break;
+    }
+
+    case State::STOPPED: {
+      stop_point_s = ego_s;
+      break;
+    }
+
+    case State::START: {
+      stop_point_s = std::nullopt;
+      break;
+    }
+  }
+  return {ego_s, stop_point_s};
+}
+
+StateTransitionResult advance_state(
+  State & state, std::optional<rclcpp::Time> & stopped_time, const rclcpp::Time & now,
+  const double distance_to_stop_point, const bool is_vehicle_stopped,
+  const double hold_stop_margin_distance, const double required_stop_duration_sec)
+{
+  switch (state) {
+    case State::APPROACH: {
+      if (distance_to_stop_point < hold_stop_margin_distance && is_vehicle_stopped) {
+        state = State::STOPPED;
+        stopped_time = now;
+        return {StateTransition::APPROACH_TO_STOPPED};
+      }
+      return {StateTransition::APPROACH_STAY};
+    }
+    case State::STOPPED: {
+      if (!stopped_time.has_value()) {
+        stopped_time = now;
+        return {StateTransition::STOPPED_TIME_RECOVERY};
+      }
+      const double stop_duration = (now - *stopped_time).seconds();
+      if (stop_duration > required_stop_duration_sec) {
+        state = State::START;
+        stopped_time.reset();
+        return {StateTransition::STOPPED_TO_START, stop_duration};
+      }
+      return {StateTransition::STOPPED_STAY, stop_duration};
+    }
+    case State::START: {
+      return {StateTransition::START};
+    }
+  }
+  return {StateTransition::START};
+}
+
+}  // namespace autoware::behavior_velocity_planner::stop_line_utils

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/stop_line_util.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/stop_line_util.hpp
@@ -1,0 +1,111 @@
+// Copyright 2025 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STOP_LINE_UTIL_HPP_
+#define STOP_LINE_UTIL_HPP_
+#define EIGEN_MPL2_ONLY
+
+#include "autoware/behavior_velocity_planner_common/utilization/util.hpp"
+#include "autoware/trajectory/path_point_with_lane_id.hpp"
+
+#include <rclcpp/time.hpp>
+
+#include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/pose.hpp>
+
+#include <lanelet2_core/Forward.h>
+#include <lanelet2_core/primitives/LineString.h>
+
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace autoware::behavior_velocity_planner::stop_line_utils
+{
+
+/// @brief Trajectory type shared by both the legacy and experimental stop-line scenes.
+using Trajectory = autoware::experimental::trajectory::Trajectory<
+  autoware_internal_planning_msgs::msg::PathPointWithLaneId>;
+
+/// @brief State machine state of the stop-line module.
+/// @details Shared between the legacy and experimental implementations so the state-machine logic
+/// can be factored into a single set of pure free functions.
+enum class State { APPROACH, STOPPED, START };
+
+/// @brief Result of @ref advance_state describing which transition (if any) occurred.
+/// @details The module wrappers use this to reproduce their exact log output without duplicating
+/// the decision logic.
+enum class StateTransition {
+  APPROACH_STAY,          ///< Stayed in APPROACH (not yet stopped / too far).
+  APPROACH_TO_STOPPED,    ///< Transitioned APPROACH -> STOPPED.
+  STOPPED_TIME_RECOVERY,  ///< In STOPPED but stopped_time had no value; it was recovered.
+  STOPPED_STAY,           ///< Stayed in STOPPED (duration not yet reached).
+  STOPPED_TO_START,       ///< Transitioned STOPPED -> START.
+  START                   ///< Stayed in START.
+};
+
+/// @brief Outcome of @ref advance_state.
+struct StateTransitionResult
+{
+  StateTransition transition;  ///< Which transition occurred.
+  /// Stop duration (seconds) computed in the STOPPED branch; only meaningful for STOPPED_STAY /
+  /// STOPPED_TO_START, where it is the value logged by the caller before any reset.
+  double stop_duration{0.0};
+};
+
+/// @brief Check whether @p connected_lanelet_ids and @p point_lane_ids share any id.
+/// @details Replaces the hand-rolled sorted-set intersection check that used to be copy-pasted
+/// between the legacy and experimental scenes. The invariant side is passed as the (typically
+/// pre-built) @p connected_lanelet_ids vector and the per-point ids are scanned linearly, so no
+/// temporary @c std::set is allocated per call.
+bool has_intersection(
+  const lanelet::Ids & connected_lanelet_ids, const std::vector<int64_t> & point_lane_ids);
+
+/// @brief Compute the ego arc length and (optional) stop-point arc length on @p trajectory.
+/// @param trajectory Current trajectory.
+/// @param left_bound Left bound used to extend the stop line.
+/// @param right_bound Right bound used to extend the stop line.
+/// @param stop_line Raw stop-line geometry.
+/// @param ego_pose Current pose of the vehicle.
+/// @param state Current state of the stop-line module.
+/// @param connected_lanelet_ids Lanelet ids connected to the stop line (loop invariant).
+/// @param base_link2front Distance from base link to vehicle front.
+/// @param stop_margin Stop margin to the stop line.
+/// @return Pair of ego arc length and optional stop-point arc length.
+std::pair<double, std::optional<double>> compute_ego_and_stop_point(
+  const Trajectory & trajectory, const std::vector<geometry_msgs::msg::Point> & left_bound,
+  const std::vector<geometry_msgs::msg::Point> & right_bound,
+  const lanelet::ConstLineString3d & stop_line, const geometry_msgs::msg::Pose & ego_pose,
+  const State & state, const lanelet::Ids & connected_lanelet_ids, const double base_link2front,
+  const double stop_margin);
+
+/// @brief Advance the stop-line state machine.
+/// @param state In/out current state.
+/// @param stopped_time In/out time when the vehicle stopped.
+/// @param now Current time.
+/// @param distance_to_stop_point Distance to the stop point.
+/// @param is_vehicle_stopped Whether the vehicle is stopped.
+/// @param hold_stop_margin_distance Distance threshold for transitioning to STOPPED.
+/// @param required_stop_duration_sec Required stop duration before transitioning to START.
+/// @return The transition that occurred (and stop duration), so the caller can reproduce its log
+/// output.
+StateTransitionResult advance_state(
+  State & state, std::optional<rclcpp::Time> & stopped_time, const rclcpp::Time & now,
+  const double distance_to_stop_point, const bool is_vehicle_stopped,
+  const double hold_stop_margin_distance, const double required_stop_duration_sec);
+
+}  // namespace autoware::behavior_velocity_planner::stop_line_utils
+
+#endif  // STOP_LINE_UTIL_HPP_

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/test/test_stop_line_util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/test/test_stop_line_util.cpp
@@ -1,0 +1,275 @@
+// Copyright 2025 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/stop_line_util.hpp"
+
+#include <autoware_utils_geometry/geometry.hpp>
+#include <rclcpp/clock.hpp>
+#include <rclcpp/time.hpp>
+
+#include <autoware_internal_planning_msgs/msg/path_point_with_lane_id.hpp>
+
+#include <gtest/gtest.h>
+#include <lanelet2_core/primitives/LineString.h>
+#include <lanelet2_core/primitives/Point.h>
+#include <lanelet2_core/utility/Utilities.h>
+
+#include <optional>
+#include <vector>
+
+namespace
+{
+using autoware::behavior_velocity_planner::stop_line_utils::advance_state;
+using autoware::behavior_velocity_planner::stop_line_utils::compute_ego_and_stop_point;
+using autoware::behavior_velocity_planner::stop_line_utils::has_intersection;
+using autoware::behavior_velocity_planner::stop_line_utils::State;
+using autoware::behavior_velocity_planner::stop_line_utils::StateTransition;
+using autoware::behavior_velocity_planner::stop_line_utils::Trajectory;
+using autoware_utils_geometry::create_point;
+
+autoware_internal_planning_msgs::msg::PathPointWithLaneId make_path_point(
+  const double x, const double y, const int64_t lane_id)
+{
+  autoware_internal_planning_msgs::msg::PathPointWithLaneId point;
+  point.point.pose.position = create_point(x, y, 0.0);
+  point.lane_ids = {lane_id};
+  return point;
+}
+
+struct StopLineFixture
+{
+  StopLineFixture()
+  {
+    points = {
+      make_path_point(0.0, 0.0, 0), make_path_point(1.0, 0.0, 0), make_path_point(2.0, 0.0, 0),
+      make_path_point(3.0, 0.0, 0), make_path_point(4.0, 0.0, 0), make_path_point(5.0, 0.0, 0),
+      make_path_point(6.0, 0.0, 0), make_path_point(7.0, 0.0, 0), make_path_point(8.0, 0.0, 0),
+      make_path_point(9.0, 0.0, 0), make_path_point(10.0, 0.0, 0)};
+    left_bound = {create_point(0.0, 1.0, 0.0), create_point(10.0, 1.0, 0.0)};
+    right_bound = {create_point(0.0, -1.0, 0.0), create_point(10.0, -1.0, 0.0)};
+
+    // Stop line crossing the path at x = 7.0.
+    stop_line = lanelet::ConstLineString3d(
+      lanelet::utils::getId(), {lanelet::Point3d(lanelet::utils::getId(), 7.0, -1.0, 0.0),
+                                lanelet::Point3d(lanelet::utils::getId(), 7.0, 1.0, 0.0)});
+
+    trajectory = *Trajectory::Builder{}.build(points);
+  }
+
+  std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId> points;
+  std::vector<geometry_msgs::msg::Point> left_bound;
+  std::vector<geometry_msgs::msg::Point> right_bound;
+  lanelet::ConstLineString3d stop_line;
+  Trajectory trajectory;
+};
+
+geometry_msgs::msg::Pose make_ego_pose(const double x, const double y)
+{
+  geometry_msgs::msg::Pose pose;
+  pose.position = create_point(x, y, 0.0);
+  return pose;
+}
+}  // namespace
+
+// --- has_intersection -------------------------------------------------------
+
+TEST(StopLineUtilHasIntersection, ReturnsTrueWhenShared)
+{
+  EXPECT_TRUE(has_intersection(lanelet::Ids{1, 2, 3}, std::vector<int64_t>{3, 4}));
+  EXPECT_TRUE(has_intersection(lanelet::Ids{5}, std::vector<int64_t>{5}));
+}
+
+TEST(StopLineUtilHasIntersection, ReturnsFalseWhenDisjointOrEmpty)
+{
+  EXPECT_FALSE(has_intersection(lanelet::Ids{1, 2, 3}, std::vector<int64_t>{4, 5}));
+  EXPECT_FALSE(has_intersection(lanelet::Ids{}, std::vector<int64_t>{1}));
+  EXPECT_FALSE(has_intersection(lanelet::Ids{1}, std::vector<int64_t>{}));
+}
+
+// --- compute_ego_and_stop_point ---------------------------------------------
+
+TEST(StopLineUtilComputeEgoAndStopPoint, ApproachPositiveStopPoint)
+{
+  const StopLineFixture f;
+  const auto [ego_s, stop_point_s] = compute_ego_and_stop_point(
+    f.trajectory, f.left_bound, f.right_bound, f.stop_line, make_ego_pose(5.0, 0.0),
+    State::APPROACH, lanelet::Ids{0}, /*base_link2front=*/1.0, /*stop_margin=*/0.5);
+
+  EXPECT_DOUBLE_EQ(ego_s, 5.0);
+  ASSERT_TRUE(stop_point_s.has_value());
+  EXPECT_DOUBLE_EQ(stop_point_s.value(), 7.0 - 0.5 - 1.0);
+}
+
+TEST(StopLineUtilComputeEgoAndStopPoint, ApproachNoIntersectionReturnsNullopt)
+{
+  const StopLineFixture f;
+  // Connected lanelet ids do not overlap the path lane id (0), so the stop-line constraint
+  // never matches and no intersection is found.
+  const auto [ego_s, stop_point_s] = compute_ego_and_stop_point(
+    f.trajectory, f.left_bound, f.right_bound, f.stop_line, make_ego_pose(5.0, 0.0),
+    State::APPROACH, lanelet::Ids{42}, /*base_link2front=*/1.0, /*stop_margin=*/0.5);
+
+  EXPECT_DOUBLE_EQ(ego_s, 5.0);
+  EXPECT_FALSE(stop_point_s.has_value());
+}
+
+TEST(StopLineUtilComputeEgoAndStopPoint, ApproachNegativeStopPointReturnsNullopt)
+{
+  const StopLineFixture f;
+  // base_link2front + stop_margin pushes the stop point behind ego (< 0).
+  const auto [ego_s, stop_point_s] = compute_ego_and_stop_point(
+    f.trajectory, f.left_bound, f.right_bound, f.stop_line, make_ego_pose(5.0, 0.0),
+    State::APPROACH, lanelet::Ids{0}, /*base_link2front=*/100.0, /*stop_margin=*/0.5);
+
+  EXPECT_DOUBLE_EQ(ego_s, 5.0);
+  EXPECT_FALSE(stop_point_s.has_value());
+}
+
+TEST(StopLineUtilComputeEgoAndStopPoint, StoppedReturnsEgoS)
+{
+  const StopLineFixture f;
+  const auto [ego_s, stop_point_s] = compute_ego_and_stop_point(
+    f.trajectory, f.left_bound, f.right_bound, f.stop_line, make_ego_pose(5.0, 0.0), State::STOPPED,
+    lanelet::Ids{0}, 1.0, 0.5);
+
+  EXPECT_DOUBLE_EQ(ego_s, 5.0);
+  ASSERT_TRUE(stop_point_s.has_value());
+  EXPECT_DOUBLE_EQ(stop_point_s.value(), 5.0);
+}
+
+TEST(StopLineUtilComputeEgoAndStopPoint, StartReturnsNullopt)
+{
+  const StopLineFixture f;
+  const auto [ego_s, stop_point_s] = compute_ego_and_stop_point(
+    f.trajectory, f.left_bound, f.right_bound, f.stop_line, make_ego_pose(5.0, 0.0), State::START,
+    lanelet::Ids{0}, 1.0, 0.5);
+
+  EXPECT_DOUBLE_EQ(ego_s, 5.0);
+  EXPECT_FALSE(stop_point_s.has_value());
+}
+
+// --- advance_state ----------------------------------------------------------
+
+class AdvanceStateTest : public ::testing::Test
+{
+protected:
+  static constexpr double kHoldStopMarginDistance = 0.5;
+  static constexpr double kRequiredStopDurationSec = 2.0;
+  rclcpp::Clock clock_{RCL_ROS_TIME};
+};
+
+TEST_F(AdvanceStateTest, ApproachToStopped)
+{
+  State state = State::APPROACH;
+  std::optional<rclcpp::Time> stopped_time;
+  const auto now = clock_.now();
+
+  const auto result = advance_state(
+    state, stopped_time, now, /*distance=*/0.1, /*is_stopped=*/true, kHoldStopMarginDistance,
+    kRequiredStopDurationSec);
+
+  EXPECT_EQ(result.transition, StateTransition::APPROACH_TO_STOPPED);
+  EXPECT_EQ(state, State::STOPPED);
+  ASSERT_TRUE(stopped_time.has_value());
+  EXPECT_EQ(stopped_time.value(), now);
+}
+
+TEST_F(AdvanceStateTest, ApproachStaysWhenNotStopped)
+{
+  State state = State::APPROACH;
+  std::optional<rclcpp::Time> stopped_time;
+
+  const auto result = advance_state(
+    state, stopped_time, clock_.now(), /*distance=*/0.1, /*is_stopped=*/false,
+    kHoldStopMarginDistance, kRequiredStopDurationSec);
+
+  EXPECT_EQ(result.transition, StateTransition::APPROACH_STAY);
+  EXPECT_EQ(state, State::APPROACH);
+  EXPECT_FALSE(stopped_time.has_value());
+}
+
+TEST_F(AdvanceStateTest, ApproachStaysWhenTooFar)
+{
+  State state = State::APPROACH;
+  std::optional<rclcpp::Time> stopped_time;
+
+  const auto result = advance_state(
+    state, stopped_time, clock_.now(), /*distance=*/2.0, /*is_stopped=*/true,
+    kHoldStopMarginDistance, kRequiredStopDurationSec);
+
+  EXPECT_EQ(result.transition, StateTransition::APPROACH_STAY);
+  EXPECT_EQ(state, State::APPROACH);
+  EXPECT_FALSE(stopped_time.has_value());
+}
+
+TEST_F(AdvanceStateTest, StoppedTimeRecoveryWhenNoValue)
+{
+  State state = State::STOPPED;
+  std::optional<rclcpp::Time> stopped_time;  // no value
+  const auto now = clock_.now();
+
+  const auto result = advance_state(
+    state, stopped_time, now, /*distance=*/0.1, /*is_stopped=*/true, kHoldStopMarginDistance,
+    kRequiredStopDurationSec);
+
+  EXPECT_EQ(result.transition, StateTransition::STOPPED_TIME_RECOVERY);
+  EXPECT_EQ(state, State::STOPPED);
+  ASSERT_TRUE(stopped_time.has_value());
+  EXPECT_EQ(stopped_time.value(), now);
+}
+
+TEST_F(AdvanceStateTest, StoppedStaysWhenDurationNotReached)
+{
+  State state = State::STOPPED;
+  const auto start = clock_.now();
+  std::optional<rclcpp::Time> stopped_time = start;
+
+  const auto result = advance_state(
+    state, stopped_time, start + rclcpp::Duration::from_seconds(1.0), /*distance=*/0.1,
+    /*is_stopped=*/false, kHoldStopMarginDistance, kRequiredStopDurationSec);
+
+  EXPECT_EQ(result.transition, StateTransition::STOPPED_STAY);
+  EXPECT_EQ(state, State::STOPPED);
+  ASSERT_TRUE(stopped_time.has_value());
+  EXPECT_DOUBLE_EQ(result.stop_duration, 1.0);
+}
+
+TEST_F(AdvanceStateTest, StoppedToStartAfterDuration)
+{
+  State state = State::STOPPED;
+  const auto start = clock_.now();
+  std::optional<rclcpp::Time> stopped_time = start;
+
+  const auto result = advance_state(
+    state, stopped_time, start + rclcpp::Duration::from_seconds(3.0), /*distance=*/0.1,
+    /*is_stopped=*/true, kHoldStopMarginDistance, kRequiredStopDurationSec);
+
+  EXPECT_EQ(result.transition, StateTransition::STOPPED_TO_START);
+  EXPECT_EQ(state, State::START);
+  EXPECT_FALSE(stopped_time.has_value());
+  EXPECT_DOUBLE_EQ(result.stop_duration, 3.0);
+}
+
+TEST_F(AdvanceStateTest, StartStaysStart)
+{
+  State state = State::START;
+  std::optional<rclcpp::Time> stopped_time;
+
+  const auto result = advance_state(
+    state, stopped_time, clock_.now(), /*distance=*/0.1, /*is_stopped=*/true,
+    kHoldStopMarginDistance, kRequiredStopDurationSec);
+
+  EXPECT_EQ(result.transition, StateTransition::START);
+  EXPECT_EQ(state, State::START);
+}


### PR DESCRIPTION
## What

Extracts the duplicated stop-line state machine and stop-point geometry computation into pure free functions in a new internal `stop_line_util` translation unit (`src/stop_line_util.{hpp,cpp}`, namespace `autoware::behavior_velocity_planner::stop_line_utils`), reused by both the legacy (`src/scene.cpp`) and experimental (`src/experimental/scene.cpp`) `StopLineModule`.

The two scene implementations previously carried near-identical copies of the `hasIntersection` helper, the `getEgoAndStopPoint` stop-point geometry, and the `updateStateAndStoppedTime` state machine. This PR de-duplicates them:

- **`has_intersection(connected_lanelet_ids, point_lane_ids)`** replaces the two verbatim copies of `hasIntersection`. It scans the per-point lane ids against the (loop-invariant) connected lanelet ids, removing the per-call `std::set` construction that used to happen inside the `crossed_with_constraint` lambda on every trajectory point (addresses the performance findings about per-call set allocation and the loop-invariant set).
- **`compute_ego_and_stop_point(...)`** takes plain inputs (trajectory, bounds, raw stop line, ego pose, state, pre-collected connected lanelet ids, `base_link2front`, `stop_margin`) and returns `{ego_s, optional<stop_point_s>}`. Both modules collect the connected lanelet ids from their respective `PlannerData` access (member pointer vs reference) and delegate to it.
- **`advance_state(...)`** is the pure state-machine decision. It mutates `state` / `stopped_time` and returns a `StateTransitionResult` (transition kind + computed stop duration) so each module's `updateStateAndStoppedTime` wrapper reproduces its exact log output without duplicating the decision logic.

A shared `State` enum and `Trajectory` alias live in the util header; `StopLineModule::State` / `StopLineModule::Trajectory` are now aliases to them, so existing references (e.g. `StopLineModule::State::APPROACH`) keep compiling.

## Tests

New `test/test_stop_line_util.cpp` unit-tests the extracted free functions with no ROS node, covering the experimental code path (which now shares the same logic) and the previously untested branches:

- `has_intersection`: shared / disjoint / empty inputs.
- `compute_ego_and_stop_point`: APPROACH positive stop point, APPROACH no-intersection -> nullopt, APPROACH negative-stop-point -> nullopt, STOPPED, START.
- `advance_state`: APPROACH->STOPPED, APPROACH stays (not stopped / too far), STOPPED time-recovery (no `stopped_time` value), STOPPED stays, STOPPED->START (asserting the logged `stop_duration`), START.

The existing `test/test_scene.cpp` (legacy module) is unchanged and still passes, confirming behavior preservation.

## Behavior

Behavior-preserving: public `modifyPathVelocity` / `getEgoAndStopPoint` / `updateStateAndStoppedTime` signatures and all existing log messages (including the differing legacy `"stopped_time ..."` vs experimental `"stopped_time_ ..."` recovery text) are unchanged.

## Verification

Built and tested in `autoware:core-devel-jazzy`: build green, `colcon test-result` reports 59 tests, 0 errors, 0 failures, 14 skipped (the launch_test scenarios, consistent with baseline). clang-format and the package linters (cppcheck, copyright, cpplint, lint_cmake, xmllint) pass.

Refs: autowarefoundation/autoware_core#1096
