### PR TITLE
test: verify -above static_centerline GUI exercises createCircleMarker with autoware_tools fix (do not merge)

### DIFF
--- a/packages_above.repos
+++ b/packages_above.repos
@@ -76,5 +76,10 @@ repositories:
   # Tools
   tools/autoware_tools:
     type: git
-    url: https://github.com/autowarefoundation/autoware_tools.git
-    version: main
+    # TEMP (verification only — do not merge / do not upstream): youtalk fork branch carrying the
+    # centerline lane_ids cache-refresh fix, so the -above static_centerline_generator GUI launch
+    # test (a downstream consumer of autoware_objects_of_interest_marker_interface via the
+    # behavior_path modules) goes green and actually exercises the new createCircleMarker signature
+    # end-to-end. See youtalk/autoware_core#62.
+    url: https://github.com/youtalk/autoware_tools.git
+    version: fix/static_centerline_lane_ids_cache

--- a/planning/autoware_objects_of_interest_marker_interface/CMakeLists.txt
+++ b/planning/autoware_objects_of_interest_marker_interface/CMakeLists.txt
@@ -25,6 +25,10 @@ ament_auto_add_library(autoware_objects_of_interest_marker_interface SHARED
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  ament_auto_add_gtest(test_${PROJECT_NAME}
+    test/test_marker_utils.cpp
+  )
 endif()
 
 autoware_ament_auto_package()

--- a/planning/autoware_objects_of_interest_marker_interface/include/autoware/objects_of_interest_marker_interface/marker_utils.hpp
+++ b/planning/autoware_objects_of_interest_marker_interface/include/autoware/objects_of_interest_marker_interface/marker_utils.hpp
@@ -22,6 +22,8 @@
 #include <autoware_utils_math/constants.hpp>
 #include <autoware_utils_math/trigonometry.hpp>
 #include <autoware_utils_visualization/marker_helper.hpp>
+#include <rclcpp/clock.hpp>
+#include <rclcpp/time.hpp>
 
 #include <autoware_perception_msgs/msg/predicted_object.hpp>
 #include <geometry_msgs/msg/pose.hpp>
@@ -39,10 +41,12 @@ namespace autoware::objects_of_interest_marker_interface::marker_utils
  * @param name Module name
  * @param height_offset Height offset of arrow marker
  * @param arrow_length Length of arrow marker
+ * @param stamp Header stamp of the marker (defaults to the current ROS time)
  */
 visualization_msgs::msg::Marker createArrowMarker(
   const size_t id, const ObjectMarkerData & data, const std::string & name,
-  const double height_offset, const double arrow_length = 1.0);
+  const double height_offset, const double arrow_length = 1.0,
+  const rclcpp::Time & stamp = rclcpp::Clock{RCL_ROS_TIME}.now());
 
 /**
  * @brief Create circle marker from object marker data
@@ -52,10 +56,12 @@ visualization_msgs::msg::Marker createArrowMarker(
  * @param radius Radius of circle marker
  * @param height_offset Height offset of circle marker
  * @param line_width Line width of circle marker
+ * @param stamp Header stamp of the marker (defaults to the current ROS time)
  */
 visualization_msgs::msg::Marker createCircleMarker(
   const size_t id, const ObjectMarkerData & data, const std::string & name, const double radius,
-  const double height_offset, const double line_width = 0.1);
+  const double height_offset, const double line_width = 0.1,
+  const rclcpp::Time & stamp = rclcpp::Clock{RCL_ROS_TIME}.now());
 
 /**
  * @brief Create text marker visualizing module name
@@ -64,10 +70,12 @@ visualization_msgs::msg::Marker createCircleMarker(
  * @param name Module name
  * @param height_offset Height offset of target marker
  * @param text_size Text size
+ * @param stamp Header stamp of the marker (defaults to the current ROS time)
  */
 visualization_msgs::msg::Marker createNameTextMarker(
   const size_t id, const ObjectMarkerData & data, const std::string & name,
-  const double height_offset, const double text_size = 0.5);
+  const double height_offset, const double text_size = 0.5,
+  const rclcpp::Time & stamp = rclcpp::Clock{RCL_ROS_TIME}.now());
 
 /**
  * @brief Create target marker from object marker data
@@ -77,10 +85,12 @@ visualization_msgs::msg::Marker createNameTextMarker(
  * @param height_offset Height offset of target marker
  * @param arrow_length Length of arrow marker
  * @param line_width Line width of circle marker
+ * @param stamp Header stamp shared by all markers (defaults to the current ROS time)
  */
 visualization_msgs::msg::MarkerArray createTargetMarker(
   const size_t id, const ObjectMarkerData & data, const std::string & name,
-  const double height_offset, const double arrow_length = 1.0, const double line_width = 0.1);
+  const double height_offset, const double arrow_length = 1.0, const double line_width = 0.1,
+  const rclcpp::Time & stamp = rclcpp::Clock{RCL_ROS_TIME}.now());
 }  // namespace autoware::objects_of_interest_marker_interface::marker_utils
 
 #endif  // AUTOWARE__OBJECTS_OF_INTEREST_MARKER_INTERFACE__MARKER_UTILS_HPP_

--- a/planning/autoware_objects_of_interest_marker_interface/src/marker_utils.cpp
+++ b/planning/autoware_objects_of_interest_marker_interface/src/marker_utils.cpp
@@ -30,15 +30,15 @@ using visualization_msgs::msg::MarkerArray;
 
 Marker createArrowMarker(
   const size_t id, const ObjectMarkerData & data, const std::string & name,
-  const double height_offset, const double arrow_length)
+  const double height_offset, const double arrow_length, const rclcpp::Time & stamp)
 {
   const double line_width = 0.25 * arrow_length;
   const double head_width = 0.5 * arrow_length;
   const double head_height = 0.5 * arrow_length;
 
   Marker marker = create_default_marker(
-    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), name + "_arrow", static_cast<int32_t>(id),
-    Marker::ARROW, create_marker_scale(line_width, head_width, head_height), data.color);
+    "map", stamp, name + "_arrow", static_cast<int32_t>(id), Marker::ARROW,
+    create_marker_scale(line_width, head_width, head_height), data.color);
 
   const double height = 0.5 * data.shape.dimensions.z;
 
@@ -56,15 +56,16 @@ Marker createArrowMarker(
 
 Marker createCircleMarker(
   const size_t id, const ObjectMarkerData & data, const std::string & name, const double radius,
-  const double height_offset, const double line_width)
+  const double height_offset, const double line_width, const rclcpp::Time & stamp)
 {
   Marker marker = create_default_marker(
-    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), name, static_cast<int32_t>(id), Marker::LINE_STRIP,
+    "map", stamp, name, static_cast<int32_t>(id), Marker::LINE_STRIP,
     create_marker_scale(line_width, 0.0, 0.0), data.color);
 
   const double height = 0.5 * data.shape.dimensions.z;
 
   constexpr size_t num_points = 20;
+  marker.points.reserve(num_points + 1);
   for (size_t i = 0; i < num_points; ++i) {
     Point point;
     const double ratio = static_cast<double>(i) / static_cast<double>(num_points);
@@ -81,12 +82,11 @@ Marker createCircleMarker(
 
 visualization_msgs::msg::Marker createNameTextMarker(
   const size_t id, const ObjectMarkerData & data, const std::string & name,
-  const double height_offset, const double text_size)
+  const double height_offset, const double text_size, const rclcpp::Time & stamp)
 {
   Marker marker = create_default_marker(
-    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), name + "_name_text", static_cast<int32_t>(id),
-    Marker::TEXT_VIEW_FACING, create_marker_scale(0.0, 0.0, text_size),
-    coloring::getGray(data.color.a));
+    "map", stamp, name + "_name_text", static_cast<int32_t>(id), Marker::TEXT_VIEW_FACING,
+    create_marker_scale(0.0, 0.0, text_size), coloring::getGray(data.color.a));
 
   marker.text = name;
 
@@ -99,18 +99,20 @@ visualization_msgs::msg::Marker createNameTextMarker(
 
 MarkerArray createTargetMarker(
   const size_t id, const ObjectMarkerData & data, const std::string & name,
-  const double height_offset, const double arrow_length, const double line_width)
+  const double height_offset, const double arrow_length, const double line_width,
+  const rclcpp::Time & stamp)
 {
   MarkerArray marker_array;
-  marker_array.markers.push_back(createArrowMarker(id, data, name, height_offset, arrow_length));
+  marker_array.markers.push_back(
+    createArrowMarker(id, data, name, height_offset, arrow_length, stamp));
   marker_array.markers.push_back(createCircleMarker(
     id, data, name + "_circle1", 0.5 * arrow_length, height_offset + 0.75 * arrow_length,
-    line_width));
+    line_width, stamp));
   marker_array.markers.push_back(createCircleMarker(
     id, data, name + "_circle2", 0.75 * arrow_length, height_offset + 0.75 * arrow_length,
-    line_width));
-  marker_array.markers.push_back(
-    createNameTextMarker(id, data, name, height_offset + 1.5 * arrow_length, 0.5 * arrow_length));
+    line_width, stamp));
+  marker_array.markers.push_back(createNameTextMarker(
+    id, data, name, height_offset + 1.5 * arrow_length, 0.5 * arrow_length, stamp));
 
   return marker_array;
 }

--- a/planning/autoware_objects_of_interest_marker_interface/src/objects_of_interest_marker_interface.cpp
+++ b/planning/autoware_objects_of_interest_marker_interface/src/objects_of_interest_marker_interface.cpp
@@ -55,10 +55,12 @@ void ObjectsOfInterestMarkerInterface::publishMarkerArray()
     return;
   }
   MarkerArray marker_array;
+  const auto & name = getName();
+  const auto height_offset = getHeightOffset();
   for (size_t i = 0; i < obj_marker_data_array_.size(); ++i) {
-    const auto data = obj_marker_data_array_.at(i);
+    const auto & data = obj_marker_data_array_.at(i);
     const MarkerArray target_marker =
-      marker_utils::createTargetMarker(i, data, getName(), getHeightOffset());
+      marker_utils::createTargetMarker(i, data, name, height_offset);
     marker_array.markers.insert(
       marker_array.markers.end(), target_marker.markers.begin(), target_marker.markers.end());
   }

--- a/planning/autoware_objects_of_interest_marker_interface/test/test_marker_utils.cpp
+++ b/planning/autoware_objects_of_interest_marker_interface/test/test_marker_utils.cpp
@@ -1,0 +1,268 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/objects_of_interest_marker_interface/coloring.hpp"
+#include "autoware/objects_of_interest_marker_interface/marker_data.hpp"
+#include "autoware/objects_of_interest_marker_interface/marker_utils.hpp"
+#include "autoware/objects_of_interest_marker_interface/objects_of_interest_marker_interface.hpp"
+
+#include <builtin_interfaces/msg/time.hpp>
+#include <rclcpp/time.hpp>
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace autoware::objects_of_interest_marker_interface
+{
+namespace
+{
+constexpr float kAlpha = 0.5f;
+constexpr float kEps = 1e-4f;
+
+// Compares a marker's header.stamp against an expected ROS time by raw fields,
+// avoiding rclcpp::Time clock-source comparison (the message stores a
+// source-less builtin_interfaces::msg::Time).
+void expect_stamp_eq(const builtin_interfaces::msg::Time & actual, const rclcpp::Time & expected)
+{
+  const builtin_interfaces::msg::Time expected_msg = expected;
+  EXPECT_EQ(actual.sec, expected_msg.sec);
+  EXPECT_EQ(actual.nanosec, expected_msg.nanosec);
+}
+
+ObjectMarkerData make_data()
+{
+  ObjectMarkerData data;
+  data.pose.position.x = 1.0;
+  data.pose.position.y = 2.0;
+  data.pose.position.z = 3.0;
+  data.shape.dimensions.z = 4.0;  // height = 0.5 * 4.0 = 2.0
+  data.color.r = 0.1f;
+  data.color.g = 0.2f;
+  data.color.b = 0.3f;
+  data.color.a = 0.9f;
+  return data;
+}
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// coloring: pin the exact hex-decode results (the >>16 / <<48>>56 / <<56>>56
+// bit math is non-obvious and worth a regression test).
+// ---------------------------------------------------------------------------
+TEST(Coloring, GetGreenDecodes0x00e676)
+{
+  const auto color = coloring::getGreen(kAlpha);
+  EXPECT_NEAR(color.r, 0x00 / 255.0f, kEps);
+  EXPECT_NEAR(color.g, 0xe6 / 255.0f, kEps);
+  EXPECT_NEAR(color.b, 0x76 / 255.0f, kEps);
+  EXPECT_FLOAT_EQ(color.a, kAlpha);
+}
+
+TEST(Coloring, GetAmberDecodes0xffea00)
+{
+  const auto color = coloring::getAmber(kAlpha);
+  EXPECT_NEAR(color.r, 0xff / 255.0f, kEps);
+  EXPECT_NEAR(color.g, 0xea / 255.0f, kEps);
+  EXPECT_NEAR(color.b, 0x00 / 255.0f, kEps);
+  EXPECT_FLOAT_EQ(color.a, kAlpha);
+}
+
+TEST(Coloring, GetRedDecodes0xff3d00)
+{
+  const auto color = coloring::getRed(kAlpha);
+  EXPECT_NEAR(color.r, 0xff / 255.0f, kEps);
+  EXPECT_NEAR(color.g, 0x3d / 255.0f, kEps);
+  EXPECT_NEAR(color.b, 0x00 / 255.0f, kEps);
+  EXPECT_FLOAT_EQ(color.a, kAlpha);
+}
+
+TEST(Coloring, GetGrayDecodes0xbdbdbd)
+{
+  const auto color = coloring::getGray(kAlpha);
+  EXPECT_NEAR(color.r, 0xbd / 255.0f, kEps);
+  EXPECT_NEAR(color.g, 0xbd / 255.0f, kEps);
+  EXPECT_NEAR(color.b, 0xbd / 255.0f, kEps);
+  EXPECT_FLOAT_EQ(color.a, kAlpha);
+}
+
+TEST(Coloring, DefaultAlphaIsApplied)
+{
+  // The free functions take alpha explicitly; verify alpha is forwarded.
+  EXPECT_FLOAT_EQ(coloring::getGreen(0.25f).a, 0.25f);
+  EXPECT_FLOAT_EQ(coloring::getGray(1.0f).a, 1.0f);
+}
+
+// ---------------------------------------------------------------------------
+// getColor: each ColorName maps to the matching coloring helper, and an
+// out-of-range value falls through to the GRAY default branch.
+// ---------------------------------------------------------------------------
+TEST(GetColor, MapsEachColorName)
+{
+  const float a = 0.7f;
+  const auto green = ObjectsOfInterestMarkerInterface::getColor(ColorName::GREEN, a);
+  EXPECT_NEAR(green.r, 0x00 / 255.0f, kEps);
+  EXPECT_NEAR(green.g, 0xe6 / 255.0f, kEps);
+  EXPECT_NEAR(green.b, 0x76 / 255.0f, kEps);
+
+  const auto amber = ObjectsOfInterestMarkerInterface::getColor(ColorName::AMBER, a);
+  EXPECT_NEAR(amber.r, 0xff / 255.0f, kEps);
+  EXPECT_NEAR(amber.g, 0xea / 255.0f, kEps);
+
+  const auto red = ObjectsOfInterestMarkerInterface::getColor(ColorName::RED, a);
+  EXPECT_NEAR(red.r, 0xff / 255.0f, kEps);
+  EXPECT_NEAR(red.g, 0x3d / 255.0f, kEps);
+
+  const auto gray = ObjectsOfInterestMarkerInterface::getColor(ColorName::GRAY, a);
+  EXPECT_NEAR(gray.r, 0xbd / 255.0f, kEps);
+}
+
+TEST(GetColor, DefaultBranchReturnsGray)
+{
+  // Force the switch default branch with an out-of-enum value.
+  const auto color = ObjectsOfInterestMarkerInterface::getColor(static_cast<ColorName>(999), 0.4f);
+  EXPECT_NEAR(color.r, 0xbd / 255.0f, kEps);
+  EXPECT_NEAR(color.g, 0xbd / 255.0f, kEps);
+  EXPECT_NEAR(color.b, 0xbd / 255.0f, kEps);
+  EXPECT_FLOAT_EQ(color.a, 0.4f);
+}
+
+TEST(GetColor, DefaultAlphaArgument)
+{
+  // The default alpha argument (0.99f) is applied when omitted.
+  const auto color = ObjectsOfInterestMarkerInterface::getColor(ColorName::GRAY);
+  EXPECT_FLOAT_EQ(color.a, 0.99f);
+}
+
+// ---------------------------------------------------------------------------
+// createArrowMarker: 2 points, ARROW type, "_arrow" namespace, z-stacking.
+// ---------------------------------------------------------------------------
+TEST(MarkerUtils, CreateArrowMarker)
+{
+  const auto data = make_data();
+  const rclcpp::Time stamp(123, 456);
+  const auto marker = marker_utils::createArrowMarker(
+    7, data, "mod", /*height_offset=*/0.5, /*arrow_length=*/2.0, stamp);
+
+  EXPECT_EQ(marker.ns, "mod_arrow");
+  EXPECT_EQ(marker.id, 7);
+  EXPECT_EQ(marker.type, visualization_msgs::msg::Marker::ARROW);
+  EXPECT_EQ(marker.color.r, data.color.r);
+  EXPECT_EQ(marker.color.a, data.color.a);
+
+  // scale = (0.25*len, 0.5*len, 0.5*len)
+  EXPECT_DOUBLE_EQ(marker.scale.x, 0.25 * 2.0);
+  EXPECT_DOUBLE_EQ(marker.scale.y, 0.5 * 2.0);
+  EXPECT_DOUBLE_EQ(marker.scale.z, 0.5 * 2.0);
+
+  ASSERT_EQ(marker.points.size(), 2u);
+  const double height = 0.5 * data.shape.dimensions.z;  // 2.0
+  // src is higher than dst by arrow_length.
+  EXPECT_DOUBLE_EQ(marker.points[0].z, data.pose.position.z + height + 0.5 + 2.0);
+  EXPECT_DOUBLE_EQ(marker.points[1].z, data.pose.position.z + height + 0.5);
+  EXPECT_DOUBLE_EQ(marker.points[0].x, data.pose.position.x);
+  EXPECT_DOUBLE_EQ(marker.points[1].y, data.pose.position.y);
+
+  // Injected stamp is used verbatim (no internal clock).
+  expect_stamp_eq(marker.header.stamp, stamp);
+}
+
+// ---------------------------------------------------------------------------
+// createCircleMarker: 21 points with first == last closure, LINE_STRIP type.
+// ---------------------------------------------------------------------------
+TEST(MarkerUtils, CreateCircleMarkerClosesLoop)
+{
+  const auto data = make_data();
+  const rclcpp::Time stamp(10, 20);
+  const auto marker = marker_utils::createCircleMarker(
+    3, data, "ring", /*radius=*/1.0, /*height_offset=*/0.25, /*line_width=*/0.1, stamp);
+
+  EXPECT_EQ(marker.ns, "ring");
+  EXPECT_EQ(marker.type, visualization_msgs::msg::Marker::LINE_STRIP);
+  ASSERT_EQ(marker.points.size(), 21u);  // 20 + closing point
+
+  // First and last point are identical (closure).
+  EXPECT_DOUBLE_EQ(marker.points.front().x, marker.points.back().x);
+  EXPECT_DOUBLE_EQ(marker.points.front().y, marker.points.back().y);
+  EXPECT_DOUBLE_EQ(marker.points.front().z, marker.points.back().z);
+
+  // First point: theta = 0 -> (x + radius, y), shared z.
+  const double height = 0.5 * data.shape.dimensions.z;
+  EXPECT_NEAR(marker.points.front().x, data.pose.position.x + 1.0, 1e-3);
+  EXPECT_NEAR(marker.points.front().y, data.pose.position.y, 1e-3);
+  EXPECT_DOUBLE_EQ(marker.points.front().z, data.pose.position.z + height + 0.25);
+
+  expect_stamp_eq(marker.header.stamp, stamp);
+}
+
+// ---------------------------------------------------------------------------
+// createNameTextMarker: text == name, gray color, TEXT_VIEW_FACING type.
+// ---------------------------------------------------------------------------
+TEST(MarkerUtils, CreateNameTextMarker)
+{
+  const auto data = make_data();
+  const rclcpp::Time stamp(5, 0);
+  const auto marker = marker_utils::createNameTextMarker(
+    9, data, "label", /*height_offset=*/1.0, /*text_size=*/0.5, stamp);
+
+  EXPECT_EQ(marker.ns, "label_name_text");
+  EXPECT_EQ(marker.text, "label");
+  EXPECT_EQ(marker.type, visualization_msgs::msg::Marker::TEXT_VIEW_FACING);
+
+  // Color is gray with the data's alpha.
+  EXPECT_NEAR(marker.color.r, 0xbd / 255.0f, kEps);
+  EXPECT_NEAR(marker.color.g, 0xbd / 255.0f, kEps);
+  EXPECT_NEAR(marker.color.b, 0xbd / 255.0f, kEps);
+  EXPECT_FLOAT_EQ(marker.color.a, data.color.a);
+
+  // Pose copied from data with z raised by height + offset.
+  const double height = 0.5 * data.shape.dimensions.z;
+  EXPECT_DOUBLE_EQ(marker.pose.position.x, data.pose.position.x);
+  EXPECT_DOUBLE_EQ(marker.pose.position.z, data.pose.position.z + height + 1.0);
+
+  expect_stamp_eq(marker.header.stamp, stamp);
+}
+
+// ---------------------------------------------------------------------------
+// createTargetMarker: 4 markers with the expected namespaces, all sharing the
+// injected stamp.
+// ---------------------------------------------------------------------------
+TEST(MarkerUtils, CreateTargetMarkerAssembly)
+{
+  const auto data = make_data();
+  const rclcpp::Time stamp(99, 1);
+  const auto array = marker_utils::createTargetMarker(
+    2, data, "tgt", /*height_offset=*/0.5, /*arrow_length=*/1.0, /*line_width=*/0.1, stamp);
+
+  ASSERT_EQ(array.markers.size(), 4u);
+  EXPECT_EQ(array.markers[0].ns, "tgt_arrow");
+  EXPECT_EQ(array.markers[1].ns, "tgt_circle1");
+  EXPECT_EQ(array.markers[2].ns, "tgt_circle2");
+  EXPECT_EQ(array.markers[3].ns, "tgt_name_text");
+
+  // All markers share the single injected stamp.
+  for (const auto & marker : array.markers) {
+    expect_stamp_eq(marker.header.stamp, stamp);
+  }
+
+  // circle2 has a larger radius than circle1.
+  EXPECT_GT(array.markers[2].points.front().x, array.markers[1].points.front().x);
+}
+
+}  // namespace autoware::objects_of_interest_marker_interface
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## ⚠️ Verification only — do not merge / do not upstream

Confirms that the optional-`stamp` `createCircleMarker` / `createTargetMarker` changes in #51 are
safe for their real downstream consumers in the `-above` (universe + tools) tree, per the review
request on #51.

- `packages_above.repos` `tools/autoware_tools` repinned to
  `youtalk/autoware_tools@fix/static_centerline_lane_ids_cache` (centerline lane_ids cache-refresh
  fix), so the `-above` differential rebuilds and tests `autoware_static_centerline_generator` —
  which pulls in `autoware_objects_of_interest_marker_interface` via the `behavior_path` modules —
  and its GUI launch test passes instead of failing on the pre-existing, non-deterministic
  `Cannot save map: size mismatch` (lane_ids staleness).
- The signature change is purely additive (a new defaulted trailing parameter), so every existing
  caller still compiles unchanged; this run confirms that end-to-end.

Watch: `build-and-test-diff-{jazzy,humble}-above`.

Refs: youtalk/autoware_core#51, youtalk/autoware_core#62
