### PR TITLE
test(autoware_euclidean_cluster_object_detector): pin empty-cloud input on implemented voxel cluster overload

### DIFF
--- a/perception/autoware_euclidean_cluster_object_detector/test/test_voxel_grid_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster_object_detector/test/test_voxel_grid_based_euclidean_cluster.cpp
@@ -323,6 +323,38 @@ TEST(VoxelGridBasedEuclideanClusterTest, ClusterOutputMatchesObjects)
   EXPECT_LE(position.y, 0.3);
 }
 
+// Characterization test for the previously-untested empty-input path of the implemented
+// `cluster(pointcloud_msg, objects, clusters)` overload. An empty cloud (fields and point_step
+// set, no data, width 0) must flow through fromROSMsg -> voxel filter -> KdTree -> extraction
+// without crashing and pin the degenerate-input contract: the call returns true and produces no
+// objects and no clusters.
+TEST(VoxelGridBasedEuclideanClusterTest, ClusterEmptyInput)
+{
+  sensor_msgs::msg::PointCloud2 pointcloud;
+  setPointCloud2Fields(pointcloud);
+  pointcloud.data.clear();
+  pointcloud.width = 0;
+  pointcloud.row_step = 0;
+
+  const sensor_msgs::msg::PointCloud2::ConstSharedPtr pointcloud_msg =
+    std::make_shared<sensor_msgs::msg::PointCloud2>(pointcloud);
+  autoware_perception_msgs::msg::DetectedObjects objects;
+  float tolerance = 0.7;
+  float voxel_leaf_size = 0.3;
+  int min_points_number_per_voxel = 1;
+  int min_cluster_size = 1;
+  int max_cluster_size = 100;
+  bool use_height = false;
+  auto cluster_ = std::make_shared<autoware::euclidean_cluster::VoxelGridBasedEuclideanCluster>(
+    use_height, min_cluster_size, max_cluster_size, tolerance, voxel_leaf_size,
+    min_points_number_per_voxel);
+
+  std::vector<pcl::PointCloud<pcl::PointXYZ>> clusters;
+  EXPECT_TRUE(cluster_->cluster(pointcloud_msg, objects, clusters));
+  EXPECT_EQ(objects.objects.size(), 0u);
+  EXPECT_EQ(clusters.size(), 0u);
+}
+
 // Test exceeding max_cluster_size case
 TEST(VoxelGridBasedEuclideanClusterTest, ExceedMaxClusterSize)
 {


### PR DESCRIPTION
**Review-only PR — do not merge via GitHub.**

Shows the single spec-v2 test-quality fix commit applied on top of `perf/autoware_euclidean_cluster_object_detector`, which is the head of:
- upstream PR autowarefoundation/autoware_core#1124
- fork PR youtalk/autoware_core#29 (same branch)

The diff here is exactly that one additional commit (base = `perf/autoware_euclidean_cluster_object_detector`). After approval the commit will be pushed directly onto `perf/autoware_euclidean_cluster_object_detector` (fast-forward, no rebase/amend — a clean additional commit), updating both the fork and upstream PRs; this `review/autoware_euclidean_cluster_object_detector` branch is then deleted. Merging via GitHub would add a merge commit, so don't.

**Fix:** Add an empty-point-cloud characterization test on the implemented 3-arg voxel cluster() overload (PCL handles it gracefully: returns true with empty outputs, so no guard needed).
