### PR TITLE
perf(autoware_planning_test_manager): harden planning_test_manager_utils

### DIFF
--- a/testing/autoware_planning_test_manager/CMakeLists.txt
+++ b/testing/autoware_planning_test_manager/CMakeLists.txt
@@ -12,6 +12,10 @@ if(BUILD_TESTING)
   ament_auto_add_gtest(test_autoware_planning_test_manager
     test/test_planning_test_manager.cpp
   )
+
+  ament_auto_add_gtest(test_autoware_planning_test_manager_utils
+    test/test_planning_test_manager_utils.cpp
+  )
 endif()
 
 autoware_ament_auto_package(

--- a/testing/autoware_planning_test_manager/include/autoware/planning_test_manager/autoware_planning_test_manager_utils.hpp
+++ b/testing/autoware_planning_test_manager/include/autoware/planning_test_manager/autoware_planning_test_manager_utils.hpp
@@ -16,13 +16,13 @@
 #define AUTOWARE__PLANNING_TEST_MANAGER__AUTOWARE_PLANNING_TEST_MANAGER_UTILS_HPP_
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware_test_utils/autoware_test_utils.hpp>
-#include <autoware_utils/geometry/geometry.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 
-#include <iostream>
+#include <cmath>
 #include <memory>
 #include <string>
 #include <vector>
@@ -35,37 +35,66 @@ using geometry_msgs::msg::Pose;
 using nav_msgs::msg::Odometry;
 using RouteSections = std::vector<autoware_planning_msgs::msg::LaneletSegment>;
 
-inline Pose createPoseFromLaneID(
-  const lanelet::Id & lane_id, const std::string & package_name = "autoware_test_utils",
-  const std::string & map_filename = "lanelet2_map.osm")
+// Compute the mid-lanelet pose for the given lanelet id using an already-loaded RouteHandler.
+// The orientation is derived from the heading between the two central centerline points.
+inline Pose createPoseFromLaneID(const RouteHandler & route_handler, const lanelet::Id & lane_id)
 {
-  auto map_bin_msg = autoware::test_utils::makeMapBinMsg(package_name, map_filename);
-  // create route_handler
-  auto route_handler = std::make_shared<RouteHandler>();
-  route_handler->setMap(map_bin_msg);
-
   // get middle idx of the lanelet
-  const auto lanelet = route_handler->getLaneletsFromId(lane_id);
+  const auto lanelet = route_handler.getLaneletsFromId(lane_id);
   const auto center_line = lanelet.centerline();
-  const size_t middle_point_idx = std::floor(center_line.size() / 2.0);
+
+  geometry_msgs::msg::Pose middle_pose;
+  // Pose default-constructs its quaternion to (0,0,0,0), which is invalid; start from identity
+  // so degenerate centerlines (empty / single point) still return a valid orientation.
+  middle_pose.orientation.w = 1.0;
+  if (center_line.empty()) {
+    return middle_pose;
+  }
+
+  const size_t middle_point_idx = static_cast<size_t>(std::floor(center_line.size() / 2.0));
 
   // get middle position of the lanelet
   geometry_msgs::msg::Point middle_pos;
   middle_pos.x = center_line[middle_point_idx].x();
   middle_pos.y = center_line[middle_point_idx].y();
-
-  // get next middle position of the lanelet
-  geometry_msgs::msg::Point next_middle_pos;
-  next_middle_pos.x = center_line[middle_point_idx + 1].x();
-  next_middle_pos.y = center_line[middle_point_idx + 1].y();
-
-  // calculate middle pose
-  geometry_msgs::msg::Pose middle_pose;
   middle_pose.position = middle_pos;
-  const double yaw = autoware_utils::calc_azimuth_angle(middle_pos, next_middle_pos);
-  middle_pose.orientation = autoware_utils::create_quaternion_from_yaw(yaw);
+
+  // Derive the heading from a centerline segment adjacent to the middle point: normally the
+  // forward segment (middle, middle+1), but when the middle point is the last one (a two-point
+  // centerline, where middle_point_idx == 1) fall back to the preceding segment so the heading
+  // is still derivable. A single point cannot define a heading, so keep the identity orientation.
+  size_t from_idx = middle_point_idx;
+  size_t to_idx = middle_point_idx + 1;
+  if (to_idx >= center_line.size()) {
+    if (middle_point_idx == 0) {
+      return middle_pose;
+    }
+    from_idx = middle_point_idx - 1;
+    to_idx = middle_point_idx;
+  }
+
+  geometry_msgs::msg::Point from_pos;
+  from_pos.x = center_line[from_idx].x();
+  from_pos.y = center_line[from_idx].y();
+  geometry_msgs::msg::Point to_pos;
+  to_pos.x = center_line[to_idx].x();
+  to_pos.y = center_line[to_idx].y();
+
+  // calculate middle pose orientation
+  const double yaw = autoware_utils_geometry::calc_azimuth_angle(from_pos, to_pos);
+  middle_pose.orientation = autoware_utils_geometry::create_quaternion_from_yaw(yaw);
 
   return middle_pose;
+}
+
+inline Pose createPoseFromLaneID(
+  const lanelet::Id & lane_id, const std::string & package_name = "autoware_test_utils",
+  const std::string & map_filename = "lanelet2_map.osm")
+{
+  const auto map_bin_msg = autoware::test_utils::makeMapBinMsg(package_name, map_filename);
+  RouteHandler route_handler;
+  route_handler.setMap(map_bin_msg);
+  return createPoseFromLaneID(route_handler, lane_id);
 }
 
 // Function to create a route from given start and goal lanelet ids
@@ -75,17 +104,18 @@ inline LaneletRoute makeBehaviorRouteFromLaneId(
   const std::string & package_name = "autoware_test_utils",
   const std::string & map_filename = "lanelet2_map.osm")
 {
-  LaneletRoute route;
-  route.header.frame_id = "map";
-  auto start_pose = createPoseFromLaneID(start_lane_id, package_name, map_filename);
-  auto goal_pose = createPoseFromLaneID(goal_lane_id, package_name, map_filename);
-  route.start_pose = start_pose;
-  route.goal_pose = goal_pose;
-
-  auto map_bin_msg = autoware::test_utils::makeMapBinMsg(package_name, map_filename);
-  // create route_handler
+  // load the lanelet map / routing graph once and reuse it for both pose
+  // extraction and route planning
+  const auto map_bin_msg = autoware::test_utils::makeMapBinMsg(package_name, map_filename);
   auto route_handler = std::make_shared<RouteHandler>();
   route_handler->setMap(map_bin_msg);
+
+  LaneletRoute route;
+  route.header.frame_id = "map";
+  const auto start_pose = createPoseFromLaneID(*route_handler, start_lane_id);
+  const auto goal_pose = createPoseFromLaneID(*route_handler, goal_lane_id);
+  route.start_pose = start_pose;
+  route.goal_pose = goal_pose;
 
   LaneletRoute route_msg;
   RouteSections route_sections;
@@ -106,12 +136,6 @@ inline LaneletRoute makeBehaviorRouteFromLaneId(
   const auto local_route_sections = route_handler->createMapSegments(path_lanelets);
   route_sections =
     autoware::test_utils::combineConsecutiveRouteSections(route_sections, local_route_sections);
-  for (const auto & route_section : route_sections) {
-    for (const auto & primitive : route_section.primitives) {
-      std::cerr << "primitive: " << primitive.id << std::endl;
-    }
-    std::cerr << "preferred_primitive id : " << route_section.preferred_primitive.id << std::endl;
-  }
   route_handler->setRouteLanelets(all_route_lanelets);
   route.segments = route_sections;
 

--- a/testing/autoware_planning_test_manager/package.xml
+++ b/testing/autoware_planning_test_manager/package.xml
@@ -18,7 +18,9 @@
   <depend>autoware_component_interface_specs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>
+  <depend>autoware_route_handler</depend>
   <depend>autoware_test_utils</depend>
+  <depend>autoware_utils_geometry</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>tf2_msgs</depend>

--- a/testing/autoware_planning_test_manager/test/test_planning_test_manager_utils.cpp
+++ b/testing/autoware_planning_test_manager/test/test_planning_test_manager_utils.cpp
@@ -1,0 +1,102 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/planning_test_manager/autoware_planning_test_manager_utils.hpp"
+
+#include <autoware/route_handler/route_handler.hpp>
+#include <autoware_test_utils/autoware_test_utils.hpp>
+
+#include <gtest/gtest.h>
+
+namespace autoware_planning_test_manager::utils
+{
+namespace
+{
+// IDs of connected lanelets in the bundled autoware_test_utils sample map
+// (lanelet2_map.osm). The directed path 9102 -> ... -> 112 is the one exercised
+// by autoware_test_utils::makeBehaviorGoalOnLeftSideRoute().
+constexpr lanelet::Id g_start_lane_id = 9102;
+constexpr lanelet::Id g_goal_lane_id = 112;
+}  // namespace
+
+TEST(PlanningTestManagerUtils, CreatePoseFromLaneIdReturnsPoseOnCenterline)
+{
+  const auto pose = createPoseFromLaneID(g_start_lane_id);
+
+  // The pose must be populated (non-zero position on the map) and carry a
+  // normalized orientation derived from the centerline heading.
+  EXPECT_TRUE(std::isfinite(pose.position.x));
+  EXPECT_TRUE(std::isfinite(pose.position.y));
+  EXPECT_NE(pose.position.x, 0.0);
+  EXPECT_NE(pose.position.y, 0.0);
+
+  const double norm = std::sqrt(
+    pose.orientation.x * pose.orientation.x + pose.orientation.y * pose.orientation.y +
+    pose.orientation.z * pose.orientation.z + pose.orientation.w * pose.orientation.w);
+  EXPECT_NEAR(norm, 1.0, 1e-9);
+}
+
+TEST(PlanningTestManagerUtils, CreatePoseFromLaneIdSharedRouteHandlerMatchesFileOverload)
+{
+  // The injectable-RouteHandler overload must produce exactly the same pose as
+  // the file-loading convenience overload (the latter just loads the map once
+  // and delegates to the former).
+  const auto map_bin_msg = autoware::test_utils::makeMapBinMsg();
+  autoware::route_handler::RouteHandler route_handler;
+  route_handler.setMap(map_bin_msg);
+
+  const auto pose_via_handler = createPoseFromLaneID(route_handler, g_start_lane_id);
+  const auto pose_via_file = createPoseFromLaneID(g_start_lane_id);
+
+  EXPECT_DOUBLE_EQ(pose_via_handler.position.x, pose_via_file.position.x);
+  EXPECT_DOUBLE_EQ(pose_via_handler.position.y, pose_via_file.position.y);
+  EXPECT_DOUBLE_EQ(pose_via_handler.orientation.z, pose_via_file.orientation.z);
+  EXPECT_DOUBLE_EQ(pose_via_handler.orientation.w, pose_via_file.orientation.w);
+}
+
+TEST(PlanningTestManagerUtils, MakeBehaviorRouteFromLaneIdHappyPath)
+{
+  const auto route = makeBehaviorRouteFromLaneId(g_start_lane_id, g_goal_lane_id);
+
+  EXPECT_EQ(route.header.frame_id, "map");
+  EXPECT_FALSE(route.allow_modification);
+  // a connected start/goal pair must yield a non-empty set of route segments
+  EXPECT_FALSE(route.segments.empty());
+
+  // start/goal poses are filled from the lanelet centerlines
+  EXPECT_NE(route.start_pose.position.x, 0.0);
+  EXPECT_NE(route.goal_pose.position.x, 0.0);
+}
+
+TEST(PlanningTestManagerUtils, MakeBehaviorRouteFromLaneIdPlanningFailureReturnsEmptyRoute)
+{
+  // Reversing the directed path (goal lanelet used as start) has no forward
+  // route, so planPathLaneletsBetweenCheckpoints fails and an empty LaneletRoute
+  // is returned (default frame_id, no segments).
+  const auto route = makeBehaviorRouteFromLaneId(g_goal_lane_id, g_start_lane_id);
+
+  EXPECT_TRUE(route.segments.empty());
+  EXPECT_TRUE(route.header.frame_id.empty());
+}
+
+TEST(PlanningTestManagerUtils, MakeInitialPoseFromLaneIdSetsMapFrame)
+{
+  const auto odometry = makeInitialPoseFromLaneId(g_start_lane_id);
+
+  EXPECT_EQ(odometry.header.frame_id, "map");
+  EXPECT_NE(odometry.pose.pose.position.x, 0.0);
+  EXPECT_NE(odometry.pose.pose.position.y, 0.0);
+}
+
+}  // namespace autoware_planning_test_manager::utils


### PR DESCRIPTION
## Description

Hardens the header-only `autoware_planning_test_manager_utils.hpp` module, which is shipped as a public header but had zero test coverage and re-loaded the lanelet map three times per route build.

- **Perf: load the map / RouteHandler once.** Add an additive `createPoseFromLaneID(const RouteHandler &, const lanelet::Id &)` overload so a single already-loaded `RouteHandler` is reused for start-pose, goal-pose extraction and route planning. `makeBehaviorRouteFromLaneId` now loads `LaneletMapBin` + builds the routing graph once instead of three times (the two `createPoseFromLaneID` calls plus a third direct load). The existing file-loading `createPoseFromLaneID(lane_id, package_name, map_filename)` overload is kept and now delegates to the new one, so all existing call sites and the public API/ABI stay valid.
- **Safety: guard the centerline access.** The old code unconditionally read `center_line[middle_point_idx + 1]`, which reads past the end for a single-point centerline. Now empty centerlines return a position-less pose and single-point centerlines return the centerline point with identity orientation (no heading is derivable), eliminating the out-of-bounds read.
- **Remove production-path debug spam.** Dropped the `std::cerr` loop that printed every primitive id and the preferred-primitive id on every call.
- **Dependency hygiene.** Switched the geometry include/namespace to `autoware_utils_geometry` and declared the previously-transitive `autoware_route_handler` and `autoware_utils_geometry` deps in `package.xml` (kept sorted).
- **Tests.** Added `test/test_planning_test_manager_utils.cpp` covering the previously-untested utils functions: pose-on-centerline (non-zero position, normalized orientation), overload equivalence (shared-RouteHandler vs file overload produce identical poses), the route happy path (`9102 -> 112`, asserting non-empty segments and filled poses), the planning-failure path (reversed `112 -> 9102`, asserting an empty `LaneletRoute` with no segments and default frame_id), and `makeInitialPoseFromLaneId` (frame_id == map).

Behavior-preserving for valid inputs; the only intentional behavior change is the OOB guard for degenerate (<2-point) centerlines, which previously read out of bounds.

## Tests

Built and tested in the `autoware:core-devel-jazzy` container. The new `test_autoware_planning_test_manager_utils` suite passes all 5 cases. The pre-existing `test_autoware_planning_test_manager` suite fails identically on a pristine `upstream/main` checkout in the container (a DDS multicast/subscriber-discovery flake on the container's non-multicast `lo`), so it is unrelated to this change and passes under the fork CI's networked environment.

Refs: autowarefoundation/autoware_core#1096
