### PR TITLE
refactor(autoware_command_gate): extract ROS-free mode dispatch helper

### DIFF
--- a/control/autoware_command_gate/CMakeLists.txt
+++ b/control/autoware_command_gate/CMakeLists.txt
@@ -34,6 +34,7 @@ if(BUILD_TESTING)
   )
   ament_target_dependencies(test_command_gate_mode_builder
     autoware_adapi_v1_msgs
+    autoware_system_msgs
     autoware_vehicle_msgs
     builtin_interfaces
   )

--- a/control/autoware_command_gate/src/autoware_command_gate.cpp
+++ b/control/autoware_command_gate/src/autoware_command_gate.cpp
@@ -77,32 +77,19 @@ public:
         const SystemChangeOperationMode::Service::Request::SharedPtr req,
         const SystemChangeOperationMode::Service::Response::SharedPtr res) {
         const builtin_interfaces::msg::Time stamp = now();
-        ModeOutputs outputs;
+        const auto outputs = CommandGateModeBuilder::dispatch_mode(req->mode, stamp);
 
-        switch (req->mode) {
-          case SystemChangeOperationMode::Service::Request::STOP:
-            outputs = mode_builder_.make_stop(stamp);
-            break;
-          case SystemChangeOperationMode::Service::Request::AUTONOMOUS:
-            outputs = mode_builder_.make_autonomous(stamp);
-            break;
-          case SystemChangeOperationMode::Service::Request::LOCAL:
-            outputs = mode_builder_.make_local(stamp);
-            break;
-          case SystemChangeOperationMode::Service::Request::REMOTE:
-            outputs = mode_builder_.make_remote(stamp);
-            break;
-          default:
-            res->status.success = false;
-            res->status.code = autoware_common_msgs::msg::ResponseStatus::PARAMETER_ERROR;
-            res->status.message = "Unknown operation mode requested.";
-            return;
+        if (!outputs) {
+          res->status.success = false;
+          res->status.code = autoware_common_msgs::msg::ResponseStatus::PARAMETER_ERROR;
+          res->status.message = "Unknown operation mode requested.";
+          return;
         }
 
-        publish(outputs);
+        publish(*outputs);
         res->status.success = true;
         res->status.code = 0;
-        res->status.message = outputs.status.message;
+        res->status.message = outputs->status.message;
       });
   }
 
@@ -121,7 +108,6 @@ private:
   rclcpp::Publisher<OperationModeSystemStateMsg>::SharedPtr system_state_pub_;
   rclcpp::Publisher<GearCommand>::SharedPtr gear_pub_;
   rclcpp::Service<SystemChangeOperationMode::Service>::SharedPtr srv_system_mode_;
-  CommandGateModeBuilder mode_builder_;
 };
 
 }  // namespace autoware::control::command_gate

--- a/control/autoware_command_gate/src/command_gate_mode_builder.cpp
+++ b/control/autoware_command_gate/src/command_gate_mode_builder.cpp
@@ -14,10 +14,30 @@
 
 #include "command_gate_mode_builder.hpp"
 
+#include <optional>
 #include <string>
 
 namespace autoware::control::command_gate
 {
+
+std::optional<ModeOutputs> CommandGateModeBuilder::dispatch_mode(
+  uint16_t mode, const builtin_interfaces::msg::Time & stamp)
+{
+  using Request = autoware_system_msgs::srv::ChangeOperationMode::Request;
+
+  switch (mode) {
+    case Request::STOP:
+      return make_stop(stamp);
+    case Request::AUTONOMOUS:
+      return make_autonomous(stamp);
+    case Request::LOCAL:
+      return make_local(stamp);
+    case Request::REMOTE:
+      return make_remote(stamp);
+    default:
+      return std::nullopt;
+  }
+}
 
 ModeOutputs CommandGateModeBuilder::make_stop(const builtin_interfaces::msg::Time & stamp)
 {

--- a/control/autoware_command_gate/src/command_gate_mode_builder.hpp
+++ b/control/autoware_command_gate/src/command_gate_mode_builder.hpp
@@ -19,8 +19,11 @@
 
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
 #include <autoware_adapi_v1_msgs/msg/response_status.hpp>
+#include <autoware_system_msgs/srv/change_operation_mode.hpp>
 #include <autoware_vehicle_msgs/msg/gear_command.hpp>
 
+#include <cstdint>
+#include <optional>
 #include <string>
 
 namespace autoware::control::command_gate
@@ -40,6 +43,13 @@ public:
   static ModeOutputs make_autonomous(const builtin_interfaces::msg::Time & stamp);
   static ModeOutputs make_local(const builtin_interfaces::msg::Time & stamp);
   static ModeOutputs make_remote(const builtin_interfaces::msg::Time & stamp);
+
+  /// Map an operation-mode request value to its outputs.
+  /// Returns std::nullopt for unknown/unsupported modes so callers can emit a
+  /// PARAMETER_ERROR response. The accepted values mirror the constants of
+  /// autoware_system_msgs::srv::ChangeOperationMode::Request (STOP/AUTONOMOUS/LOCAL/REMOTE).
+  static std::optional<ModeOutputs> dispatch_mode(
+    uint16_t mode, const builtin_interfaces::msg::Time & stamp);
 
 private:
   static void fill_state(

--- a/control/autoware_command_gate/test/unit/test_command_gate_mode_builder.cpp
+++ b/control/autoware_command_gate/test/unit/test_command_gate_mode_builder.cpp
@@ -17,6 +17,7 @@
 #include <builtin_interfaces/msg/time.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
+#include <autoware_system_msgs/srv/change_operation_mode.hpp>
 #include <autoware_vehicle_msgs/msg/gear_command.hpp>
 
 #include <gtest/gtest.h>
@@ -134,6 +135,75 @@ TEST(CommandGateModeBuilder, MakeRemote)
   EXPECT_TRUE(outputs.status.success);
   EXPECT_EQ(outputs.status.code, 0);
   EXPECT_EQ(outputs.status.message, "Switched to REMOTE");
+}
+
+TEST(CommandGateModeBuilder, DispatchModeStop)
+{
+  using Request = autoware_system_msgs::srv::ChangeOperationMode::Request;
+  builtin_interfaces::msg::Time stamp;
+  stamp.sec = 5;
+  stamp.nanosec = 50;
+
+  const auto outputs = CommandGateModeBuilder::dispatch_mode(Request::STOP, stamp);
+
+  ASSERT_TRUE(outputs.has_value());
+  EXPECT_EQ(outputs->state.mode, autoware_adapi_v1_msgs::msg::OperationModeState::STOP);
+  EXPECT_FALSE(outputs->state.is_autoware_control_enabled);
+  EXPECT_EQ(outputs->gear.command, autoware_vehicle_msgs::msg::GearCommand::PARK);
+  EXPECT_EQ(outputs->state.stamp.sec, stamp.sec);
+  EXPECT_EQ(outputs->state.stamp.nanosec, stamp.nanosec);
+  EXPECT_EQ(outputs->status.message, "Switched to STOP");
+}
+
+TEST(CommandGateModeBuilder, DispatchModeAutonomous)
+{
+  using Request = autoware_system_msgs::srv::ChangeOperationMode::Request;
+  builtin_interfaces::msg::Time stamp;
+
+  const auto outputs = CommandGateModeBuilder::dispatch_mode(Request::AUTONOMOUS, stamp);
+
+  ASSERT_TRUE(outputs.has_value());
+  EXPECT_EQ(outputs->state.mode, autoware_adapi_v1_msgs::msg::OperationModeState::AUTONOMOUS);
+  EXPECT_TRUE(outputs->state.is_autoware_control_enabled);
+  EXPECT_EQ(outputs->gear.command, autoware_vehicle_msgs::msg::GearCommand::DRIVE);
+  EXPECT_EQ(outputs->status.message, "Switched to AUTONOMOUS");
+}
+
+TEST(CommandGateModeBuilder, DispatchModeLocal)
+{
+  using Request = autoware_system_msgs::srv::ChangeOperationMode::Request;
+  builtin_interfaces::msg::Time stamp;
+
+  const auto outputs = CommandGateModeBuilder::dispatch_mode(Request::LOCAL, stamp);
+
+  ASSERT_TRUE(outputs.has_value());
+  EXPECT_EQ(outputs->state.mode, autoware_adapi_v1_msgs::msg::OperationModeState::LOCAL);
+  EXPECT_EQ(outputs->gear.command, autoware_vehicle_msgs::msg::GearCommand::NONE);
+  EXPECT_EQ(outputs->status.message, "Switched to LOCAL");
+}
+
+TEST(CommandGateModeBuilder, DispatchModeRemote)
+{
+  using Request = autoware_system_msgs::srv::ChangeOperationMode::Request;
+  builtin_interfaces::msg::Time stamp;
+
+  const auto outputs = CommandGateModeBuilder::dispatch_mode(Request::REMOTE, stamp);
+
+  ASSERT_TRUE(outputs.has_value());
+  EXPECT_EQ(outputs->state.mode, autoware_adapi_v1_msgs::msg::OperationModeState::REMOTE);
+  EXPECT_EQ(outputs->gear.command, autoware_vehicle_msgs::msg::GearCommand::NONE);
+  EXPECT_EQ(outputs->status.message, "Switched to REMOTE");
+}
+
+TEST(CommandGateModeBuilder, DispatchModeUnknownReturnsNullopt)
+{
+  builtin_interfaces::msg::Time stamp;
+
+  // 0 is reserved (no mode constant) and any value outside STOP/AUTONOMOUS/LOCAL/REMOTE
+  // must be rejected so the node can report a PARAMETER_ERROR.
+  EXPECT_FALSE(CommandGateModeBuilder::dispatch_mode(0, stamp).has_value());
+  EXPECT_FALSE(CommandGateModeBuilder::dispatch_mode(5, stamp).has_value());
+  EXPECT_FALSE(CommandGateModeBuilder::dispatch_mode(255, stamp).has_value());
 }
 
 }  // namespace autoware::control::command_gate


### PR DESCRIPTION
## What

Move the request-to-mode dispatch (switch on the requested operation mode and build the corresponding outputs) out of the node's service-callback lambda in `src/autoware_command_gate.cpp` into a ROS-free static helper `CommandGateModeBuilder::dispatch_mode(uint16_t mode, const builtin_interfaces::msg::Time & stamp)` in `src/command_gate_mode_builder.{hpp,cpp}`. The helper returns `std::optional<ModeOutputs>` — a value for STOP/AUTONOMOUS/LOCAL/REMOTE and `std::nullopt` for unknown/unsupported modes.

The node constructor lambda now calls `dispatch_mode` and fills the response: on `std::nullopt` it sets `success=false`, `code=PARAMETER_ERROR`, `message="Unknown operation mode requested."`; on a value it publishes the outputs and sets `success=true`, `code=0`, `message=outputs->status.message`. The now-unused `mode_builder_` instance member was removed (all builder methods are static).

## Why

The dispatch logic, including its only error path (unknown mode → `PARAMETER_ERROR`), previously lived inside the service-callback lambda and could only be exercised through the heavyweight ROS integration test, which never sent an out-of-range mode. Extracting a ROS-free seam makes the dispatch and its error mapping unit-testable with plain gtest (no rclcpp) and closes the untested error branch. Implements the recommended PR for this package in the refactor campaign backlog.

## Tests

Added 5 plain-gtest cases to `test/unit/test_command_gate_mode_builder.cpp`:
- `DispatchModeStop/Autonomous/Local/Remote` assert the returned mode, gear, control flag, timestamp pass-through, and status message for each valid mode.
- `DispatchModeUnknownReturnsNullopt` asserts `dispatch_mode` returns `std::nullopt` for mode values 0, 5, and 255 — the previously untested unknown-mode path.

Built and tested in `autoware:core-devel-jazzy`: build green; all 15 tests pass (9 unit + 4 integration); clang-format compliant.

## API / behavior

Additive only: `dispatch_mode` is a new static method; the public node API and all four existing `make_*` signatures are unchanged. Behavior-preserving — same publishes, same response status semantics, same PARAMETER_ERROR on unknown modes. `mode` is `uint16_t` to match the service's `uint16 mode` field (no truncation).

Refs: autowarefoundation/autoware_core#1096
