### PR TITLE
refactor(autoware_motion_velocity_planner): extract pure node logic into testable free functions

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/CMakeLists.txt
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/CMakeLists.txt
@@ -23,6 +23,13 @@ if(BUILD_TESTING)
     ${PROJECT_NAME}_lib
     yaml-cpp
   )
+
+  ament_auto_add_gtest(test_node_utils
+    test/test_node_utils.cpp
+  )
+  target_link_libraries(test_node_utils
+    ${PROJECT_NAME}_lib
+  )
 endif()
 
 autoware_ament_auto_package(INSTALL_TO_SHARE

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
@@ -15,6 +15,7 @@
 #include "node.hpp"
 
 #include "autoware/motion_velocity_planner_common/utils.hpp"
+#include "node_utils.hpp"
 
 #include <autoware/motion_utils/resample/resample.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
@@ -234,16 +235,22 @@ MotionVelocityPlannerNode::process_no_ground_pointcloud(
   const bool is_pcl_time_valid = (this->get_clock()->now() - rclcpp::Time(msg->header.stamp)) <
                                  rclcpp::Duration::from_seconds(1.0);
 
-  if (
-    is_pcl_time_valid && tf_buffer_.canTransform("map", msg->header.frame_id, msg->header.stamp)) {
-    transform = tf_buffer_.lookupTransform(
-      "map", msg->header.frame_id, msg->header.stamp, rclcpp::Duration::from_seconds(0.05));
-  } else if (tf_buffer_.canTransform("map", msg->header.frame_id, tf2::TimePointZero)) {
-    transform = tf_buffer_.lookupTransform("map", msg->header.frame_id, tf2::TimePointZero);
-    RCLCPP_DEBUG(get_logger(), "pcl time is invalid, using tf2::TimePointZero");
-  } else {
-    RCLCPP_WARN(get_logger(), "no transform found for no_ground_pointcloud");
-    return std::nullopt;
+  const auto transform_source = utils::select_pointcloud_transform_source(
+    is_pcl_time_valid, tf_buffer_.canTransform("map", msg->header.frame_id, msg->header.stamp),
+    tf_buffer_.canTransform("map", msg->header.frame_id, tf2::TimePointZero));
+
+  switch (transform_source) {
+    case utils::PointcloudTransformSource::AtStamp:
+      transform = tf_buffer_.lookupTransform(
+        "map", msg->header.frame_id, msg->header.stamp, rclcpp::Duration::from_seconds(0.05));
+      break;
+    case utils::PointcloudTransformSource::AtTimeZero:
+      transform = tf_buffer_.lookupTransform("map", msg->header.frame_id, tf2::TimePointZero);
+      RCLCPP_DEBUG(get_logger(), "pcl time is invalid, using tf2::TimePointZero");
+      break;
+    case utils::PointcloudTransformSource::None:
+      RCLCPP_WARN(get_logger(), "no transform found for no_ground_pointcloud");
+      return std::nullopt;
   }
 
   pcl::PointCloud<pcl::PointXYZ> pc_input;
@@ -277,36 +284,10 @@ void MotionVelocityPlannerNode::on_lanelet_map(
 void MotionVelocityPlannerNode::process_traffic_signals(
   const autoware_perception_msgs::msg::TrafficLightGroupArray::ConstSharedPtr msg)
 {
-  // clear previous observation
-  planner_data_->traffic_light_id_map_raw_.clear();
-  const auto traffic_light_id_map_last_observed_old =
-    planner_data_->traffic_light_id_map_last_observed_;
-  planner_data_->traffic_light_id_map_last_observed_.clear();
-  for (const auto & signal : msg->traffic_light_groups) {
-    TrafficSignalStamped traffic_signal;
-    traffic_signal.stamp = msg->stamp;
-    traffic_signal.signal = signal;
-    planner_data_->traffic_light_id_map_raw_[signal.traffic_light_group_id] = traffic_signal;
-    const bool is_unknown_observation =
-      std::any_of(signal.elements.begin(), signal.elements.end(), [](const auto & element) {
-        return element.color == autoware_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-      });
-    // if the observation is UNKNOWN and past observation is available, only update the timestamp
-    // and keep the body of the info
-    const auto old_data =
-      traffic_light_id_map_last_observed_old.find(signal.traffic_light_group_id);
-    if (is_unknown_observation && old_data != traffic_light_id_map_last_observed_old.end()) {
-      // copy last observation
-      planner_data_->traffic_light_id_map_last_observed_[signal.traffic_light_group_id] =
-        old_data->second;
-      // update timestamp
-      planner_data_->traffic_light_id_map_last_observed_[signal.traffic_light_group_id].stamp =
-        msg->stamp;
-    } else {
-      planner_data_->traffic_light_id_map_last_observed_[signal.traffic_light_group_id] =
-        traffic_signal;
-    }
-  }
+  auto processed =
+    utils::process_traffic_signals(*msg, planner_data_->traffic_light_id_map_last_observed_);
+  planner_data_->traffic_light_id_map_raw_ = std::move(processed.raw);
+  planner_data_->traffic_light_id_map_last_observed_ = std::move(processed.last_observed);
 }
 
 void MotionVelocityPlannerNode::on_trajectory(
@@ -419,20 +400,10 @@ autoware_planning_msgs::msg::Trajectory MotionVelocityPlannerNode::generate_traj
   processing_times["velocity_smoothing"] = stop_watch.toc("smooth");
 
   stop_watch.tic("resample");
-  TrajectoryPoints resampled_smoothed_trajectory_points;
   // skip points that are too close together to make computation easier
-  if (!smoothed_trajectory_points.empty()) {
-    resampled_smoothed_trajectory_points.push_back(smoothed_trajectory_points.front());
-    constexpr auto min_interval_squared = 0.5 * 0.5;  // TODO(Maxime): change to a parameter
-    for (auto i = 1UL; i < smoothed_trajectory_points.size(); ++i) {
-      const auto & p = smoothed_trajectory_points[i];
-      const auto dist_to_prev_point = autoware_utils_geometry::calc_squared_distance2d(
-        resampled_smoothed_trajectory_points.back(), p);
-      if (dist_to_prev_point > min_interval_squared) {
-        resampled_smoothed_trajectory_points.push_back(p);
-      }
-    }
-  }
+  constexpr auto min_interval_squared = 0.5 * 0.5;  // TODO(Maxime): change to a parameter
+  auto resampled_smoothed_trajectory_points =
+    utils::resample_trajectory_by_min_interval(smoothed_trajectory_points, min_interval_squared);
   processing_times["resample"] = stop_watch.toc("resample");
   stop_watch.tic("calculate_time_from_start");
   motion_utils::calculate_time_from_start(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node_utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node_utils.cpp
@@ -1,0 +1,84 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "node_utils.hpp"
+
+#include <autoware_utils_geometry/geometry.hpp>
+
+#include <algorithm>
+
+namespace autoware::motion_velocity_planner::utils
+{
+ProcessedTrafficSignals process_traffic_signals(
+  const autoware_perception_msgs::msg::TrafficLightGroupArray & msg,
+  const TrafficLightIdMap & last_observed_old)
+{
+  ProcessedTrafficSignals result;
+  for (const auto & signal : msg.traffic_light_groups) {
+    TrafficSignalStamped traffic_signal;
+    traffic_signal.stamp = msg.stamp;
+    traffic_signal.signal = signal;
+    result.raw[signal.traffic_light_group_id] = traffic_signal;
+    const bool is_unknown_observation =
+      std::any_of(signal.elements.begin(), signal.elements.end(), [](const auto & element) {
+        return element.color == autoware_perception_msgs::msg::TrafficLightElement::UNKNOWN;
+      });
+    // if the observation is UNKNOWN and past observation is available, only update the timestamp
+    // and keep the body of the info
+    const auto old_data = last_observed_old.find(signal.traffic_light_group_id);
+    if (is_unknown_observation && old_data != last_observed_old.end()) {
+      // copy last observation
+      result.last_observed[signal.traffic_light_group_id] = old_data->second;
+      // update timestamp
+      result.last_observed[signal.traffic_light_group_id].stamp = msg.stamp;
+    } else {
+      result.last_observed[signal.traffic_light_group_id] = traffic_signal;
+    }
+  }
+  return result;
+}
+
+TrajectoryPoints resample_trajectory_by_min_interval(
+  const TrajectoryPoints & trajectory_points, const double min_interval_squared)
+{
+  TrajectoryPoints resampled;
+  // skip points that are too close together to make computation easier
+  if (!trajectory_points.empty()) {
+    resampled.push_back(trajectory_points.front());
+    for (auto i = 1UL; i < trajectory_points.size(); ++i) {
+      const auto & p = trajectory_points[i];
+      const auto dist_to_prev_point =
+        autoware_utils_geometry::calc_squared_distance2d(resampled.back(), p);
+      if (dist_to_prev_point > min_interval_squared) {
+        resampled.push_back(p);
+      }
+    }
+  }
+  return resampled;
+}
+
+PointcloudTransformSource select_pointcloud_transform_source(
+  const bool is_pcl_time_valid, const bool can_transform_at_stamp,
+  const bool can_transform_at_time_zero)
+{
+  if (is_pcl_time_valid && can_transform_at_stamp) {
+    return PointcloudTransformSource::AtStamp;
+  }
+  if (can_transform_at_time_zero) {
+    return PointcloudTransformSource::AtTimeZero;
+  }
+  return PointcloudTransformSource::None;
+}
+
+}  // namespace autoware::motion_velocity_planner::utils

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node_utils.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node_utils.hpp
@@ -1,0 +1,81 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NODE_UTILS_HPP_
+#define NODE_UTILS_HPP_
+
+#include <autoware/motion_velocity_planner_common/planner_data.hpp>
+
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+#include <autoware_planning_msgs/msg/trajectory_point.hpp>
+
+#include <lanelet2_core/primitives/Lanelet.h>
+
+#include <map>
+#include <vector>
+
+namespace autoware::motion_velocity_planner::utils
+{
+using TrajectoryPoints = std::vector<autoware_planning_msgs::msg::TrajectoryPoint>;
+using TrafficLightIdMap = std::map<lanelet::Id, TrafficSignalStamped>;
+
+/// @brief result of processing a TrafficLightGroupArray observation
+struct ProcessedTrafficSignals
+{
+  /// @brief raw observation, one entry per traffic light group in the message
+  TrafficLightIdMap raw;
+  /// @brief last observed signals; for an UNKNOWN observation with a prior entry the previous body
+  ///        is kept and only the timestamp is refreshed
+  TrafficLightIdMap last_observed;
+};
+
+/// @brief which transform to use when transforming the no-ground pointcloud into the map frame
+enum class PointcloudTransformSource {
+  /// @brief use the transform at the pointcloud message stamp
+  AtStamp,
+  /// @brief the message stamp is stale or unavailable; fall back to the latest available transform
+  AtTimeZero,
+  /// @brief no transform is available; the pointcloud must be dropped
+  None,
+};
+
+/// @brief turn a raw TrafficLightGroupArray observation into the raw and last-observed maps
+/// @param msg incoming traffic light group array
+/// @param last_observed_old the previous last-observed map (used to keep the body of UNKNOWN
+///        observations that have a prior entry)
+/// @return the freshly built raw and last-observed maps
+ProcessedTrafficSignals process_traffic_signals(
+  const autoware_perception_msgs::msg::TrafficLightGroupArray & msg,
+  const TrafficLightIdMap & last_observed_old);
+
+/// @brief decimate a trajectory by dropping points that are closer than a minimum interval
+/// @details the first point is always kept; a later point is kept only when its squared 2D distance
+///          to the previously kept point exceeds @p min_interval_squared
+/// @param trajectory_points input trajectory points
+/// @param min_interval_squared squared minimum interval [m^2] between two consecutive kept points
+/// @return the decimated trajectory points (empty if the input is empty)
+TrajectoryPoints resample_trajectory_by_min_interval(
+  const TrajectoryPoints & trajectory_points, double min_interval_squared);
+
+/// @brief choose which transform source to use for the no-ground pointcloud
+/// @param is_pcl_time_valid whether the pointcloud stamp is recent enough to be trusted
+/// @param can_transform_at_stamp whether a transform is available at the pointcloud stamp
+/// @param can_transform_at_time_zero whether a transform is available at the latest time
+/// @return the transform source to use
+PointcloudTransformSource select_pointcloud_transform_source(
+  bool is_pcl_time_valid, bool can_transform_at_stamp, bool can_transform_at_time_zero);
+
+}  // namespace autoware::motion_velocity_planner::utils
+
+#endif  // NODE_UTILS_HPP_

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/test/test_node_utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/test/test_node_utils.cpp
@@ -1,0 +1,243 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/node_utils.hpp"
+
+#include <autoware_perception_msgs/msg/traffic_light_element.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+#include <autoware_planning_msgs/msg/trajectory_point.hpp>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace
+{
+using autoware::motion_velocity_planner::TrafficSignalStamped;
+using autoware::motion_velocity_planner::utils::PointcloudTransformSource;
+using autoware::motion_velocity_planner::utils::process_traffic_signals;
+using autoware::motion_velocity_planner::utils::resample_trajectory_by_min_interval;
+using autoware::motion_velocity_planner::utils::select_pointcloud_transform_source;
+using autoware::motion_velocity_planner::utils::TrafficLightIdMap;
+using autoware::motion_velocity_planner::utils::TrajectoryPoints;
+using autoware_perception_msgs::msg::TrafficLightElement;
+using autoware_perception_msgs::msg::TrafficLightGroup;
+using autoware_perception_msgs::msg::TrafficLightGroupArray;
+
+builtin_interfaces::msg::Time make_time(const int32_t sec, const uint32_t nanosec)
+{
+  builtin_interfaces::msg::Time t;
+  t.sec = sec;
+  t.nanosec = nanosec;
+  return t;
+}
+
+TrafficLightGroup make_group(const int64_t id, const uint8_t color)
+{
+  TrafficLightGroup group;
+  group.traffic_light_group_id = id;
+  TrafficLightElement element;
+  element.color = color;
+  group.elements.push_back(element);
+  return group;
+}
+
+autoware_planning_msgs::msg::TrajectoryPoint make_point(const double x, const double y)
+{
+  autoware_planning_msgs::msg::TrajectoryPoint p;
+  p.pose.position.x = x;
+  p.pose.position.y = y;
+  return p;
+}
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// process_traffic_signals
+// ---------------------------------------------------------------------------
+
+TEST(ProcessTrafficSignals, FreshGreenObservationStoresBodyInBothMaps)
+{
+  TrafficLightGroupArray msg;
+  msg.stamp = make_time(10, 0);
+  msg.traffic_light_groups.push_back(make_group(1, TrafficLightElement::GREEN));
+
+  const auto result = process_traffic_signals(msg, TrafficLightIdMap{});
+
+  ASSERT_EQ(result.raw.size(), 1U);
+  ASSERT_EQ(result.last_observed.size(), 1U);
+  const auto & raw = result.raw.at(1);
+  const auto & last = result.last_observed.at(1);
+  EXPECT_EQ(raw.stamp.sec, 10);
+  ASSERT_EQ(raw.signal.elements.size(), 1U);
+  EXPECT_EQ(raw.signal.elements.front().color, TrafficLightElement::GREEN);
+  // fresh observation: last_observed mirrors the raw observation
+  EXPECT_EQ(last.stamp.sec, 10);
+  ASSERT_EQ(last.signal.elements.size(), 1U);
+  EXPECT_EQ(last.signal.elements.front().color, TrafficLightElement::GREEN);
+}
+
+TEST(ProcessTrafficSignals, UnknownWithPriorKeepsBodyAndRefreshesStamp)
+{
+  // prior observation: GREEN at t=5
+  TrafficLightIdMap last_observed_old;
+  {
+    TrafficSignalStamped prior;
+    prior.stamp = make_time(5, 0);
+    prior.signal = make_group(1, TrafficLightElement::GREEN);
+    last_observed_old[1] = prior;
+  }
+
+  // new observation: UNKNOWN at t=10
+  TrafficLightGroupArray msg;
+  msg.stamp = make_time(10, 0);
+  msg.traffic_light_groups.push_back(make_group(1, TrafficLightElement::UNKNOWN));
+
+  const auto result = process_traffic_signals(msg, last_observed_old);
+
+  // raw always reflects the new (UNKNOWN) observation with the new stamp
+  ASSERT_EQ(result.raw.size(), 1U);
+  EXPECT_EQ(result.raw.at(1).stamp.sec, 10);
+  ASSERT_EQ(result.raw.at(1).signal.elements.size(), 1U);
+  EXPECT_EQ(result.raw.at(1).signal.elements.front().color, TrafficLightElement::UNKNOWN);
+
+  // last_observed keeps the prior GREEN body but refreshes the stamp to the new time
+  ASSERT_EQ(result.last_observed.size(), 1U);
+  const auto & last = result.last_observed.at(1);
+  EXPECT_EQ(last.stamp.sec, 10);
+  ASSERT_EQ(last.signal.elements.size(), 1U);
+  EXPECT_EQ(last.signal.elements.front().color, TrafficLightElement::GREEN);
+}
+
+TEST(ProcessTrafficSignals, UnknownWithoutPriorStoresUnknownBody)
+{
+  TrafficLightGroupArray msg;
+  msg.stamp = make_time(10, 0);
+  msg.traffic_light_groups.push_back(make_group(2, TrafficLightElement::UNKNOWN));
+
+  const auto result = process_traffic_signals(msg, TrafficLightIdMap{});
+
+  ASSERT_EQ(result.last_observed.size(), 1U);
+  const auto & last = result.last_observed.at(2);
+  EXPECT_EQ(last.stamp.sec, 10);
+  ASSERT_EQ(last.signal.elements.size(), 1U);
+  // no prior -> the UNKNOWN body is stored as-is
+  EXPECT_EQ(last.signal.elements.front().color, TrafficLightElement::UNKNOWN);
+}
+
+TEST(ProcessTrafficSignals, EmptyMessageClearsBothMaps)
+{
+  TrafficLightIdMap last_observed_old;
+  {
+    TrafficSignalStamped prior;
+    prior.stamp = make_time(5, 0);
+    prior.signal = make_group(1, TrafficLightElement::GREEN);
+    last_observed_old[1] = prior;
+  }
+
+  TrafficLightGroupArray msg;
+  msg.stamp = make_time(10, 0);
+
+  const auto result = process_traffic_signals(msg, last_observed_old);
+
+  EXPECT_TRUE(result.raw.empty());
+  EXPECT_TRUE(result.last_observed.empty());
+}
+
+// ---------------------------------------------------------------------------
+// resample_trajectory_by_min_interval
+// ---------------------------------------------------------------------------
+
+TEST(ResampleTrajectoryByMinInterval, EmptyInputReturnsEmpty)
+{
+  const auto out = resample_trajectory_by_min_interval(TrajectoryPoints{}, 0.25);
+  EXPECT_TRUE(out.empty());
+}
+
+TEST(ResampleTrajectoryByMinInterval, SinglePointIsKept)
+{
+  TrajectoryPoints in{make_point(1.0, 2.0)};
+  const auto out = resample_trajectory_by_min_interval(in, 0.25);
+  ASSERT_EQ(out.size(), 1U);
+  EXPECT_DOUBLE_EQ(out.front().pose.position.x, 1.0);
+  EXPECT_DOUBLE_EQ(out.front().pose.position.y, 2.0);
+}
+
+TEST(ResampleTrajectoryByMinInterval, AllPointsCloserThanThresholdKeepOnlyFirst)
+{
+  // step of 0.1 m -> squared distance 0.01 < threshold 0.25
+  TrajectoryPoints in;
+  for (int i = 0; i < 5; ++i) {
+    in.push_back(make_point(0.1 * i, 0.0));
+  }
+  const auto out = resample_trajectory_by_min_interval(in, 0.5 * 0.5);
+  ASSERT_EQ(out.size(), 1U);
+  EXPECT_DOUBLE_EQ(out.front().pose.position.x, 0.0);
+}
+
+TEST(ResampleTrajectoryByMinInterval, KeepsPointsBeyondThresholdRelativeToLastKept)
+{
+  // points at x = 0.0, 0.4, 0.8, 1.2 with threshold 0.25 (=0.5^2)
+  // 0.0 kept (first); 0.4 -> 0.16 < 0.25 dropped; 0.8 -> 0.64 > 0.25 kept;
+  // 1.2 -> dist to last kept (0.8) is 0.16 < 0.25 dropped.
+  TrajectoryPoints in{
+    make_point(0.0, 0.0), make_point(0.4, 0.0), make_point(0.8, 0.0), make_point(1.2, 0.0)};
+  const auto out = resample_trajectory_by_min_interval(in, 0.5 * 0.5);
+  ASSERT_EQ(out.size(), 2U);
+  EXPECT_DOUBLE_EQ(out[0].pose.position.x, 0.0);
+  EXPECT_DOUBLE_EQ(out[1].pose.position.x, 0.8);
+}
+
+TEST(ResampleTrajectoryByMinInterval, ExactlyAtThresholdIsDropped)
+{
+  // squared distance exactly equal to threshold -> dropped (strict > comparison)
+  TrajectoryPoints in{make_point(0.0, 0.0), make_point(0.5, 0.0)};
+  const auto out = resample_trajectory_by_min_interval(in, 0.5 * 0.5);
+  ASSERT_EQ(out.size(), 1U);
+  EXPECT_DOUBLE_EQ(out.front().pose.position.x, 0.0);
+}
+
+// ---------------------------------------------------------------------------
+// select_pointcloud_transform_source
+// ---------------------------------------------------------------------------
+
+TEST(SelectPointcloudTransformSource, ValidTimeAndStampTransformUsesStamp)
+{
+  EXPECT_EQ(
+    select_pointcloud_transform_source(true, true, true), PointcloudTransformSource::AtStamp);
+  EXPECT_EQ(
+    select_pointcloud_transform_source(true, true, false), PointcloudTransformSource::AtStamp);
+}
+
+TEST(SelectPointcloudTransformSource, InvalidTimeFallsBackToTimeZero)
+{
+  EXPECT_EQ(
+    select_pointcloud_transform_source(false, true, true), PointcloudTransformSource::AtTimeZero);
+}
+
+TEST(SelectPointcloudTransformSource, ValidTimeButNoStampTransformFallsBackToTimeZero)
+{
+  EXPECT_EQ(
+    select_pointcloud_transform_source(true, false, true), PointcloudTransformSource::AtTimeZero);
+}
+
+TEST(SelectPointcloudTransformSource, NoTransformAvailableReturnsNone)
+{
+  EXPECT_EQ(
+    select_pointcloud_transform_source(true, false, false), PointcloudTransformSource::None);
+  EXPECT_EQ(
+    select_pointcloud_transform_source(false, true, false), PointcloudTransformSource::None);
+  EXPECT_EQ(
+    select_pointcloud_transform_source(false, false, false), PointcloudTransformSource::None);
+}


### PR DESCRIPTION
## What

Extract three pure pieces of `MotionVelocityPlannerNode` logic into free functions in a new internal header (`src/node_utils.hpp` / `src/node_utils.cpp`), turning the node methods into thin wrappers. No public node API change.

- `process_traffic_signals(msg, last_observed_old) -> {raw, last_observed}`: builds the raw and last-observed traffic-light maps from a `TrafficLightGroupArray`, including the subtle UNKNOWN-with-prior carry-over (keep the prior body, only refresh the timestamp).
- `resample_trajectory_by_min_interval(points, min_interval_squared)`: the min-interval point decimation previously inlined in `generate_trajectory` (first point always kept; later point kept only when squared 2D distance to the previously kept point exceeds the threshold).
- `select_pointcloud_transform_source(is_pcl_time_valid, can_transform_at_stamp, can_transform_at_time_zero)`: the TF transform-selection branch from `process_no_ground_pointcloud`, expressed as a pure decision over `canTransform` results (at-stamp / time-zero fallback / none). The node still performs the actual `lookupTransform` and logging; only the branch decision is extracted, isolating it from `tf2_ros` and the node clock.

## Why

All three were buried in private node methods reachable only through the full node via pub/sub, so their decision branches (UNKNOWN traffic-signal carry-over, empty/single-point/all-close resampling, TF fallback/no-transform) were untested. Extracting them creates a unit-test seam without changing behavior. Addresses the `testability` (high) and `coverage_gaps` findings for this package in the refactor campaign.

## Tests

New `test_node_utils` gtest (13 cases) asserting concrete values/branches:
- traffic signals: fresh observation mirrored into both maps; UNKNOWN-with-prior keeps prior body + refreshes stamp; UNKNOWN-without-prior stores the UNKNOWN body; empty message clears both maps.
- resampling: empty input -> empty; single point kept; all-points-closer-than-threshold keeps only the first; points beyond threshold (relative to last kept) survive; distance exactly equal to threshold is dropped (pins the strict `>` comparison).
- transform source: valid-time+stamp -> AtStamp; invalid time -> AtTimeZero; valid time but no stamp transform -> AtTimeZero; nothing available -> None.

## Verification

Built and unit-tested in the `autoware:core-devel-jazzy` container. `colcon build` is green; `test_node_utils` is 13/13 green. The pre-existing integration test `test_node` passes in isolation on this branch identically to upstream/main (it is byte-identical and untouched); a flaky timeout only appeared when both ROS gtests ran concurrently under the container's disabled-multicast networking, which the full fork CI does not hit.

Behavior preserving.

Refs: autowarefoundation/autoware_core#1096
