### PR TITLE
test(autoware_ground_filter): pin negative-Y-axis kept-point fix and radial-limit boundary

### DIFF
--- a/perception/autoware_ground_filter/src/grid.hpp
+++ b/perception/autoware_ground_filter/src/grid.hpp
@@ -206,6 +206,10 @@ public:
     const float x_fixed = x - origin_x_;
     const float y_fixed = y - origin_y_;
     const float radius = std::sqrt(x_fixed * x_fixed + y_fixed * y_fixed);
+    // A point exactly on the origin's negative-Y axis (x_fixed == 0, y_fixed < 0)
+    // now yields azimuth 3*pi/2 and is kept. Previously pseudoArcTan2 returned
+    // -pi/2 for this axis, which getGridIdx() rejected as out-of-range, dropping
+    // the point below.
     const float azimuth = detail::pseudoArcTan2(y_fixed, x_fixed);
 
     // calculate the grid id

--- a/perception/autoware_ground_filter/test/test_grid.cpp
+++ b/perception/autoware_ground_filter/test/test_grid.cpp
@@ -160,6 +160,15 @@ TEST_F(GridTest, RadialIdxOutOfRange)
   // Far beyond the configured radial limit (200 m) -> invalid.
   EXPECT_EQ(getRadialIdx(1.0e4f), -1);
 
+  // Exactly at the configured radial limit (grid_radial_limit_ == 200 m): the
+  // limit is exclusive (radius < grid_radial_limit_ in both branches), so the
+  // boundary value falls through to -1 just like out-of-range radii.
+  EXPECT_EQ(getRadialIdx(200.0f), -1);
+
+  // Just below the limit -> valid (non-negative) index, pinning the open
+  // boundary on the in-range side.
+  EXPECT_GE(getRadialIdx(199.9f), 0);
+
   // Within the constant-distance region radial index is floor(radius / size).
   EXPECT_EQ(getRadialIdx(0.0f), 0);
   EXPECT_EQ(getRadialIdx(0.4f), 0);  // < grid_dist_size (0.5)
@@ -209,6 +218,50 @@ TEST_F(GridTest, GridIdxFromRadiusAzimuth)
   // reset to bin 0 by the loop-back clause. This exercises the
   // (azimuth_grid_idx == azimuth_grid_num) reset, not just the trivial bin-0 case.
   EXPECT_EQ(getAzimuthGridIdx(0, 2.0f * M_PIf), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Grid::addPoint on the origin's negative-Y axis: this is the external
+// postcondition of the pseudoArcTan2 negative-Y-axis fix. A point with
+// x_fixed == 0 and y_fixed < 0 yields azimuth 3*pi/2 (was -pi/2), so it now
+// bins into a valid cell and is KEPT.
+//
+// Prior behavior (regression guard): pseudoArcTan2 returned -pi/2 for this axis,
+// the only negative azimuth the function produced. getAzimuthGridIdx floored it
+// into a negative bin, getGridIdx returned -1, and addPoint DROPPED the point
+// (the destination cell stayed empty). This test pins that the point is now
+// retained in a non-empty cell.
+// ---------------------------------------------------------------------------
+TEST_F(GridTest, AddPointOnNegativeYAxisIsKept)
+{
+  // Point exactly on the origin's negative-Y axis: x == origin_x_ (x_fixed == 0)
+  // and y < origin_y_ (y_fixed < 0). radius == 5 m is inside the switch radius.
+  const float x = kOriginX;
+  const float y = kOriginY - 5.0f;
+  const float z = 0.0f;
+  const size_t point_idx = 7;
+
+  const float x_fixed = x - kOriginX;
+  const float y_fixed = y - kOriginY;
+  const float radius = std::sqrt(x_fixed * x_fixed + y_fixed * y_fixed);
+  const float azimuth = detail::pseudoArcTan2(y_fixed, x_fixed);
+
+  // Sanity: this branch is the negative-Y axis with the fixed [0, 2*pi) value.
+  ASSERT_FLOAT_EQ(x_fixed, 0.0f);
+  EXPECT_FLOAT_EQ(azimuth, 3.0f * M_PI_2f);
+
+  // The destination cell index is valid (>= 0); under the old -pi/2 value this
+  // would have been -1 and the point dropped.
+  const int grid_idx = getGridIdx(radius, azimuth);
+  ASSERT_GE(grid_idx, 0);
+
+  // Adding the point lands it in that cell, which becomes non-empty.
+  grid_->addPoint(x, y, z, point_idx);
+
+  auto & cell = grid_->getCell(grid_idx);
+  EXPECT_FALSE(cell.isEmpty());
+  ASSERT_EQ(cell.point_list_.size(), 1u);
+  EXPECT_EQ(cell.point_list_.front().index, point_idx);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
**Review-only PR — do not merge via GitHub.**

Shows the single spec-v2 test-quality fix commit applied on top of `refactor/autoware_ground_filter`, which is the head of:
- upstream PR autowarefoundation/autoware_core#1125
- fork PR youtalk/autoware_core#30 (same branch)

The diff here is exactly that one additional commit (base = `refactor/autoware_ground_filter`). After approval the commit will be pushed directly onto `refactor/autoware_ground_filter` (fast-forward, no rebase/amend — a clean additional commit), updating both the fork and upstream PRs; this `review/autoware_ground_filter` branch is then deleted. Merging via GitHub would add a merge commit, so don't.

**Fix:** Keep the negative-Y-axis kept-point fix (pseudoArcTan2 x==0,y<0) and pin it with a RED-verified Grid::addPoint test plus the exact radial-limit boundary. NOTE: this makes the change a behavior fix -> the upstream PR should be relabeled test -> fix and its body updated (held for approval).
