### PR TITLE
refactor(autoware_map_loader): dedup PCD cell loader and cover selected module

### DIFF
--- a/map/autoware_map_loader/CMakeLists.txt
+++ b/map/autoware_map_loader/CMakeLists.txt
@@ -66,6 +66,7 @@ if(BUILD_TESTING)
   add_testcase(test/test_pointcloud_map_loader_module.cpp)
   add_testcase(test/test_partial_map_loader_module.cpp)
   add_testcase(test/test_differential_map_loader_module.cpp)
+  add_testcase(test/test_selected_map_loader_module.cpp)
   add_testcase(test/test_lanelet2_map_loader_utils.cpp)
 endif()
 

--- a/map/autoware_map_loader/src/pointcloud_map_loader/differential_map_loader_module.cpp
+++ b/map/autoware_map_loader/src/pointcloud_map_loader/differential_map_loader_module.cpp
@@ -53,13 +53,8 @@ void DifferentialMapLoaderModule::differential_area_load(
       int index = static_cast<int>(id_in_cached_list - cached_ids.begin());
       should_remove[index] = false;
     } else {
-      autoware_map_msgs::msg::PointCloudMapCellWithID pointcloud_map_cell_with_id =
-        load_point_cloud_map_cell_with_id(path, map_id);
-      pointcloud_map_cell_with_id.metadata.min_x = metadata.min.x;
-      pointcloud_map_cell_with_id.metadata.min_y = metadata.min.y;
-      pointcloud_map_cell_with_id.metadata.max_x = metadata.max.x;
-      pointcloud_map_cell_with_id.metadata.max_y = metadata.max.y;
-      response->new_pointcloud_with_ids.push_back(pointcloud_map_cell_with_id);
+      response->new_pointcloud_with_ids.push_back(
+        load_point_cloud_map_cell_with_id(logger_, path, map_id, metadata));
     }
   }
 
@@ -79,19 +74,5 @@ bool DifferentialMapLoaderModule::on_service_get_differential_point_cloud_map(
   differential_area_load(area, cached_ids, res);
   res->header.frame_id = "map";
   return true;
-}
-
-autoware_map_msgs::msg::PointCloudMapCellWithID
-DifferentialMapLoaderModule::load_point_cloud_map_cell_with_id(
-  const std::string & path, const std::string & map_id) const
-{
-  sensor_msgs::msg::PointCloud2 pcd;
-  if (pcl::io::loadPCDFile(path, pcd) == -1) {
-    RCLCPP_ERROR_STREAM(logger_, "PCD load failed: " << path);
-  }
-  autoware_map_msgs::msg::PointCloudMapCellWithID pointcloud_map_cell_with_id;
-  pointcloud_map_cell_with_id.pointcloud = pcd;
-  pointcloud_map_cell_with_id.cell_id = map_id;
-  return pointcloud_map_cell_with_id;
 }
 }  // namespace autoware::map_loader

--- a/map/autoware_map_loader/src/pointcloud_map_loader/differential_map_loader_module.hpp
+++ b/map/autoware_map_loader/src/pointcloud_map_loader/differential_map_loader_module.hpp
@@ -54,8 +54,6 @@ private:
   void differential_area_load(
     const autoware_map_msgs::msg::AreaInfo & area_info, const std::vector<std::string> & cached_ids,
     const GetDifferentialPointCloudMap::Response::SharedPtr & response) const;
-  [[nodiscard]] autoware_map_msgs::msg::PointCloudMapCellWithID load_point_cloud_map_cell_with_id(
-    const std::string & path, const std::string & map_id) const;
 };
 }  // namespace autoware::map_loader
 

--- a/map/autoware_map_loader/src/pointcloud_map_loader/partial_map_loader_module.cpp
+++ b/map/autoware_map_loader/src/pointcloud_map_loader/partial_map_loader_module.cpp
@@ -46,14 +46,8 @@ void PartialMapLoaderModule::partial_area_load(
     // skip if the pcd file is not within the queried area
     if (!is_grid_within_queried_area(area, metadata)) continue;
 
-    autoware_map_msgs::msg::PointCloudMapCellWithID pointcloud_map_cell_with_id =
-      load_point_cloud_map_cell_with_id(path, map_id);
-    pointcloud_map_cell_with_id.metadata.min_x = metadata.min.x;
-    pointcloud_map_cell_with_id.metadata.min_y = metadata.min.y;
-    pointcloud_map_cell_with_id.metadata.max_x = metadata.max.x;
-    pointcloud_map_cell_with_id.metadata.max_y = metadata.max.y;
-
-    response->new_pointcloud_with_ids.push_back(pointcloud_map_cell_with_id);
+    response->new_pointcloud_with_ids.push_back(
+      load_point_cloud_map_cell_with_id(logger_, path, map_id, metadata));
   }
 }
 
@@ -65,19 +59,5 @@ bool PartialMapLoaderModule::on_service_get_partial_point_cloud_map(
   partial_area_load(area, res);
   res->header.frame_id = "map";
   return true;
-}
-
-autoware_map_msgs::msg::PointCloudMapCellWithID
-PartialMapLoaderModule::load_point_cloud_map_cell_with_id(
-  const std::string & path, const std::string & map_id) const
-{
-  sensor_msgs::msg::PointCloud2 pcd;
-  if (pcl::io::loadPCDFile(path, pcd) == -1) {
-    RCLCPP_ERROR_STREAM(logger_, "PCD load failed: " << path);
-  }
-  autoware_map_msgs::msg::PointCloudMapCellWithID pointcloud_map_cell_with_id;
-  pointcloud_map_cell_with_id.pointcloud = pcd;
-  pointcloud_map_cell_with_id.cell_id = map_id;
-  return pointcloud_map_cell_with_id;
 }
 }  // namespace autoware::map_loader

--- a/map/autoware_map_loader/src/pointcloud_map_loader/partial_map_loader_module.hpp
+++ b/map/autoware_map_loader/src/pointcloud_map_loader/partial_map_loader_module.hpp
@@ -54,8 +54,6 @@ private:
   void partial_area_load(
     const autoware_map_msgs::msg::AreaInfo & area,
     const GetPartialPointCloudMap::Response::SharedPtr & response) const;
-  [[nodiscard]] autoware_map_msgs::msg::PointCloudMapCellWithID load_point_cloud_map_cell_with_id(
-    const std::string & path, const std::string & map_id) const;
 };
 }  // namespace autoware::map_loader
 

--- a/map/autoware_map_loader/src/pointcloud_map_loader/selected_map_loader_module.cpp
+++ b/map/autoware_map_loader/src/pointcloud_map_loader/selected_map_loader_module.cpp
@@ -81,32 +81,12 @@ bool SelectedMapLoaderModule::on_service_get_selected_point_cloud_map(
     const std::string path = requested_selected_map_iterator->first;
     // assume that the map ID = map path (for now)
     const std::string & map_id = path;
-    PCDFileMetadata metadata = requested_selected_map_iterator->second;
+    const PCDFileMetadata & metadata = requested_selected_map_iterator->second;
 
-    autoware_map_msgs::msg::PointCloudMapCellWithID pointcloud_map_cell_with_id =
-      load_point_cloud_map_cell_with_id(path, map_id);
-    pointcloud_map_cell_with_id.metadata.min_x = metadata.min.x;
-    pointcloud_map_cell_with_id.metadata.min_y = metadata.min.y;
-    pointcloud_map_cell_with_id.metadata.max_x = metadata.max.x;
-    pointcloud_map_cell_with_id.metadata.max_y = metadata.max.y;
-
-    res->new_pointcloud_with_ids.push_back(pointcloud_map_cell_with_id);
+    res->new_pointcloud_with_ids.push_back(
+      load_point_cloud_map_cell_with_id(logger_, path, map_id, metadata));
   }
   res->header.frame_id = "map";
   return true;
-}
-
-autoware_map_msgs::msg::PointCloudMapCellWithID
-SelectedMapLoaderModule::load_point_cloud_map_cell_with_id(
-  const std::string & path, const std::string & map_id) const
-{
-  sensor_msgs::msg::PointCloud2 pcd;
-  if (pcl::io::loadPCDFile(path, pcd) == -1) {
-    RCLCPP_ERROR_STREAM(logger_, "PCD load failed: " << path);
-  }
-  autoware_map_msgs::msg::PointCloudMapCellWithID pointcloud_map_cell_with_id;
-  pointcloud_map_cell_with_id.pointcloud = pcd;
-  pointcloud_map_cell_with_id.cell_id = map_id;
-  return pointcloud_map_cell_with_id;
 }
 }  // namespace autoware::map_loader

--- a/map/autoware_map_loader/src/pointcloud_map_loader/selected_map_loader_module.hpp
+++ b/map/autoware_map_loader/src/pointcloud_map_loader/selected_map_loader_module.hpp
@@ -35,6 +35,11 @@
 
 namespace autoware::map_loader
 {
+// Build the durable map-metadata message published on construction from the PCD metadata dict.
+// Declared here so it can be unit-tested directly without instantiating the module.
+autoware_map_msgs::msg::PointCloudMapMetaData create_metadata(
+  const std::map<std::string, PCDFileMetadata> & pcd_file_metadata_dict);
+
 class SelectedMapLoaderModule
 {
   using GetSelectedPointCloudMap = autoware_map_msgs::srv::GetSelectedPointCloudMap;
@@ -54,8 +59,6 @@ private:
   [[nodiscard]] bool on_service_get_selected_point_cloud_map(
     GetSelectedPointCloudMap::Request::SharedPtr req,
     GetSelectedPointCloudMap::Response::SharedPtr res) const;
-  [[nodiscard]] autoware_map_msgs::msg::PointCloudMapCellWithID load_point_cloud_map_cell_with_id(
-    const std::string & path, const std::string & map_id) const;
 };
 }  // namespace autoware::map_loader
 

--- a/map/autoware_map_loader/src/pointcloud_map_loader/utils.cpp
+++ b/map/autoware_map_loader/src/pointcloud_map_loader/utils.cpp
@@ -14,7 +14,13 @@
 
 #include "utils.hpp"
 
+#include <rclcpp/logging.hpp>
+
+#include <sensor_msgs/msg/point_cloud2.hpp>
+
 #include <fmt/format.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl_conversions/pcl_conversions.h>
 
 #include <map>
 #include <set>
@@ -109,5 +115,23 @@ bool is_grid_within_queried_area(
   bool res =
     cylinder_and_box_overlap_exists(center_x, center_y, radius, metadata.min, metadata.max);
   return res;
+}
+
+autoware_map_msgs::msg::PointCloudMapCellWithID load_point_cloud_map_cell_with_id(
+  const rclcpp::Logger & logger, const std::string & path, const std::string & map_id,
+  const PCDFileMetadata & metadata)
+{
+  sensor_msgs::msg::PointCloud2 pcd;
+  if (pcl::io::loadPCDFile(path, pcd) == -1) {
+    RCLCPP_ERROR_STREAM(logger, "PCD load failed: " << path);
+  }
+  autoware_map_msgs::msg::PointCloudMapCellWithID pointcloud_map_cell_with_id;
+  pointcloud_map_cell_with_id.pointcloud = pcd;
+  pointcloud_map_cell_with_id.cell_id = map_id;
+  pointcloud_map_cell_with_id.metadata.min_x = metadata.min.x;
+  pointcloud_map_cell_with_id.metadata.min_y = metadata.min.y;
+  pointcloud_map_cell_with_id.metadata.max_x = metadata.max.x;
+  pointcloud_map_cell_with_id.metadata.max_y = metadata.max.y;
+  return pointcloud_map_cell_with_id;
 }
 }  // namespace autoware::map_loader

--- a/map/autoware_map_loader/src/pointcloud_map_loader/utils.hpp
+++ b/map/autoware_map_loader/src/pointcloud_map_loader/utils.hpp
@@ -15,7 +15,10 @@
 #ifndef POINTCLOUD_MAP_LOADER__UTILS_HPP_
 #define POINTCLOUD_MAP_LOADER__UTILS_HPP_
 
+#include <rclcpp/logger.hpp>
+
 #include <autoware_map_msgs/msg/area_info.hpp>
+#include <autoware_map_msgs/msg/point_cloud_map_cell_with_id.hpp>
 #include <geometry_msgs/msg/point.hpp>
 
 #include <pcl/common/common.h>
@@ -49,6 +52,12 @@ bool cylinder_and_box_overlap_exists(
   const pcl::PointXYZ box_min_point, const pcl::PointXYZ box_max_point);
 bool is_grid_within_queried_area(
   const autoware_map_msgs::msg::AreaInfo area, const PCDFileMetadata metadata);
+
+// Load a single PCD file into a fully-populated PointCloudMapCellWithID, copying the cell id and
+// the metadata bounds. Shared by the partial / differential / selected loaders.
+autoware_map_msgs::msg::PointCloudMapCellWithID load_point_cloud_map_cell_with_id(
+  const rclcpp::Logger & logger, const std::string & path, const std::string & map_id,
+  const PCDFileMetadata & metadata);
 
 }  // namespace autoware::map_loader
 

--- a/map/autoware_map_loader/test/test_selected_map_loader_module.cpp
+++ b/map/autoware_map_loader/test/test_selected_map_loader_module.cpp
@@ -1,0 +1,152 @@
+// Copyright 2024 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/pointcloud_map_loader/selected_map_loader_module.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_map_msgs/srv/get_selected_point_cloud_map.hpp>
+
+#include <gtest/gtest.h>
+#include <pcl/io/pcd_io.h>
+
+#include <map>
+#include <memory>
+#include <string>
+
+using autoware::map_loader::SelectedMapLoaderModule;
+using autoware_map_msgs::srv::GetSelectedPointCloudMap;
+
+class TestSelectedMapLoaderModule : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    // Initialize ROS node
+    rclcpp::init(0, nullptr);
+    node_ = std::make_shared<rclcpp::Node>("test_selected_map_loader_module");
+
+    // Generate a sample dummy pointcloud and save it to a file
+    pcl::PointCloud<pcl::PointXYZ> dummy_cloud;
+    dummy_cloud.width = 3;
+    dummy_cloud.height = 1;
+    dummy_cloud.points.resize(dummy_cloud.width * dummy_cloud.height);
+    dummy_cloud.points[0] = pcl::PointXYZ(-1.0, -1.0, -1.0);
+    dummy_cloud.points[1] = pcl::PointXYZ(0.0, 0.0, 0.0);
+    dummy_cloud.points[2] = pcl::PointXYZ(1.0, 1.0, 1.0);
+    pcl::io::savePCDFileASCII("/tmp/dummy.pcd", dummy_cloud);
+
+    // Generate a sample dummy pointcloud metadata dictionary
+    autoware::map_loader::PCDFileMetadata dummy_metadata;
+    dummy_metadata.min = pcl::PointXYZ(-1.0, -2.0, -3.0);
+    dummy_metadata.max = pcl::PointXYZ(1.0, 2.0, 3.0);
+    dummy_metadata_dict_["/tmp/dummy.pcd"] = dummy_metadata;
+
+    // Initialize the SelectedMapLoaderModule with the dummy metadata dictionary
+    module_ = std::make_shared<SelectedMapLoaderModule>(node_.get(), dummy_metadata_dict_);
+
+    // Create a client for the GetSelectedPointCloudMap service
+    client_ = node_->create_client<GetSelectedPointCloudMap>("service/get_selected_pcd_map");
+  }
+
+  void TearDown() override { rclcpp::shutdown(); }
+
+  rclcpp::Node::SharedPtr node_;
+  std::shared_ptr<SelectedMapLoaderModule> module_;
+  rclcpp::Client<GetSelectedPointCloudMap>::SharedPtr client_;
+  std::map<std::string, autoware::map_loader::PCDFileMetadata> dummy_metadata_dict_;
+};
+
+TEST_F(TestSelectedMapLoaderModule, LoadSelectedPCDFiles)
+{
+  // Wait for the GetSelectedPointCloudMap service to be available
+  ASSERT_TRUE(client_->wait_for_service(std::chrono::seconds(3)));
+
+  // Prepare a request for an existing cell id
+  auto request = std::make_shared<GetSelectedPointCloudMap::Request>();
+  request->cell_ids.push_back("/tmp/dummy.pcd");
+
+  // Call the service
+  auto result_future = client_->async_send_request(request);
+  ASSERT_EQ(
+    rclcpp::spin_until_future_complete(node_, result_future), rclcpp::FutureReturnCode::SUCCESS);
+
+  // The requested cell is found and populated with its metadata bounds
+  auto result = result_future.get();
+  ASSERT_EQ(static_cast<int>(result->new_pointcloud_with_ids.size()), 1);
+  const auto & cell = result->new_pointcloud_with_ids[0];
+  EXPECT_EQ(cell.cell_id, "/tmp/dummy.pcd");
+  EXPECT_FLOAT_EQ(cell.metadata.min_x, -1.0F);
+  EXPECT_FLOAT_EQ(cell.metadata.min_y, -2.0F);
+  EXPECT_FLOAT_EQ(cell.metadata.max_x, 1.0F);
+  EXPECT_FLOAT_EQ(cell.metadata.max_y, 2.0F);
+  EXPECT_EQ(result->header.frame_id, "map");
+}
+
+TEST_F(TestSelectedMapLoaderModule, RequestedIdNotFound)
+{
+  // Wait for the GetSelectedPointCloudMap service to be available
+  ASSERT_TRUE(client_->wait_for_service(std::chrono::seconds(3)));
+
+  // Prepare a request for a cell id that does not exist in the metadata dict
+  auto request = std::make_shared<GetSelectedPointCloudMap::Request>();
+  request->cell_ids.push_back("/tmp/does_not_exist.pcd");
+
+  // Call the service
+  auto result_future = client_->async_send_request(request);
+  ASSERT_EQ(
+    rclcpp::spin_until_future_complete(node_, result_future), rclcpp::FutureReturnCode::SUCCESS);
+
+  // The not-found branch is taken: nothing is returned but the call still succeeds
+  auto result = result_future.get();
+  EXPECT_EQ(static_cast<int>(result->new_pointcloud_with_ids.size()), 0);
+  EXPECT_EQ(result->header.frame_id, "map");
+}
+
+TEST(TestCreateMetadata, PopulatesCellMetadataFromDict)
+{
+  std::map<std::string, autoware::map_loader::PCDFileMetadata> dict;
+  autoware::map_loader::PCDFileMetadata m0;
+  m0.min = pcl::PointXYZ(0.0, 1.0, 2.0);
+  m0.max = pcl::PointXYZ(10.0, 11.0, 12.0);
+  dict["a.pcd"] = m0;
+  autoware::map_loader::PCDFileMetadata m1;
+  m1.min = pcl::PointXYZ(-5.0, -6.0, -7.0);
+  m1.max = pcl::PointXYZ(5.0, 6.0, 7.0);
+  dict["b.pcd"] = m1;
+
+  const auto msg = autoware::map_loader::create_metadata(dict);
+
+  EXPECT_EQ(msg.header.frame_id, "map");
+  ASSERT_EQ(msg.metadata_list.size(), 2U);
+
+  // std::map iterates in sorted key order, so "a.pcd" comes first
+  EXPECT_EQ(msg.metadata_list[0].cell_id, "a.pcd");
+  EXPECT_FLOAT_EQ(msg.metadata_list[0].metadata.min_x, 0.0F);
+  EXPECT_FLOAT_EQ(msg.metadata_list[0].metadata.min_y, 1.0F);
+  EXPECT_FLOAT_EQ(msg.metadata_list[0].metadata.max_x, 10.0F);
+  EXPECT_FLOAT_EQ(msg.metadata_list[0].metadata.max_y, 11.0F);
+
+  EXPECT_EQ(msg.metadata_list[1].cell_id, "b.pcd");
+  EXPECT_FLOAT_EQ(msg.metadata_list[1].metadata.min_x, -5.0F);
+  EXPECT_FLOAT_EQ(msg.metadata_list[1].metadata.min_y, -6.0F);
+  EXPECT_FLOAT_EQ(msg.metadata_list[1].metadata.max_x, 5.0F);
+  EXPECT_FLOAT_EQ(msg.metadata_list[1].metadata.max_y, 6.0F);
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

Implements the recommended PR for `map/autoware_map_loader` from the Core refactor campaign backlog: remove the intra-package duplication of the PCD-cell loading logic, and close the highest-value coverage gap (the entirely untested `SelectedMapLoaderModule`).

### Deduplication
The private method `load_point_cloud_map_cell_with_id` was implemented byte-for-byte identically in three modules (partial / differential / selected), and the 4-line `metadata.min/max -> cell.metadata.{min,max}_{x,y}` copy block was repeated verbatim alongside each call. These are now consolidated into a single free function in `utils.{hpp,cpp}`:

```cpp
autoware_map_msgs::msg::PointCloudMapCellWithID load_point_cloud_map_cell_with_id(
  const rclcpp::Logger & logger, const std::string & path, const std::string & map_id,
  const PCDFileMetadata & metadata);
```

which returns a fully-populated cell (PCD load + error log + cell id + metadata bounds). All three modules now call it; their per-module private methods are removed. This is intra-package PCD/autoware_map_msgs domain logic, not an `autoware_utils` candidate.

### Coverage
Adds `test/test_selected_map_loader_module.cpp` (registered in `CMakeLists.txt`) covering the previously zero-test `SelectedMapLoaderModule`:
- `LoadSelectedPCDFiles` — service returns the requested cell with its metadata bounds populated (asserts `cell_id`, `min_x/min_y/max_x/max_y`, `header.frame_id`).
- `RequestedIdNotFound` — the not-found WARN branch: call still succeeds, returns no cells.
- `TestCreateMetadata.PopulatesCellMetadataFromDict` — direct unit test of the `create_metadata` free function, which is now declared in the module header so it is testable without instantiating the module (asserts sorted-key order and per-cell metadata values).

### Behavior
Behavior-preserving and internal-only. Public module constructor signatures are unchanged; the only header change is an additive free-function declaration plus exposing `create_metadata` for testing.

Refs: autowarefoundation/autoware_core#1096
