### PR TITLE
test: verify -above static_centerline GUI with lane_ids cache fix (do not merge)

### DIFF
--- a/common/autoware_lanelet2_utils/include/autoware/lanelet2_utils/topology.hpp
+++ b/common/autoware_lanelet2_utils/include/autoware/lanelet2_utils/topology.hpp
@@ -15,6 +15,10 @@
 #ifndef AUTOWARE__LANELET2_UTILS__TOPOLOGY_HPP_
 #define AUTOWARE__LANELET2_UTILS__TOPOLOGY_HPP_
 
+// NOTE (verification only — do not upstream): trivial touch to mark autoware_lanelet2_utils as
+// modified so the -above differential builds+tests downstream static_centerline_generator,
+// exercising the centerline lane_ids cache-refresh fix pinned in packages_above.repos.
+
 #include <lanelet2_core/primitives/Lanelet.h>
 #include <lanelet2_routing/Forward.h>
 #include <lanelet2_traffic_rules/TrafficRulesFactory.h>

--- a/packages_above.repos
+++ b/packages_above.repos
@@ -76,5 +76,8 @@ repositories:
   # Tools
   tools/autoware_tools:
     type: git
-    url: https://github.com/autowarefoundation/autoware_tools.git
-    version: main
+    # TEMP (verification only — do not upstream): youtalk fork branch carrying BOTH the
+    # offscreen GUI-test fix and the centerline lane_ids cache-refresh fix, to confirm the
+    # -above static_centerline_generator GUI test goes green on jazzy.
+    url: https://github.com/youtalk/autoware_tools.git
+    version: fix/static_centerline_lane_ids_cache


### PR DESCRIPTION
## ⚠️ Verification only — do not merge / do not upstream

Confirms the autoware_core `-above` jazzy `test_static_centerline_generator_gui_launch` goes green with the
**centerline lane_ids cache-refresh fix** (on top of the offscreen GUI fix).

- `packages_above.repos` `tools/autoware_tools` pinned to
  `youtalk/autoware_tools@fix/static_centerline_lane_ids_cache` (offscreen + lane_ids cache fix).
- Trivial touch to `autoware_lanelet2_utils` so the `-above` differential builds+tests downstream
  `autoware_static_centerline_generator`, exercising the GUI launch test on latest universe-main.

Watch: `build-and-test-diff-jazzy-above` (the one that previously failed on `size mismatch`).

Refs: autowarefoundation/autoware_tools#391
