### PR TITLE
test(autoware_motion_velocity_planner_common): pin empty-input degenerates and guard get_extended_trajectory_points

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/utils.cpp
@@ -80,6 +80,12 @@ std::vector<TrajectoryPoint> get_extended_trajectory_points(
     return output_points;
   }
 
+  // Guard against dereferencing back() on an empty trajectory: there is no goal point to extend
+  // from, so return the (empty) input unchanged.
+  if (input_points.empty()) {
+    return output_points;
+  }
+
   const auto goal_point = input_points.back();
   for (double extend_sum = step_length; extend_sum < extend_distance - step_length;
        extend_sum += step_length) {

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/test/test_utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/test/test_utils.cpp
@@ -285,6 +285,16 @@ TEST(MvpUtilsExtend, OnlyFinalPointWhenStepLargerThanDistance)
   EXPECT_NEAR(result.back().pose.position.x, 2.0 + extend_distance, 1e-6);  // x = 3.0
 }
 
+TEST(MvpUtilsExtend, EmptyInputReturnsEmptyWithoutDereferencingBack)
+{
+  // Degenerate case: an empty trajectory has no goal point to extend from. With an
+  // extend_distance >= min_step_length (0.1) the short-distance early return is skipped, so the
+  // empty guard must prevent the back() dereference and return the input unchanged.
+  const std::vector<TrajectoryPoint> empty_points;
+  const auto result = get_extended_trajectory_points(empty_points, 5.0, 2.0);
+  EXPECT_TRUE(result.empty());
+}
+
 // ----------------------------- calc_distance_to_front_object -----------------------------------
 
 TEST(MvpUtilsFrontObject, ReturnsArcLengthForObjectAhead)
@@ -303,6 +313,15 @@ TEST(MvpUtilsFrontObject, ReturnsNulloptForObjectBehind)
   // ego at index 3 (x = 3), obstacle behind at x = 0.2 (nearest index 0) -> negative arc length.
   const auto dist = calc_distance_to_front_object(points, 3, make_point(0.2, 0.0));
   EXPECT_FALSE(dist.has_value());
+}
+
+TEST(MvpUtilsFrontObject, EmptyTrajectoryThrows)
+{
+  // Precondition violation: findNearestIndex validates a non-empty trajectory and throws on an
+  // empty one. Pin that the precondition is enforced rather than silently producing a result.
+  const std::vector<TrajectoryPoint> empty_points;
+  EXPECT_THROW(
+    calc_distance_to_front_object(empty_points, 0, make_point(1.0, 0.0)), std::invalid_argument);
 }
 
 // ----------------------------- concat_vectors --------------------------------------------------


### PR DESCRIPTION
**Review-only PR — do not merge via GitHub.**

Shows the single spec-v2 test-quality fix commit applied on top of `test/autoware_motion_velocity_planner_common`, which is the head of:
- upstream PR autowarefoundation/autoware_core#1116
- fork PR youtalk/autoware_core#25 (same branch)

The diff here is exactly that one additional commit (base = `test/autoware_motion_velocity_planner_common`). After approval the commit will be pushed directly onto `test/autoware_motion_velocity_planner_common` (fast-forward, no rebase/amend — a clean additional commit), updating both the fork and upstream PRs; this `review/autoware_motion_velocity_planner_common` branch is then deleted. Merging via GitHub would add a merge commit, so don't.

**Fix:** Guard get_extended_trajectory_points() empty input against a .back() UB with a RED test, and add EXPECT_THROW for calc_distance_to_front_object on an empty trajectory.
