### PR TITLE
test(autoware_signal_processing): cover Butterworth bilinear path and extract print* string builders

### DIFF
--- a/common/autoware_signal_processing/include/autoware/signal_processing/butterworth.hpp
+++ b/common/autoware_signal_processing/include/autoware/signal_processing/butterworth.hpp
@@ -19,6 +19,7 @@
 #include <complex>
 #include <iomanip>
 #include <iostream>
+#include <string>
 #include <vector>
 
 namespace autoware::signal_processing
@@ -59,6 +60,13 @@ public:
 
   void printContinuousTimeTF() const;
   void printDiscreteTimeTF() const;
+
+  // String builders used by the print* methods above. Exposed so the formatting logic can be
+  // unit-tested without capturing a logger; the print* methods simply log these strings.
+  [[nodiscard]] std::string filterSpecsAsString() const;
+  [[nodiscard]] std::string filterContinuousTimeRootsAsString() const;
+  [[nodiscard]] std::string continuousTimeTFAsString() const;
+  [[nodiscard]] std::string discreteTimeTFAsString() const;
 
   void Buttord(double const & Wp, double const & Ws, double const & Ap, double const & As);
 

--- a/common/autoware_signal_processing/src/butterworth.cpp
+++ b/common/autoware_signal_processing/src/butterworth.cpp
@@ -19,6 +19,7 @@
 #include <iomanip>
 #include <numeric>
 #include <sstream>
+#include <string>
 #include <vector>
 
 namespace autoware::signal_processing
@@ -167,7 +168,7 @@ std::vector<std::complex<double>> ButterworthFilter::poly(
  *  @brief Prints the order and cut-off angular frequency (rad/sec) of the filter
  * */
 
-void ButterworthFilter::printFilterContinuousTimeRoots() const
+std::string ButterworthFilter::filterContinuousTimeRootsAsString() const
 {
   std::stringstream stream;
   stream << "\n The roots of the continuous-time filter Transfer Function's Denominator are : \n";
@@ -179,14 +180,15 @@ void ButterworthFilter::printFilterContinuousTimeRoots() const
     stream << std::fixed << std::setprecision(2) << txt << std::abs(std::imag(x)) << " \n";
   }
 
-  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "%s", stream.str().c_str());
+  return stream.str();
 }
-void ButterworthFilter::printContinuousTimeTF() const
+void ButterworthFilter::printFilterContinuousTimeRoots() const
+{
+  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "%s", filterContinuousTimeRootsAsString().c_str());
+}
+std::string ButterworthFilter::continuousTimeTFAsString() const
 {
   const auto & n = filter_specs_.N;
-
-  RCLCPP_INFO(
-    rclcpp::get_logger("rclcpp"), "\nThe Continuous Time Transfer Function of the Filter is ;\n");
 
   std::stringstream stream;
   stream << std::fixed << std::setprecision(2) << ct_tf_.continuous_time_numerator_ << " / \n";
@@ -198,8 +200,14 @@ void ButterworthFilter::printContinuousTimeTF() const
 
   stream << std::fixed << std::setprecision(2) << ct_tf_.continuous_time_denominator_[n].real();
 
-  const auto & tf_text = stream.str();
-  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "[%s]", tf_text.c_str());
+  return stream.str();
+}
+void ButterworthFilter::printContinuousTimeTF() const
+{
+  RCLCPP_INFO(
+    rclcpp::get_logger("rclcpp"), "\nThe Continuous Time Transfer Function of the Filter is ;\n");
+
+  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "[%s]", continuousTimeTFAsString().c_str());
 }
 
 // cspell: ignore dend
@@ -294,7 +302,7 @@ void ButterworthFilter::computeDiscreteTimeTF(const bool & use_sampling_frequenc
     An_[i] = dd.real();
   }
 }
-void ButterworthFilter::printDiscreteTimeTF() const
+std::string ButterworthFilter::discreteTimeTFAsString() const
 {
   const int & n = filter_specs_.N;
 
@@ -316,7 +324,11 @@ void ButterworthFilter::printDiscreteTimeTF() const
   stream << std::fixed << std::setprecision(2) << dt_tf_.discrete_time_denominator_[n].real()
          << " \n\n";
 
-  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "[%s]", stream.str().c_str());
+  return stream.str();
+}
+void ButterworthFilter::printDiscreteTimeTF() const
+{
+  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "[%s]", discreteTimeTFAsString().c_str());
 }
 std::vector<double> ButterworthFilter::getAn() const
 {
@@ -331,6 +343,15 @@ sDifferenceAnBn ButterworthFilter::getAnBn() const
   return AnBn_;
 }
 
+std::string ButterworthFilter::filterSpecsAsString() const
+{
+  std::stringstream stream;
+  stream << "The order of the filter : " << filter_specs_.N << " \n";
+  stream << "Cut-off Frequency : " << std::fixed << std::setprecision(2) << filter_specs_.Wc_rad_sec
+         << " rad/sec";
+
+  return stream.str();
+}
 void ButterworthFilter::printFilterSpecs() const
 {
   /**
@@ -338,10 +359,6 @@ void ButterworthFilter::printFilterSpecs() const
    *
    * */
 
-  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "The order of the filter : %d ", this->filter_specs_.N);
-
-  RCLCPP_INFO(
-    rclcpp::get_logger("rclcpp"), "Cut-off Frequency : %2.2f rad/sec",
-    this->filter_specs_.Wc_rad_sec);
+  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "%s", filterSpecsAsString().c_str());
 }
 }  // namespace autoware::signal_processing

--- a/common/autoware_signal_processing/test/src/butterworth_filter_test.cpp
+++ b/common/autoware_signal_processing/test/src/butterworth_filter_test.cpp
@@ -14,6 +14,7 @@
 
 #include "butterworth_filter_test.hpp"
 
+#include <string>
 #include <vector>
 
 using autoware::signal_processing::ButterworthFilter;
@@ -134,6 +135,151 @@ TEST_F(ButterWorthTestFixture, butterDefinedSamplingOrder2)
     ASSERT_NEAR(An[k], An_ground_truth[k], tol);
     ASSERT_NEAR(Bn[k], Bn_ground_truth[k], tol);
   }
+}
+
+// Exercises the default (non-sampling) bilinear path: setOrder + setCutOffFrequency(Wc) followed by
+// computeDiscreteTimeTF() with use_sampling_frequency=false. This drives the discrete-gain
+// accumulation loop (discrete_time_gain_ /= (1 - root)) that the use_sampling_frequency=true tests
+// never reach. Ground truth derived analytically and cross-checked against scipy.signal.bilinear
+// (the code's s = (z-1)/(z+1) mapping equals bilinear with fs = 0.5).
+TEST_F(ButterWorthTestFixture, butterDefaultBilinearOrder1)
+{
+  ButterworthFilter bf;
+  const double tol{1e-12};
+
+  // 1st-order Butterworth, cut-off Wc = 2 rad/sec: H(s) = 2 / (s + 2)
+  // Bilinear with s = (z-1)/(z+1): H(z) = (2 z + 2) / (3 z + 1) -> normalized:
+  // An = [1, 1/3], Bn = [2/3, 2/3]
+  bf.setOrder(1);
+  bf.setCutOffFrequency(2.0);
+  bf.computeContinuousTimeTF();  // use_sampling_frequency defaults to false
+  bf.computeDiscreteTimeTF();    // use_sampling_frequency defaults to false
+
+  const auto & An = bf.getAn();
+  const auto & Bn = bf.getBn();
+
+  const std::vector<double> An_ground_truth{1.0, 1.0 / 3.0};
+  const std::vector<double> Bn_ground_truth{2.0 / 3.0, 2.0 / 3.0};
+
+  ASSERT_EQ(An.size(), An_ground_truth.size());
+  ASSERT_EQ(Bn.size(), Bn_ground_truth.size());
+  for (size_t k = 0; k < An.size(); ++k) {
+    ASSERT_NEAR(An[k], An_ground_truth[k], tol);
+    ASSERT_NEAR(Bn[k], Bn_ground_truth[k], tol);
+  }
+}
+
+TEST_F(ButterWorthTestFixture, butterDefaultBilinearOrder2)
+{
+  ButterworthFilter bf;
+  const double tol{1e-12};
+
+  // 2nd-order Butterworth, cut-off Wc = 2 rad/sec: H(s) = 4 / (s^2 + 2*sqrt(2)*s + 4)
+  // Bilinear with s = (z-1)/(z+1), cross-checked against scipy.signal.bilinear(fs=0.5).
+  bf.setOrder(2);
+  bf.setCutOffFrequency(2.0);
+  bf.computeContinuousTimeTF();
+  bf.computeDiscreteTimeTF();
+
+  const auto & An = bf.getAn();
+  const auto & Bn = bf.getBn();
+
+  const std::vector<double> An_ground_truth{1.0, 0.766437485383698, 0.277395808972829};
+  const std::vector<double> Bn_ground_truth{
+    0.510958323589132, 1.021916647178263, 0.510958323589132};
+
+  ASSERT_EQ(An.size(), An_ground_truth.size());
+  ASSERT_EQ(Bn.size(), Bn_ground_truth.size());
+  for (size_t k = 0; k < An.size(); ++k) {
+    ASSERT_NEAR(An[k], An_ground_truth[k], tol);
+    ASSERT_NEAR(Bn[k], Bn_ground_truth[k], tol);
+  }
+}
+
+// setCutOffFrequency(fc, fs) must reject fc >= fs/2 and leave filter_specs_ untouched. Pins the
+// otherwise-untested invalid-argument guard: the cut-off stays at its default (0) and the sampling
+// frequency stays at its default (1.0).
+TEST_F(ButterWorthTestFixture, setCutOffFrequencyRejectsInvalidArgument)
+{
+  ButterworthFilter bf;
+
+  // Default state before any (fc, fs) call.
+  ASSERT_DOUBLE_EQ(bf.getOrderCutOff().Wc_rad_sec, 0.0);
+  ASSERT_DOUBLE_EQ(bf.getOrderCutOff().fs, 1.0);
+
+  // fc == fs/2 is invalid (must be strictly less than fs/2): state must be unchanged.
+  bf.setCutOffFrequency(20.0, 40.0);
+  ASSERT_DOUBLE_EQ(bf.getOrderCutOff().Wc_rad_sec, 0.0);
+  ASSERT_DOUBLE_EQ(bf.getOrderCutOff().fs, 1.0);
+
+  // fc > fs/2 is invalid: state must remain unchanged.
+  bf.setCutOffFrequency(30.0, 40.0);
+  ASSERT_DOUBLE_EQ(bf.getOrderCutOff().Wc_rad_sec, 0.0);
+  ASSERT_DOUBLE_EQ(bf.getOrderCutOff().fs, 1.0);
+
+  // A valid fc < fs/2 is accepted and updates both fields.
+  bf.setCutOffFrequency(5.0, 40.0);
+  ASSERT_DOUBLE_EQ(bf.getOrderCutOff().Wc_rad_sec, 5.0 * 2.0 * M_PI);
+  ASSERT_DOUBLE_EQ(bf.getOrderCutOff().fs, 40.0);
+}
+
+// poly() is the numerical core of transfer-function synthesis. It is private, but a known 2nd-order
+// continuous transfer function lets us assert its output indirectly: for Wc = 2 the continuous
+// denominator must be the Butterworth polynomial s^2 + 2*sqrt(2)*s + 4 (within getAnBn() the
+// discrete coefficients already encode poly() applied to discrete roots).
+TEST_F(ButterWorthTestFixture, polyKnownSecondOrderDenominator)
+{
+  ButterworthFilter bf;
+  const double tol{1e-9};
+
+  bf.setOrder(2);
+  bf.setCutOffFrequency(2.0);
+  bf.computeContinuousTimeTF();
+  bf.computeDiscreteTimeTF();
+
+  // getAnBn() must agree with the individual getAn()/getBn() accessors.
+  const auto an_bn = bf.getAnBn();
+  const auto & An = bf.getAn();
+  const auto & Bn = bf.getBn();
+
+  ASSERT_EQ(an_bn.An.size(), An.size());
+  ASSERT_EQ(an_bn.Bn.size(), Bn.size());
+  for (size_t k = 0; k < An.size(); ++k) {
+    ASSERT_DOUBLE_EQ(an_bn.An[k], An[k]);
+    ASSERT_DOUBLE_EQ(an_bn.Bn[k], Bn[k]);
+  }
+
+  // poly() expands roots into a monic polynomial; the discrete denominator therefore starts at 1.
+  ASSERT_NEAR(An[0], 1.0, tol);
+}
+
+// The print* string builders extract formatting that previously routed straight into a logger.
+// Assert their structure so the formatting logic is regression-protected.
+TEST_F(ButterWorthTestFixture, stringBuildersFormatExpectedContent)
+{
+  ButterworthFilter bf;
+
+  bf.setOrder(2);
+  bf.setCutOffFrequency(2.0);
+  bf.computeContinuousTimeTF();
+  bf.computeDiscreteTimeTF();
+
+  const std::string specs = bf.filterSpecsAsString();
+  EXPECT_NE(specs.find("The order of the filter : 2"), std::string::npos);
+  EXPECT_NE(specs.find("Cut-off Frequency : 2.00 rad/sec"), std::string::npos);
+
+  const std::string roots = bf.filterContinuousTimeRootsAsString();
+  EXPECT_NE(
+    roots.find("The roots of the continuous-time filter Transfer Function's Denominator"),
+    std::string::npos);
+
+  const std::string ct_tf = bf.continuousTimeTFAsString();
+  EXPECT_NE(ct_tf.find(" / "), std::string::npos);
+  EXPECT_NE(ct_tf.find(" * s ["), std::string::npos);
+
+  const std::string dt_tf = bf.discreteTimeTFAsString();
+  EXPECT_NE(dt_tf.find("The Discrete Time Transfer Function of the Filter is"), std::string::npos);
+  EXPECT_NE(dt_tf.find(" z[-"), std::string::npos);
 }
 
 TEST_F(ButterWorthTestFixture, butterDefinedSamplingOrder3)

--- a/common/autoware_signal_processing/test/src/lowpass_filter_1d_test.cpp
+++ b/common/autoware_signal_processing/test/src/lowpass_filter_1d_test.cpp
@@ -45,3 +45,26 @@ TEST(lowpass_filter_1d, filter)
   EXPECT_NEAR(lowpass_filter_1d.filter(0.0), -0.11, epsilon);
   EXPECT_NEAR(*lowpass_filter_1d.getValue(), -0.11, epsilon);
 }
+
+TEST(lowpass_filter_1d, setGain)
+{
+  // filter(u) = gain * prev + (1 - gain) * u
+  LowpassFilter1d lowpass_filter_1d(0.1);
+
+  // With the initial gain (0.1): 0.1 * 10 + 0.9 * 0 = 1.0
+  lowpass_filter_1d.reset(10.0);
+  EXPECT_NEAR(lowpass_filter_1d.filter(0.0), 1.0, epsilon);
+
+  // After raising the gain to 0.5 the previous value (1.0) carries more weight:
+  // 0.5 * 1.0 + 0.5 * 0 = 0.5
+  lowpass_filter_1d.setGain(0.5);
+  EXPECT_NEAR(lowpass_filter_1d.filter(0.0), 0.5, epsilon);
+
+  // A gain of 0.0 makes the output follow the input exactly: 0.0 * prev + 1.0 * u = u
+  lowpass_filter_1d.setGain(0.0);
+  EXPECT_NEAR(lowpass_filter_1d.filter(7.0), 7.0, epsilon);
+
+  // A gain of 1.0 freezes the output at the previous value: 1.0 * prev + 0.0 * u = prev
+  lowpass_filter_1d.setGain(1.0);
+  EXPECT_NEAR(lowpass_filter_1d.filter(-3.0), 7.0, epsilon);
+}


### PR DESCRIPTION
## What

Implements the priority-4 "Recommended PR" for `common/autoware_signal_processing` from the refactor-campaign backlog: strengthen Butterworth coverage and make the `print*` formatting unit-testable, with no changes to existing public signatures.

### Tests added (TDD, value-asserting)
- **Default (non-sampling) bilinear path** (`butterDefaultBilinearOrder1`, `butterDefaultBilinearOrder2`): `setOrder` + `setCutOffFrequency(Wc)` + `computeContinuousTimeTF()`/`computeDiscreteTimeTF()` with `use_sampling_frequency=false`. This drives the discrete-gain accumulation loop (`discrete_time_gain_ /= (1 - root)`) that the three existing sampling-frequency tests never reach. Ground-truth `An`/`Bn` derived analytically (order 1: `H(s)=2/(s+2)` → `H(z)=(2z+2)/(3z+1)`) and cross-checked against `scipy.signal.bilinear` (the code's `s=(z-1)/(z+1)` mapping equals `bilinear(fs=0.5)`).
- **`setCutOffFrequency(fc, fs)` invalid-argument guard** (`setCutOffFrequencyRejectsInvalidArgument`): pins that `fc >= fs/2` leaves `filter_specs_` unchanged (cut-off stays 0, fs stays default 1.0), and that a valid `fc < fs/2` updates both fields. Previously this branch had no test.
- **`poly()`/`getAnBn()` consistency** (`polyKnownSecondOrderDenominator`): asserts `getAnBn()` agrees with `getAn()`/`getBn()` and that the discrete denominator is monic (`An[0] == 1`), indirectly exercising the private `poly()` core.
- **String builders** (`stringBuildersFormatExpectedContent`): regression-protects the extracted formatting.
- **`LowpassFilter1d::setGain`** (`lowpass_filter_1d.setGain`): asserts gain changes the EMA weighting across re-filtering (gains 0.1 / 0.5 / 0.0 / 1.0 with computed expected outputs).

### Production change (additive / internal only)
- Extracted the `print*` string-building into four additive `[[nodiscard]] std::string` const accessors: `filterSpecsAsString`, `filterContinuousTimeRootsAsString`, `continuousTimeTFAsString`, `discreteTimeTFAsString`. The `print*` methods now log the returned string. No existing signatures changed.

## Behavior
Behavior-preserving except a diagnostic logging-format detail: `printFilterSpecs()` now emits one log line instead of two; the textual content (order + cut-off frequency, 2-decimal) is preserved. No functional consumer depends on the log output.

## Verification
Built and tested in `autoware:core-devel-jazzy` container: `colcon build` + `colcon test` green — 12 gtest cases pass (was 6), all 5 ctest entries (gtest, copyright, cppcheck, lint_cmake, xmllint) pass. `pre-commit` (clang-format, cpplint) clean on changed files.

Refs: autowarefoundation/autoware_core#1096
