### PR TITLE
test: verify -above passes with static_centerline_generator GUI fix (do not merge)

### DIFF
--- a/common/autoware_lanelet2_utils/include/autoware/lanelet2_utils/topology.hpp
+++ b/common/autoware_lanelet2_utils/include/autoware/lanelet2_utils/topology.hpp
@@ -15,6 +15,10 @@
 #ifndef AUTOWARE__LANELET2_UTILS__TOPOLOGY_HPP_
 #define AUTOWARE__LANELET2_UTILS__TOPOLOGY_HPP_
 
+// NOTE (verification only — do not upstream): trivial touch to mark autoware_lanelet2_utils as
+// modified so the -above differential builds+tests its downstream static_centerline_generator,
+// exercising the headless-GUI test fix pinned in packages_above.repos.
+
 #include <lanelet2_core/primitives/Lanelet.h>
 #include <lanelet2_routing/Forward.h>
 #include <lanelet2_traffic_rules/TrafficRulesFactory.h>

--- a/packages_above.repos
+++ b/packages_above.repos
@@ -76,5 +76,7 @@ repositories:
   # Tools
   tools/autoware_tools:
     type: git
-    url: https://github.com/autowarefoundation/autoware_tools.git
-    version: main
+    # TEMP (verification only — do not upstream): point at youtalk fork branch carrying the
+    # static_centerline_generator headless-GUI test fix to confirm the -above test goes green.
+    url: https://github.com/youtalk/autoware_tools.git
+    version: fix/static_centerline_generator_gui_offscreen


### PR DESCRIPTION
## ⚠️ Verification only — do not merge / do not upstream

Confirms that the autoware_core `-above` (universe) build's GUI launch test
`test_static_centerline_generator_gui_launch.test.py` passes once the
autoware_tools fix is in place.

- `packages_above.repos` `tools/autoware_tools` is temporarily pinned to
  `youtalk/autoware_tools@fix/static_centerline_generator_gui_offscreen`
  (sets `QT_QPA_PLATFORM=offscreen` in the launch-test description).
- A trivial touch to `autoware_lanelet2_utils` makes the `-above` differential
  build+test its downstream `autoware_static_centerline_generator`.

Watch: `build-and-test-diff-jazzy-above` / `build-and-test-diff-humble-above`.

Refs: autowarefoundation/autoware_tools#391
