### PR TITLE
refactor(autoware_gnss_poser): drop dead helpers, per-instance prev_position, unit-test pure statics

### DIFF
--- a/sensing/autoware_gnss_poser/src/gnss_poser_node.cpp
+++ b/sensing/autoware_gnss_poser/src/gnss_poser_node.cpp
@@ -147,9 +147,12 @@ void GNSSPoser::callback_nav_sat_fix(
   if (use_gnss_ins_orientation_) {
     orientation = msg_gnss_ins_orientation_stamped_->orientation.orientation;
   } else {
-    static auto prev_position = gnss_antenna_pose.position;
-    orientation = get_quaternion_by_position_difference(gnss_antenna_pose.position, prev_position);
-    prev_position = gnss_antenna_pose.position;
+    if (!has_prev_position_) {
+      prev_position_ = gnss_antenna_pose.position;
+      has_prev_position_ = true;
+    }
+    orientation = get_quaternion_by_position_difference(gnss_antenna_pose.position, prev_position_);
+    prev_position_ = gnss_antenna_pose.position;
   }
 
   gnss_antenna_pose.orientation = orientation;
@@ -276,23 +279,6 @@ geometry_msgs::msg::Point GNSSPoser::get_average_position(
   return average_point;
 }
 
-geometry_msgs::msg::Quaternion GNSSPoser::get_quaternion_by_heading(const int heading)
-{
-  int heading_conv = 0;
-  // convert heading[0(North)~360] to yaw[-M_PI(West)~M_PI]
-  if (heading >= 0 && heading <= 27000000) {
-    heading_conv = 9000000 - heading;
-  } else {
-    heading_conv = 45000000 - heading;
-  }
-  const double yaw = (heading_conv * 1e-5) * M_PI / 180.0;
-
-  tf2::Quaternion quaternion;
-  quaternion.setRPY(0, 0, yaw);
-
-  return tf2::toMsg(quaternion);
-}
-
 geometry_msgs::msg::Quaternion GNSSPoser::get_quaternion_by_position_difference(
   const geometry_msgs::msg::Point & point, const geometry_msgs::msg::Point & prev_point)
 {
@@ -300,49 +286,6 @@ geometry_msgs::msg::Quaternion GNSSPoser::get_quaternion_by_position_difference(
   tf2::Quaternion quaternion;
   quaternion.setRPY(0, 0, yaw);
   return tf2::toMsg(quaternion);
-}
-
-bool GNSSPoser::get_transform(
-  const std::string & target_frame, const std::string & source_frame,
-  const geometry_msgs::msg::TransformStamped::SharedPtr transform_stamped_ptr)
-{
-  if (target_frame == source_frame) {
-    transform_stamped_ptr->header.stamp = this->now();
-    transform_stamped_ptr->header.frame_id = target_frame;
-    transform_stamped_ptr->child_frame_id = source_frame;
-    transform_stamped_ptr->transform.translation.x = 0.0;
-    transform_stamped_ptr->transform.translation.y = 0.0;
-    transform_stamped_ptr->transform.translation.z = 0.0;
-    transform_stamped_ptr->transform.rotation.x = 0.0;
-    transform_stamped_ptr->transform.rotation.y = 0.0;
-    transform_stamped_ptr->transform.rotation.z = 0.0;
-    transform_stamped_ptr->transform.rotation.w = 1.0;
-    return true;
-  }
-
-  try {
-    *transform_stamped_ptr =
-      tf2_buffer_.lookupTransform(target_frame, source_frame, tf2::TimePointZero);
-  } catch (tf2::TransformException & ex) {
-    RCLCPP_WARN_STREAM_THROTTLE(
-      this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(), ex.what());
-    RCLCPP_WARN_STREAM_THROTTLE(
-      this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
-      "Please publish TF " << target_frame.c_str() << " to " << source_frame.c_str());
-
-    transform_stamped_ptr->header.stamp = this->now();
-    transform_stamped_ptr->header.frame_id = target_frame;
-    transform_stamped_ptr->child_frame_id = source_frame;
-    transform_stamped_ptr->transform.translation.x = 0.0;
-    transform_stamped_ptr->transform.translation.y = 0.0;
-    transform_stamped_ptr->transform.translation.z = 0.0;
-    transform_stamped_ptr->transform.rotation.x = 0.0;
-    transform_stamped_ptr->transform.rotation.y = 0.0;
-    transform_stamped_ptr->transform.rotation.z = 0.0;
-    transform_stamped_ptr->transform.rotation.w = 1.0;
-    return false;
-  }
-  return true;
 }
 
 bool GNSSPoser::get_static_transform(

--- a/sensing/autoware_gnss_poser/src/gnss_poser_node.hpp
+++ b/sensing/autoware_gnss_poser/src/gnss_poser_node.hpp
@@ -31,6 +31,10 @@
 
 #include <string>
 
+// Forward declaration so the unit-test fixture (defined at global scope) can be granted access to
+// the pure static helpers below without spinning up a node.
+class GNSSPoserHelpersTest;
+
 namespace autoware::gnss_poser
 {
 class GNSSPoser : public rclcpp::Node
@@ -39,6 +43,9 @@ public:
   explicit GNSSPoser(const rclcpp::NodeOptions & node_options);
 
 private:
+  // Allow unit tests to exercise the pure static helpers directly.
+  friend class ::GNSSPoserHelpersTest;
+
   void callback_map_projector_info(
     const autoware_map_msgs::msg::MapProjectorInfo::ConstSharedPtr msg);
   void callback_nav_sat_fix(const sensor_msgs::msg::NavSatFix::ConstSharedPtr nav_sat_fix_msg_ptr);
@@ -51,13 +58,9 @@ private:
     const boost::circular_buffer<geometry_msgs::msg::Point> & position_buffer);
   static geometry_msgs::msg::Point get_average_position(
     const boost::circular_buffer<geometry_msgs::msg::Point> & position_buffer);
-  static geometry_msgs::msg::Quaternion get_quaternion_by_heading(const int heading);
   static geometry_msgs::msg::Quaternion get_quaternion_by_position_difference(
     const geometry_msgs::msg::Point & point, const geometry_msgs::msg::Point & prev_point);
 
-  bool get_transform(
-    const std::string & target_frame, const std::string & source_frame,
-    const geometry_msgs::msg::TransformStamped::SharedPtr transform_stamped_ptr);
   bool get_static_transform(
     const std::string & target_frame, const std::string & source_frame,
     const geometry_msgs::msg::TransformStamped::SharedPtr transform_stamped_ptr,
@@ -87,6 +90,11 @@ private:
   bool use_gnss_ins_orientation_;
 
   boost::circular_buffer<geometry_msgs::msg::Point> position_buffer_;
+
+  // Previous antenna position used to derive orientation from motion. Owned per instance so the
+  // orientation-from-motion path is deterministic and reset on construction.
+  geometry_msgs::msg::Point prev_position_;
+  bool has_prev_position_ = false;
 
   autoware_sensing_msgs::msg::GnssInsOrientationStamped::SharedPtr
     msg_gnss_ins_orientation_stamped_;

--- a/sensing/autoware_gnss_poser/test/test_gnss_poser_node.cpp
+++ b/sensing/autoware_gnss_poser/test/test_gnss_poser_node.cpp
@@ -24,8 +24,11 @@
 #include <sensor_msgs/msg/nav_sat_fix.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
+#include <boost/circular_buffer.hpp>
+
 #include <gtest/gtest.h>
 
+#include <cmath>
 #include <memory>
 #include <string>
 #include <vector>
@@ -574,6 +577,139 @@ TEST_F(GNSSPoserTest, TestMedianPosition)
   EXPECT_TRUE(pose_received_);
   EXPECT_NE(last_pose_.pose.position.x, 0.0);
   EXPECT_NE(last_pose_.pose.position.y, 0.0);
+}
+
+namespace
+{
+geometry_msgs::msg::Point makePoint(double x, double y, double z)
+{
+  geometry_msgs::msg::Point point;
+  point.x = x;
+  point.y = y;
+  point.z = z;
+  return point;
+}
+
+boost::circular_buffer<geometry_msgs::msg::Point> makePositionBuffer(
+  const std::vector<geometry_msgs::msg::Point> & points)
+{
+  boost::circular_buffer<geometry_msgs::msg::Point> buffer(points.size());
+  for (const auto & point : points) {
+    buffer.push_back(point);
+  }
+  return buffer;
+}
+
+double yawOf(const geometry_msgs::msg::Quaternion & quaternion)
+{
+  tf2::Quaternion tf_quaternion;
+  tf2::fromMsg(quaternion, tf_quaternion);
+  double roll = 0.0;
+  double pitch = 0.0;
+  double yaw = 0.0;
+  tf2::Matrix3x3(tf_quaternion).getRPY(roll, pitch, yaw);
+  return yaw;
+}
+}  // namespace
+
+// Direct unit tests for the pure static helpers of GNSSPoser. The fixture is declared a friend of
+// GNSSPoser so it can reach the private static methods without spinning up a node/executor.
+class GNSSPoserHelpersTest : public ::testing::Test
+{
+protected:
+  static geometry_msgs::msg::Point getMedianPosition(
+    const boost::circular_buffer<geometry_msgs::msg::Point> & position_buffer)
+  {
+    return autoware::gnss_poser::GNSSPoser::get_median_position(position_buffer);
+  }
+
+  static geometry_msgs::msg::Point getAveragePosition(
+    const boost::circular_buffer<geometry_msgs::msg::Point> & position_buffer)
+  {
+    return autoware::gnss_poser::GNSSPoser::get_average_position(position_buffer);
+  }
+
+  static geometry_msgs::msg::Quaternion getQuaternionByPositionDifference(
+    const geometry_msgs::msg::Point & point, const geometry_msgs::msg::Point & prev_point)
+  {
+    return autoware::gnss_poser::GNSSPoser::get_quaternion_by_position_difference(
+      point, prev_point);
+  }
+};
+
+// Odd-sized buffer: median is the middle element of each coordinate.
+TEST_F(GNSSPoserHelpersTest, MedianPositionOddSize)
+{
+  const auto buffer = makePositionBuffer({
+    makePoint(3.0, 30.0, 300.0),
+    makePoint(1.0, 10.0, 100.0),
+    makePoint(2.0, 20.0, 200.0),
+  });
+
+  const auto median = getMedianPosition(buffer);
+  EXPECT_DOUBLE_EQ(median.x, 2.0);
+  EXPECT_DOUBLE_EQ(median.y, 20.0);
+  EXPECT_DOUBLE_EQ(median.z, 200.0);
+}
+
+// Even-sized buffer: median averages the two central elements (previously uncovered branch).
+TEST_F(GNSSPoserHelpersTest, MedianPositionEvenSize)
+{
+  const auto buffer = makePositionBuffer({
+    makePoint(4.0, 40.0, 400.0),
+    makePoint(1.0, 10.0, 100.0),
+    makePoint(3.0, 30.0, 300.0),
+    makePoint(2.0, 20.0, 200.0),
+  });
+
+  // Sorted x: {1,2,3,4} -> median = (2+3)/2 = 2.5; same scaling applies to y and z.
+  const auto median = getMedianPosition(buffer);
+  EXPECT_DOUBLE_EQ(median.x, 2.5);
+  EXPECT_DOUBLE_EQ(median.y, 25.0);
+  EXPECT_DOUBLE_EQ(median.z, 250.0);
+}
+
+// Average asserts the actual mean values (previously only existence was checked).
+TEST_F(GNSSPoserHelpersTest, AveragePositionValues)
+{
+  const auto buffer = makePositionBuffer({
+    makePoint(1.0, 10.0, 100.0),
+    makePoint(2.0, 20.0, 200.0),
+    makePoint(6.0, 60.0, 600.0),
+  });
+
+  const auto average = getAveragePosition(buffer);
+  EXPECT_DOUBLE_EQ(average.x, 3.0);
+  EXPECT_DOUBLE_EQ(average.y, 30.0);
+  EXPECT_DOUBLE_EQ(average.z, 300.0);
+}
+
+// Orientation-from-motion across the cardinal directions, plus the identical-points edge case.
+TEST_F(GNSSPoserHelpersTest, QuaternionByPositionDifferenceHeadings)
+{
+  const auto origin = makePoint(0.0, 0.0, 0.0);
+
+  // East: dx>0, dy=0 -> yaw 0.
+  EXPECT_NEAR(
+    yawOf(getQuaternionByPositionDifference(makePoint(1.0, 0.0, 0.0), origin)), 0.0, 1e-9);
+
+  // North: dy>0, dx=0 -> yaw +PI/2.
+  EXPECT_NEAR(
+    yawOf(getQuaternionByPositionDifference(makePoint(0.0, 1.0, 0.0), origin)), M_PI / 2.0, 1e-9);
+
+  // West: dx<0, dy=0 -> yaw +-PI.
+  EXPECT_NEAR(
+    std::abs(yawOf(getQuaternionByPositionDifference(makePoint(-1.0, 0.0, 0.0), origin))), M_PI,
+    1e-9);
+
+  // South: dy<0, dx=0 -> yaw -PI/2.
+  EXPECT_NEAR(
+    yawOf(getQuaternionByPositionDifference(makePoint(0.0, -1.0, 0.0), origin)), -M_PI / 2.0, 1e-9);
+
+  // Identical points: atan2(0,0) -> yaw 0 (identity quaternion).
+  const auto identity = getQuaternionByPositionDifference(origin, origin);
+  EXPECT_NEAR(yawOf(identity), 0.0, 1e-9);
+  EXPECT_DOUBLE_EQ(identity.w, 1.0);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
## What

Internal-only cleanup of the GNSS poser node, plus direct unit tests for its pure static helpers.

- Delete the dead `get_quaternion_by_heading` and `get_transform` helpers (both declared and defined but never called anywhere in `autoware_core`; only `get_static_transform` is invoked from `callback_nav_sat_fix`). `get_quaternion_by_heading` carried an untested, non-obvious heading->yaw conversion; `get_transform` was an untested near-duplicate of `get_static_transform`.
- Replace the function-local `static prev_position` inside `callback_nav_sat_fix` with a per-instance `prev_position_` member guarded by `has_prev_position_`. The old static was process-global mutable state shared across all `GNSSPoser` instances and never reset between node rebuilds, making the orientation-from-motion path non-deterministic and untestable in isolation. The first-sample behavior is preserved exactly: on the first non-INS sample `prev_position_` is initialized to the current position, so the initial difference is zero and yields an identity orientation, matching the previous code.
- Add direct unit tests for the pure static helpers via a `friend` test fixture, so they no longer rely solely on a full node + `SingleThreadedExecutor` + pub/sub round-trip:
  - `get_median_position` with an odd-sized buffer (middle element) and an even-sized buffer (averaging the two central elements — previously uncovered branch).
  - `get_average_position` asserting the actual mean values (previously only existence was checked).
  - `get_quaternion_by_position_difference` across all four cardinal headings (east/north/west/south) plus the identical-points `atan2(0,0)` edge case.

## Why

Addresses the `autoware_gnss_poser` findings in the Core quality campaign: dead code removal, removal of a function-local-static state hazard, and closing the pure-helper coverage gaps.

## Behavior

No public API change. Behavior-preserving: the only observable difference is that orientation-from-motion state is now per-instance and reset on construction (the previous shared static could leak stale state across instances/tests); the per-call output for a single instance is unchanged.

Refs: autowarefoundation/autoware_core#1096
