### PR TITLE
fix(autoware_ekf_localizer): guard empty delay-time table in find_closest_delay_time_index

### DIFF
--- a/localization/autoware_ekf_localizer/src/ekf_module.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_module.cpp
@@ -173,6 +173,14 @@ double EKFModule::get_yaw_bias() const
 
 size_t EKFModule::find_closest_delay_time_index(double target_value) const
 {
+  // Additive safety guard: accumulated_delay_times_ is sized to params_.extend_state_step in the
+  // constructor. A misconfigured extend_state_step == 0 leaves the table empty, and the
+  // accumulated_delay_times_.back() dereference below would be undefined behaviour. Treat an empty
+  // table as "no delay slots", returning 0 (== size()) instead of crashing.
+  if (accumulated_delay_times_.empty()) {
+    return 0;
+  }
+
   // If target_value is too large, return last index + 1
   if (target_value > accumulated_delay_times_.back()) {
     return accumulated_delay_times_.size();

--- a/localization/autoware_ekf_localizer/src/include/hyper_parameters.hpp
+++ b/localization/autoware_ekf_localizer/src/include/hyper_parameters.hpp
@@ -32,12 +32,14 @@ public:
   //
   // The in-class member initializers below give the default-constructed instance SAFE, non-zero
   // values for every field that EKFModule relies on at construction time. In particular
-  // extend_state_step must be >= 1: EKFModule sizes accumulated_delay_times_ as
-  // std::vector<double>(extend_state_step, 1.0E15), and find_closest_delay_time_index()
-  // dereferences accumulated_delay_times_.back(), which is undefined behaviour (a crash) on an
-  // empty vector. The other sizing/rate defaults (ekf_rate/ekf_dt, smoothing steps, queue sizes,
-  // gate distances, process/filter noise) are likewise non-zero so a default-constructed instance
-  // is immediately usable.
+  // extend_state_step is set to a realistic >= 1 value: EKFModule sizes accumulated_delay_times_
+  // as std::vector<double>(extend_state_step, 1.0E15) and find_closest_delay_time_index() reads
+  // accumulated_delay_times_.back(). A misconfigured extend_state_step == 0 would leave that table
+  // empty; find_closest_delay_time_index() now guards the empty table (returns 0) instead of
+  // dereferencing .back(), so the degenerate configuration no longer triggers undefined behaviour.
+  // The other sizing/rate defaults (ekf_rate/ekf_dt, smoothing steps, queue sizes, gate distances,
+  // process/filter noise) are likewise non-zero so a default-constructed instance is immediately
+  // usable.
   HyperParameters() = default;
 
   explicit HyperParameters(rclcpp::Node * node)
@@ -97,7 +99,8 @@ public:
   double ekf_dt{1.0 / 50.0};  // ekf update period [s]
   double tf_rate_{10.0};
   bool enable_yaw_bias_estimation{true};
-  // Must be >= 1: EKFModule sizes accumulated_delay_times_ to this length and calls .back() on it.
+  // Sizes accumulated_delay_times_ to this length; 0 leaves the table empty, which
+  // find_closest_delay_time_index() guards against (see ekf_module.cpp).
   size_t extend_state_step{50};
   std::string pose_frame_id{"map"};
   double pose_additional_delay{0.0};

--- a/localization/autoware_ekf_localizer/test/test_ekf_module.cpp
+++ b/localization/autoware_ekf_localizer/test/test_ekf_module.cpp
@@ -158,6 +158,22 @@ TEST(TestEKFModule, FindClosestDelayTimeIndex)
   EXPECT_EQ(module->find_closest_delay_time_index(beyond), params.extend_state_step);
 }
 
+// Degenerate configuration: extend_state_step == 0 leaves accumulated_delay_times_ empty.
+// find_closest_delay_time_index() must not dereference .back() on the empty table; it returns the
+// safe index 0 (== size()) for any target instead of crashing. The default of 50 must NOT mask
+// this, so the test sets extend_state_step to 0 explicitly.
+TEST(TestEKFModule, FindClosestDelayTimeIndexEmptyTable)
+{
+  HyperParameters params = make_params();
+  params.extend_state_step = 0;
+  auto module = make_module(params);
+
+  EXPECT_EQ(module->find_closest_delay_time_index(-1.0), 0u);
+  EXPECT_EQ(module->find_closest_delay_time_index(0.0), 0u);
+  EXPECT_EQ(module->find_closest_delay_time_index(1.0), 0u);
+  EXPECT_EQ(module->find_closest_delay_time_index(1.0e15), 0u);
+}
+
 // ---------------------------------------------------------------------------
 // accumulate_delay_time: copy_backward shift + accumulation
 // ---------------------------------------------------------------------------
@@ -307,8 +323,19 @@ protected:
 
 TEST_F(MeasurementUpdatePose, AcceptsValidMeasurement)
 {
+  using COV_IDX = autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
   const rclcpp::Time t_curr(100, 0, RCL_ROS_TIME);
-  auto pose = make_pose(0.0, 0.0, 0.0, "map", t_curr);
+
+  // Feed a measurement offset from the predicted state (origin) so a real Kalman update has an
+  // externally-observable effect: the state must move toward the measurement and the position
+  // covariance must shrink. A silent no-op after passing the gates would leave the state at the
+  // origin and the covariance unchanged, failing these postconditions.
+  auto pose = make_pose(1.0, 2.0, 0.0, "map", t_curr);
+
+  const auto pose_before = module_->get_current_pose(t_curr, false);
+  const auto cov_before = module_->get_current_pose_covariance();
+  EXPECT_DOUBLE_EQ(pose_before.pose.position.x, 0.0);
+  EXPECT_DOUBLE_EQ(pose_before.pose.position.y, 0.0);
 
   EKFDiagnosticInfo diag;
   const bool ok = module_->measurement_update_pose(pose, t_curr, diag);
@@ -316,6 +343,19 @@ TEST_F(MeasurementUpdatePose, AcceptsValidMeasurement)
   EXPECT_TRUE(ok);
   EXPECT_TRUE(diag.is_passed_delay_gate);
   EXPECT_TRUE(diag.is_passed_mahalanobis_gate);
+
+  // Postcondition: the state is blended toward the measurement (strictly between the prior
+  // estimate and the measurement), not snapped to it.
+  const auto pose_after = module_->get_current_pose(t_curr, false);
+  EXPECT_GT(pose_after.pose.position.x, 0.0);
+  EXPECT_LT(pose_after.pose.position.x, 1.0);
+  EXPECT_GT(pose_after.pose.position.y, 0.0);
+  EXPECT_LT(pose_after.pose.position.y, 2.0);
+
+  // Postcondition: the position covariance is reduced by incorporating the measurement.
+  const auto cov_after = module_->get_current_pose_covariance();
+  EXPECT_LT(cov_after[COV_IDX::X_X], cov_before[COV_IDX::X_X]);
+  EXPECT_LT(cov_after[COV_IDX::Y_Y], cov_before[COV_IDX::Y_Y]);
 }
 
 TEST_F(MeasurementUpdatePose, RejectsOnDelayGate)
@@ -407,8 +447,17 @@ protected:
 
 TEST_F(MeasurementUpdateTwist, AcceptsValidMeasurement)
 {
+  using COV_IDX = autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
   const rclcpp::Time t_curr(100, 0, RCL_ROS_TIME);
-  auto twist = make_twist(0.0, 0.0, "base_link", t_curr);
+
+  // Feed a velocity offset from the predicted state (vx == wz == 0) so the update is observable:
+  // the velocity estimate must move toward the measurement and the velocity covariance shrink.
+  auto twist = make_twist(3.0, 1.0, "base_link", t_curr);
+
+  const auto twist_before = module_->get_current_twist(t_curr);
+  const auto cov_before = module_->get_current_twist_covariance();
+  EXPECT_DOUBLE_EQ(twist_before.twist.linear.x, 0.0);
+  EXPECT_DOUBLE_EQ(twist_before.twist.angular.z, 0.0);
 
   EKFDiagnosticInfo diag;
   const bool ok = module_->measurement_update_twist(twist, t_curr, diag);
@@ -416,6 +465,17 @@ TEST_F(MeasurementUpdateTwist, AcceptsValidMeasurement)
   EXPECT_TRUE(ok);
   EXPECT_TRUE(diag.is_passed_delay_gate);
   EXPECT_TRUE(diag.is_passed_mahalanobis_gate);
+
+  // Postcondition: the velocity estimate is blended toward the measurement, not snapped to it.
+  const auto twist_after = module_->get_current_twist(t_curr);
+  EXPECT_GT(twist_after.twist.linear.x, 0.0);
+  EXPECT_LT(twist_after.twist.linear.x, 3.0);
+  EXPECT_GT(twist_after.twist.angular.z, 0.0);
+  EXPECT_LT(twist_after.twist.angular.z, 1.0);
+
+  // Postcondition: the velocity covariance (vx maps to twist covariance X_X) is reduced.
+  const auto cov_after = module_->get_current_twist_covariance();
+  EXPECT_LT(cov_after[COV_IDX::X_X], cov_before[COV_IDX::X_X]);
 }
 
 TEST_F(MeasurementUpdateTwist, RejectsOnDelayGate)


### PR DESCRIPTION
**Review-only PR — do not merge via GitHub.**

Shows the single spec-v2 test-quality fix commit applied on top of `test/autoware_ekf_localizer`, which is the head of:
- upstream PR autowarefoundation/autoware_core#1098
- fork PR youtalk/autoware_core#11 (same branch)

The diff here is exactly that one additional commit (base = `test/autoware_ekf_localizer`). After approval the commit will be pushed directly onto `test/autoware_ekf_localizer` (fast-forward, no rebase/amend — a clean additional commit), updating both the fork and upstream PRs; this `review/autoware_ekf_localizer` branch is then deleted. Merging via GitHub would add a merge commit, so don't.

**Fix:** Guard the empty delay-time table in find_closest_delay_time_index() against a .back() UB (extend_state_step==0), with a RED test (segfaults without the guard) and strengthened accept-path postcondition asserts.
