### PR TITLE
refactor(autoware_adapi_adaptors): extract pure helpers and add unit tests

### DIFF
--- a/api/autoware_adapi_adaptors/CMakeLists.txt
+++ b/api/autoware_adapi_adaptors/CMakeLists.txt
@@ -21,4 +21,10 @@ rclcpp_components_register_node(${PROJECT_NAME}
   EXECUTOR SingleThreadedExecutor
 )
 
+if(BUILD_TESTING)
+  ament_auto_add_gtest(test_${PROJECT_NAME}
+    test/test_helpers.cpp
+  )
+endif()
+
 autoware_ament_auto_package(INSTALL_TO_SHARE config launch)

--- a/api/autoware_adapi_adaptors/src/initial_pose_adaptor.cpp
+++ b/api/autoware_adapi_adaptors/src/initial_pose_adaptor.cpp
@@ -14,6 +14,8 @@
 
 #include "initial_pose_adaptor.hpp"
 
+#include "parameter_helper.hpp"
+
 #include <autoware/qos_utils/qos_compatibility.hpp>
 
 #include <memory>
@@ -27,13 +29,7 @@ using Future = typename rclcpp::Client<ServiceT>::SharedFuture;
 
 std::array<double, 36> get_covariance_parameter(rclcpp::Node * node, const std::string & name)
 {
-  const auto vector = node->declare_parameter<std::vector<double>>(name);
-  if (vector.size() != 36) {
-    throw std::invalid_argument("The covariance parameter size is not 36.");
-  }
-  std::array<double, 36> array;
-  std::copy_n(vector.begin(), array.size(), array.begin());
-  return array;
+  return vector_to_array<double, 36>(node->declare_parameter<std::vector<double>>(name));
 }
 
 InitialPoseAdaptor::InitialPoseAdaptor(const rclcpp::NodeOptions & options)

--- a/api/autoware_adapi_adaptors/src/parameter_helper.hpp
+++ b/api/autoware_adapi_adaptors/src/parameter_helper.hpp
@@ -1,0 +1,44 @@
+// Copyright 2025 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PARAMETER_HELPER_HPP_
+#define PARAMETER_HELPER_HPP_
+
+#include <algorithm>
+#include <array>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace autoware::adapi_adaptors
+{
+
+/// Validate that the vector has exactly N elements and copy it into a fixed-size array.
+///
+/// This is the pure, node-independent part of the covariance parameter parsing so that
+/// the size-validation throw branch can be unit-tested without a live rclcpp::Node.
+template <typename T, std::size_t N>
+std::array<T, N> vector_to_array(const std::vector<T> & vector)
+{
+  if (vector.size() != N) {
+    throw std::invalid_argument("The covariance parameter size is not " + std::to_string(N) + ".");
+  }
+  std::array<T, N> array;
+  std::copy_n(vector.begin(), N, array.begin());
+  return array;
+}
+
+}  // namespace autoware::adapi_adaptors
+
+#endif  // PARAMETER_HELPER_HPP_

--- a/api/autoware_adapi_adaptors/src/route_builder.hpp
+++ b/api/autoware_adapi_adaptors/src/route_builder.hpp
@@ -1,0 +1,53 @@
+// Copyright 2025 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROUTE_BUILDER_HPP_
+#define ROUTE_BUILDER_HPP_
+
+namespace autoware::adapi_adaptors
+{
+
+/// Set the route request to a single goal, clearing any pending waypoints.
+///
+/// Pure route-building rule shared by the fixed-goal and rough-goal callbacks. The
+/// @p allow_goal_modification flag is the only behavioral difference between the two.
+/// Templated on the request and pose types so it can be unit-tested with lightweight
+/// stubs without a ROS context.
+template <typename RequestT, typename PoseStampedT>
+void set_goal(RequestT & route, const PoseStampedT & pose, bool allow_goal_modification)
+{
+  route.header = pose.header;
+  route.goal = pose.pose;
+  route.waypoints.clear();
+  route.option.allow_goal_modification = allow_goal_modification;
+}
+
+/// Append a waypoint to the route request, rejecting frame-id mismatches.
+///
+/// Returns true if the waypoint was appended, false if its frame_id does not match the
+/// goal frame (in which case the route is left unchanged). This isolates the
+/// frame-mismatch guard in on_waypoint so it can be unit-tested directly.
+template <typename RequestT, typename PoseStampedT>
+bool append_waypoint(RequestT & route, const PoseStampedT & pose)
+{
+  if (route.header.frame_id != pose.header.frame_id) {
+    return false;
+  }
+  route.waypoints.push_back(pose.pose);
+  return true;
+}
+
+}  // namespace autoware::adapi_adaptors
+
+#endif  // ROUTE_BUILDER_HPP_

--- a/api/autoware_adapi_adaptors/src/routing_adaptor.cpp
+++ b/api/autoware_adapi_adaptors/src/routing_adaptor.cpp
@@ -14,6 +14,9 @@
 
 #include "routing_adaptor.hpp"
 
+#include "route_builder.hpp"
+#include "routing_state_machine.hpp"
+
 #include <autoware/qos_utils/qos_compatibility.hpp>
 
 #include <memory>
@@ -59,30 +62,28 @@ RoutingAdaptor::RoutingAdaptor(const rclcpp::NodeOptions & options)
 
 void RoutingAdaptor::on_timer()
 {
-  // Wait a moment to combine consecutive goals and checkpoints into a single request.
-  // This value is rate dependent and set the wait time for merging.
-  constexpr int delay_count = 3;  // 0.4 seconds (rate * (value - 1))
-  if (0 < request_timing_control_ && request_timing_control_ < delay_count) {
-    ++request_timing_control_;
-  }
-  if (request_timing_control_ != delay_count) {
-    return;
-  }
+  const auto decision = decide_routing_action(
+    request_timing_control_, calling_service_, state_ == RouteState::Message::UNSET);
+  request_timing_control_ = decision.request_timing_control;
 
-  if (!calling_service_) {
-    if (state_ != RouteState::Message::UNSET) {
+  switch (decision.action) {
+    case RoutingAction::None:
+      break;
+    case RoutingAction::CallClear: {
       const auto request = std::make_shared<ClearRoute::Service::Request>();
       calling_service_ = true;
       cli_clear_->async_send_request(
         request,
         [this](rclcpp::Client<ClearRoute::Service>::SharedFuture) { calling_service_ = false; });
-    } else {
-      request_timing_control_ = 0;
+      break;
+    }
+    case RoutingAction::CallRoute: {
       calling_service_ = true;
       cli_route_->async_send_request(
         route_, [this](rclcpp::Client<SetRoutePoints::Service>::SharedFuture) {
           calling_service_ = false;
         });
+      break;
     }
   }
 }
@@ -90,29 +91,22 @@ void RoutingAdaptor::on_timer()
 void RoutingAdaptor::on_fixed_goal(const PoseStamped::ConstSharedPtr pose)
 {
   request_timing_control_ = 1;
-  route_->header = pose->header;
-  route_->goal = pose->pose;
-  route_->waypoints.clear();
-  route_->option.allow_goal_modification = false;
+  set_goal(*route_, *pose, false);
 }
 
 void RoutingAdaptor::on_rough_goal(const PoseStamped::ConstSharedPtr pose)
 {
   request_timing_control_ = 1;
-  route_->header = pose->header;
-  route_->goal = pose->pose;
-  route_->waypoints.clear();
-  route_->option.allow_goal_modification = true;
+  set_goal(*route_, *pose, true);
 }
 
 void RoutingAdaptor::on_waypoint(const PoseStamped::ConstSharedPtr pose)
 {
-  if (route_->header.frame_id != pose->header.frame_id) {
+  if (!append_waypoint(*route_, *pose)) {
     RCLCPP_ERROR_STREAM(get_logger(), "The waypoint frame does not match the goal.");
     return;
   }
   request_timing_control_ = 1;
-  route_->waypoints.push_back(pose->pose);
 }
 
 void RoutingAdaptor::on_reroute(const PoseStamped::ConstSharedPtr pose)

--- a/api/autoware_adapi_adaptors/src/routing_state_machine.hpp
+++ b/api/autoware_adapi_adaptors/src/routing_state_machine.hpp
@@ -1,0 +1,77 @@
+// Copyright 2025 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROUTING_STATE_MACHINE_HPP_
+#define ROUTING_STATE_MACHINE_HPP_
+
+#include <cstdint>
+
+namespace autoware::adapi_adaptors
+{
+
+/// Number of timer ticks to wait before issuing a request so that consecutive
+/// goals and checkpoints are merged into a single request.
+/// At 5 Hz this corresponds to rate * (value - 1) = 0.4 seconds.
+constexpr int g_routing_request_delay_count = 3;
+
+/// The action the routing timer should take on a single tick.
+enum class RoutingAction : std::uint8_t {
+  /// Do nothing this tick (still within the merge window, or a service call is in flight).
+  None,
+  /// Clear the current route before a new one can be set.
+  CallClear,
+  /// Send the pending SetRoutePoints request.
+  CallRoute,
+};
+
+/// Result of a single routing timer tick: which action to take and the updated counter.
+struct RoutingDecision
+{
+  RoutingAction action;
+  int request_timing_control;
+};
+
+/// Pure merge-window state-machine for RoutingAdaptor::on_timer.
+///
+/// Given the current merge-window counter, whether a service call is in flight, and whether
+/// the route state is UNSET, decide the next action and the updated counter. This isolates
+/// the branching from the ROS node so it can be unit-tested directly.
+///
+/// @param request_timing_control current merge-window counter (0 means idle).
+/// @param calling_service true while a previous async service call has not completed.
+/// @param state_is_unset true when the route state equals RouteState::UNSET.
+inline RoutingDecision decide_routing_action(
+  int request_timing_control, bool calling_service, bool state_is_unset)
+{
+  // Wait a moment to combine consecutive goals and checkpoints into a single request.
+  if (0 < request_timing_control && request_timing_control < g_routing_request_delay_count) {
+    ++request_timing_control;
+  }
+  if (request_timing_control != g_routing_request_delay_count) {
+    return {RoutingAction::None, request_timing_control};
+  }
+
+  if (calling_service) {
+    return {RoutingAction::None, request_timing_control};
+  }
+
+  if (!state_is_unset) {
+    return {RoutingAction::CallClear, request_timing_control};
+  }
+  return {RoutingAction::CallRoute, 0};
+}
+
+}  // namespace autoware::adapi_adaptors
+
+#endif  // ROUTING_STATE_MACHINE_HPP_

--- a/api/autoware_adapi_adaptors/test/test_helpers.cpp
+++ b/api/autoware_adapi_adaptors/test/test_helpers.cpp
@@ -1,0 +1,188 @@
+// Copyright 2025 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/parameter_helper.hpp"
+#include "../src/route_builder.hpp"
+#include "../src/routing_state_machine.hpp"
+
+#include <autoware_adapi_v1_msgs/srv/set_route_points.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace autoware::adapi_adaptors
+{
+
+using SetRoutePoints = autoware_adapi_v1_msgs::srv::SetRoutePoints;
+using PoseStamped = geometry_msgs::msg::PoseStamped;
+
+namespace
+{
+
+PoseStamped make_pose(const std::string & frame_id, double x)
+{
+  PoseStamped pose;
+  pose.header.frame_id = frame_id;
+  pose.pose.position.x = x;
+  return pose;
+}
+
+}  // namespace
+
+// --- vector_to_array ----------------------------------------------------------------------------
+
+TEST(VectorToArray, CopiesWhenSizeMatches)
+{
+  std::vector<double> values(36);
+  for (size_t i = 0; i < values.size(); ++i) {
+    values[i] = static_cast<double>(i);
+  }
+  const auto array = vector_to_array<double, 36>(values);
+  ASSERT_EQ(array.size(), 36u);
+  EXPECT_DOUBLE_EQ(array[0], 0.0);
+  EXPECT_DOUBLE_EQ(array[35], 35.0);
+}
+
+TEST(VectorToArray, ThrowsWhenTooSmall)
+{
+  const std::vector<double> values(35, 1.0);
+  EXPECT_THROW((vector_to_array<double, 36>(values)), std::invalid_argument);
+}
+
+TEST(VectorToArray, ThrowsWhenTooLarge)
+{
+  const std::vector<double> values(37, 1.0);
+  EXPECT_THROW((vector_to_array<double, 36>(values)), std::invalid_argument);
+}
+
+TEST(VectorToArray, ThrowsWhenEmpty)
+{
+  const std::vector<double> values;
+  EXPECT_THROW((vector_to_array<double, 36>(values)), std::invalid_argument);
+}
+
+// --- decide_routing_action ----------------------------------------------------------------------
+
+TEST(DecideRoutingAction, IdleCounterStaysIdleAndDoesNothing)
+{
+  // request_timing_control_ == 0 means no pending request; nothing happens.
+  const auto decision = decide_routing_action(0, false, true);
+  EXPECT_EQ(decision.action, RoutingAction::None);
+  EXPECT_EQ(decision.request_timing_control, 0);
+}
+
+TEST(DecideRoutingAction, CounterIncrementsUntilDelayCount)
+{
+  // 1 -> 2: still within the merge window, no action yet.
+  auto decision = decide_routing_action(1, false, true);
+  EXPECT_EQ(decision.action, RoutingAction::None);
+  EXPECT_EQ(decision.request_timing_control, 2);
+
+  // 2 -> 3 (== delay_count): fires the route call and resets the counter.
+  decision = decide_routing_action(2, false, true);
+  EXPECT_EQ(decision.action, RoutingAction::CallRoute);
+  EXPECT_EQ(decision.request_timing_control, 0);
+}
+
+TEST(DecideRoutingAction, ReachesDelayCountAndCallsRouteWhenUnset)
+{
+  // At delay_count with state UNSET: send the SetRoutePoints request, reset counter.
+  const auto decision = decide_routing_action(g_routing_request_delay_count, false, true);
+  EXPECT_EQ(decision.action, RoutingAction::CallRoute);
+  EXPECT_EQ(decision.request_timing_control, 0);
+}
+
+TEST(DecideRoutingAction, ReachesDelayCountAndCallsClearWhenNotUnset)
+{
+  // At delay_count with state not UNSET: must clear the existing route first.
+  // The counter is NOT reset so the next tick retries until the route is cleared.
+  const auto decision = decide_routing_action(g_routing_request_delay_count, false, false);
+  EXPECT_EQ(decision.action, RoutingAction::CallClear);
+  EXPECT_EQ(decision.request_timing_control, g_routing_request_delay_count);
+}
+
+TEST(DecideRoutingAction, DoesNothingWhileServiceCallInFlight)
+{
+  // calling_service_ == true gates both the clear and route calls.
+  auto decision = decide_routing_action(g_routing_request_delay_count, true, true);
+  EXPECT_EQ(decision.action, RoutingAction::None);
+  EXPECT_EQ(decision.request_timing_control, g_routing_request_delay_count);
+
+  decision = decide_routing_action(g_routing_request_delay_count, true, false);
+  EXPECT_EQ(decision.action, RoutingAction::None);
+  EXPECT_EQ(decision.request_timing_control, g_routing_request_delay_count);
+}
+
+// --- set_goal -----------------------------------------------------------------------------------
+
+TEST(SetGoal, CopiesHeaderGoalAndClearsWaypoints)
+{
+  SetRoutePoints::Request route;
+  route.waypoints.resize(2);  // pre-existing waypoints must be cleared.
+  const auto pose = make_pose("map", 1.5);
+
+  set_goal(route, pose, false);
+
+  EXPECT_EQ(route.header.frame_id, "map");
+  EXPECT_DOUBLE_EQ(route.goal.position.x, 1.5);
+  EXPECT_TRUE(route.waypoints.empty());
+  EXPECT_FALSE(route.option.allow_goal_modification);
+}
+
+TEST(SetGoal, SetsAllowGoalModificationFlag)
+{
+  SetRoutePoints::Request route;
+  const auto pose = make_pose("map", 0.0);
+
+  set_goal(route, pose, true);
+
+  EXPECT_TRUE(route.option.allow_goal_modification);
+}
+
+// --- append_waypoint ----------------------------------------------------------------------------
+
+TEST(AppendWaypoint, AppendsWhenFrameMatches)
+{
+  SetRoutePoints::Request route;
+  set_goal(route, make_pose("map", 0.0), false);
+
+  const bool appended = append_waypoint(route, make_pose("map", 2.0));
+
+  EXPECT_TRUE(appended);
+  ASSERT_EQ(route.waypoints.size(), 1u);
+  EXPECT_DOUBLE_EQ(route.waypoints[0].position.x, 2.0);
+}
+
+TEST(AppendWaypoint, RejectsWhenFrameMismatchesAndLeavesRouteUnchanged)
+{
+  SetRoutePoints::Request route;
+  set_goal(route, make_pose("map", 0.0), false);
+
+  const bool appended = append_waypoint(route, make_pose("base_link", 2.0));
+
+  EXPECT_FALSE(appended);
+  EXPECT_TRUE(route.waypoints.empty());
+}
+
+}  // namespace autoware::adapi_adaptors
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## What

The two RViz-to-AD-API adaptor nodes (`InitialPoseAdaptor`, `RoutingAdaptor`) previously had all of their non-trivial logic inlined inside node-coupled callbacks with no `test/` directory, so every branch was unverified and untestable without spinning up a ROS executor. This PR extracts that logic into small internal-only free/templated helpers and adds the package's first unit tests.

New internal headers (under `src/`, not exported — no public API/ABI change):

- `parameter_helper.hpp` — `vector_to_array<T, N>()`: the pure size-validating vector-to-array covariance parsing. `get_covariance_parameter()` now delegates to it, so the size-mismatch `throw` branch is unit-testable without a live `rclcpp::Node`.
- `routing_state_machine.hpp` — `decide_routing_action()`: the `on_timer` merge-window/state-machine, returning the next action (`None` / `CallClear` / `CallRoute`) and the updated counter. `on_timer` now just dispatches.
- `route_builder.hpp` — `set_goal()` / `append_waypoint()`: the route-request building rules, including the `on_waypoint` frame-id mismatch guard (now returns a bool the callback acts on).

New `test/test_helpers.cpp` (13 gtest cases) asserts concrete values/branches: covariance size match + the too-small / too-large / empty throw branches; the timer state-machine transitions (idle, counter increment, reach-count → CallRoute when UNSET, reach-count → CallClear when not UNSET, call-in-flight gating, counter reset/retain); goal building with waypoint clearing and the `allow_goal_modification` flag; waypoint append-on-match and reject-on-frame-mismatch-leaving-route-unchanged.

## Behavior

Behavior-preserving. The covariance size-error message is byte-identical for the only call site (N=36). The timer and route-building branches map one-to-one onto the previous inline code; the warn-on-mismatch log path in `on_waypoint` is unchanged.

## Notes

The follow-up to promote the covariance parsing into a shared `autoware_utils_rclcpp` helper (deduplicating with `autoware_pose_initializer`) is intentionally left for a separate PR, as the backlog recommends.

Refs: autowarefoundation/autoware_core#1096
