### PR TITLE
test(autoware_osqp_interface): restore status-message seam and pin unsolved/empty branches

### DIFF
--- a/common/autoware_osqp_interface/include/autoware/osqp_interface/osqp_interface.hpp
+++ b/common/autoware_osqp_interface/include/autoware/osqp_interface/osqp_interface.hpp
@@ -24,13 +24,29 @@
 
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <vector>
 
 namespace autoware::osqp_interface
 {
 constexpr c_float INF = 1e30;
+
+namespace detail
+{
+/// \brief Build the warning message emitted when an optimization problem is not solved.
+/// \details Pure, ROS-free core of OSQPInterface::logUnsolvedStatus. Returns std::nullopt when the
+/// problem was solved (status == 1), in which case no warning should be logged. Otherwise returns
+/// the message, optionally prefixed by `prefix` followed by a single space.
+/// \param status Solver status value (1 == solved).
+/// \param status_message Human-readable solver status string (from OSQPInfo::status).
+/// \param prefix Optional prefix prepended to the message; empty means no prefix.
+/// \return The message to log, or std::nullopt when there is nothing to log.
+OSQP_INTERFACE_PUBLIC std::optional<std::string> build_unsolved_status_message(
+  int64_t status, std::string_view status_message, std::string_view prefix);
+}  // namespace detail
 
 struct OSQPResult
 {

--- a/common/autoware_osqp_interface/src/osqp_interface.cpp
+++ b/common/autoware_osqp_interface/src/osqp_interface.cpp
@@ -21,7 +21,9 @@
 #include <iostream>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <vector>
 
@@ -414,24 +416,37 @@ OSQPResult OSQPInterface::optimize(
   return result;
 }
 
-void OSQPInterface::logUnsolvedStatus(const std::string & prefix_message) const
+namespace detail
 {
-  const int status = static_cast<int>(getStatus());
+std::optional<std::string> build_unsolved_status_message(
+  const int64_t status, const std::string_view status_message, const std::string_view prefix)
+{
   if (status == 1) {
     // No need to log since optimization was solved.
-    return;
+    return std::nullopt;
   }
 
   // create message
-  std::string output_message = "";
-  if (prefix_message != "") {
-    output_message = prefix_message + " ";
+  std::string output_message;
+  if (!prefix.empty()) {
+    output_message = std::string{prefix} + " ";
   }
 
-  const auto status_message = getStatusMessage();
-  output_message += "Optimization failed due to " + status_message;
+  output_message += "Optimization failed due to " + std::string{status_message};
+
+  return output_message;
+}
+}  // namespace detail
+
+void OSQPInterface::logUnsolvedStatus(const std::string & prefix_message) const
+{
+  const auto output_message =
+    detail::build_unsolved_status_message(getStatus(), getStatusMessage(), prefix_message);
+  if (!output_message) {
+    return;
+  }
 
   // log with warning
-  RCLCPP_WARN(rclcpp::get_logger("osqp_interface"), "%s", output_message.c_str());
+  RCLCPP_WARN(rclcpp::get_logger("osqp_interface"), "%s", output_message->c_str());
 }
 }  // namespace autoware::osqp_interface

--- a/common/autoware_osqp_interface/test/test_csc_matrix_conv.cpp
+++ b/common/autoware_osqp_interface/test/test_csc_matrix_conv.cpp
@@ -205,6 +205,41 @@ TEST(TestCscMatrixConv, NearZeroPruning)
   EXPECT_EQ(square_csc.m_col_idxs[1], c_int(0));
   EXPECT_EQ(square_csc.m_col_idxs[2], c_int(1));
 }
+TEST(TestCscMatrixConv, EmptyMatrix)
+{
+  using autoware::osqp_interface::calCSCMatrix;
+  using autoware::osqp_interface::calCSCMatrixTrapezoidal;
+  using autoware::osqp_interface::CSC_Matrix;
+
+  // 0x0 matrix: the column loop never runs, so vals/row_idxs stay empty and only the leading
+  // col_idxs sentinel {0} remains.
+  {
+    const CSC_Matrix csc = calCSCMatrix(Eigen::MatrixXd(0, 0));
+    EXPECT_TRUE(csc.m_vals.empty());
+    EXPECT_TRUE(csc.m_row_idxs.empty());
+    ASSERT_EQ(csc.m_col_idxs.size(), size_t(1));
+    EXPECT_EQ(csc.m_col_idxs[0], c_int(0));
+  }
+
+  // Zero-column matrix with non-zero rows: still no columns to iterate, same postcondition.
+  {
+    const CSC_Matrix csc = calCSCMatrix(Eigen::MatrixXd(3, 0));
+    EXPECT_TRUE(csc.m_vals.empty());
+    EXPECT_TRUE(csc.m_row_idxs.empty());
+    ASSERT_EQ(csc.m_col_idxs.size(), size_t(1));
+    EXPECT_EQ(csc.m_col_idxs[0], c_int(0));
+  }
+
+  // 0x0 square matrix through the trapezoidal path: square check passes (0 == 0) and the column
+  // loop never runs.
+  {
+    const CSC_Matrix csc = calCSCMatrixTrapezoidal(Eigen::MatrixXd(0, 0));
+    EXPECT_TRUE(csc.m_vals.empty());
+    EXPECT_TRUE(csc.m_row_idxs.empty());
+    ASSERT_EQ(csc.m_col_idxs.size(), size_t(1));
+    EXPECT_EQ(csc.m_col_idxs[0], c_int(0));
+  }
+}
 TEST(TestCscMatrixConv, Print)
 {
   using autoware::osqp_interface::calCSCMatrix;

--- a/common/autoware_osqp_interface/test/test_osqp_interface.cpp
+++ b/common/autoware_osqp_interface/test/test_osqp_interface.cpp
@@ -17,9 +17,13 @@
 
 #include <Eigen/Core>
 
+#include <cstdint>
 #include <iostream>
+#include <limits>
+#include <optional>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <vector>
 
@@ -276,5 +280,41 @@ TEST(TestOsqpInterface, LogUnsolvedStatusSolvedIsNoThrow)
   ASSERT_EQ(osqp.getStatus(), 1);  // solved
   EXPECT_NO_THROW(osqp.logUnsolvedStatus());
   EXPECT_NO_THROW(osqp.logUnsolvedStatus("prefix"));
+}
+
+// Pure ROS-free core of logUnsolvedStatus. Asserted by structure/value only:
+//   - solved (status == 1) yields no message (std::nullopt);
+//   - any non-solved status yields a message (has_value());
+//   - a non-empty prefix is structurally present in the produced message, while an empty prefix is
+//     not prepended.
+TEST(TestOsqpInterface, BuildUnsolvedStatusMessage)
+{
+  using autoware::osqp_interface::detail::build_unsolved_status_message;
+
+  // Solved => nothing to log.
+  EXPECT_FALSE(build_unsolved_status_message(1, "solved", "").has_value());
+  EXPECT_FALSE(build_unsolved_status_message(1, "solved", "prefix").has_value());
+
+  // Unsolved without prefix => a message is produced and the prefix token is absent.
+  {
+    const auto msg = build_unsolved_status_message(-3, "primal infeasible", "");
+    ASSERT_TRUE(msg.has_value());
+    EXPECT_EQ(msg->find("prefix"), std::string::npos);
+  }
+
+  // Unsolved with prefix => a message is produced and the prefix is structurally present.
+  {
+    const auto msg = build_unsolved_status_message(-3, "primal infeasible", "prefix");
+    ASSERT_TRUE(msg.has_value());
+    EXPECT_NE(msg->find("prefix"), std::string::npos);
+  }
+
+  // Degenerate / boundary statuses other than the solved sentinel must still yield a message.
+  EXPECT_TRUE(build_unsolved_status_message(0, "", "").has_value());
+  EXPECT_TRUE(build_unsolved_status_message(2, "solved inaccurate", "").has_value());
+  EXPECT_TRUE(
+    build_unsolved_status_message(std::numeric_limits<int64_t>::max(), "", "").has_value());
+  EXPECT_TRUE(
+    build_unsolved_status_message(std::numeric_limits<int64_t>::min(), "", "").has_value());
 }
 }  // namespace


### PR DESCRIPTION
**Review-only PR — do not merge via GitHub.**

Shows the single spec-v2 test-quality fix commit applied on top of `test/autoware_osqp_interface`, which is the head of:
- upstream PR autowarefoundation/autoware_core#1110
- fork PR youtalk/autoware_core#19 (same branch)

The diff here is exactly that one additional commit (base = `test/autoware_osqp_interface`). After approval the commit will be pushed directly onto `test/autoware_osqp_interface` (fast-forward, no rebase/amend — a clean additional commit), updating both the fork and upstream PRs; this `review/autoware_osqp_interface` branch is then deleted. Merging via GitHub would add a merge commit, so don't.

**Fix:** Re-extract detail::build_unsolved_status_message returning std::optional<std::string> (asserted by structure/value, not human-string), route logUnsolvedStatus through it, and add a 0x0/zero-column CSC matrix boundary test.
