### PR TITLE
test(autoware_object_recognition_utils): cover feature-object transform via Core-local stand-in type

### DIFF
--- a/common/autoware_object_recognition_utils/test/src/test_transform.cpp
+++ b/common/autoware_object_recognition_utils/test/src/test_transform.cpp
@@ -14,19 +14,26 @@
 
 #include "autoware/object_recognition_utils/transform.hpp"
 
+#include <Eigen/Core>
 #include <rclcpp/clock.hpp>
 
 #include <autoware_perception_msgs/msg/detected_object.hpp>
 #include <autoware_perception_msgs/msg/detected_objects.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <std_msgs/msg/header.hpp>
 
 #include <gtest/gtest.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <pcl_conversions/pcl_conversions.h>
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2_ros/buffer.h>
 
 #include <cmath>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace
 {
@@ -57,6 +64,62 @@ tf2::Transform makeTransform(const double x, const double y, const double z, con
   t.setOrigin(tf2::Vector3(x, y, z));
   t.setRotation(q);
   return t;
+}
+
+// The concrete feature-object wire type (tier4_perception_msgs::msg::DetectedObjectsWithFeature)
+// lives outside Autoware Core, so it cannot be a Core dependency. However,
+// transformObjectsWithFeature / detail::applyTransformToFeatureObjects are duck-typed function
+// templates: they only touch msg.header, msg.feature_objects[].object.kinematics
+// .pose_with_covariance.pose and msg.feature_objects[].feature.cluster (a PointCloud2). We can
+// therefore exercise the feature path by instantiating the templates against a Core-local stand-in
+// type that mirrors exactly those member-access paths, built from Core-available message types.
+struct FeatureObjectStandIn
+{
+  autoware_perception_msgs::msg::DetectedObject object;
+  struct Feature
+  {
+    sensor_msgs::msg::PointCloud2 cluster;
+  } feature;
+};
+
+struct ObjectsWithFeatureStandIn
+{
+  std_msgs::msg::Header header;
+  std::vector<FeatureObjectStandIn> feature_objects;
+};
+
+// Build a single-point cluster cloud at (px, py, pz) with the given source frame.
+sensor_msgs::msg::PointCloud2 createCluster(
+  const double px, const double py, const double pz, const std::string & frame_id)
+{
+  pcl::PointCloud<pcl::PointXYZ> cloud;
+  cloud.push_back(pcl::PointXYZ(px, py, pz));
+  sensor_msgs::msg::PointCloud2 msg;
+  pcl::toROSMsg(cloud, msg);
+  msg.header.frame_id = frame_id;
+  return msg;
+}
+
+// Build a feature object whose object pose is at (x, y, z, yaw) and whose cluster holds a single
+// point at (px, py, pz).
+FeatureObjectStandIn createFeatureObject(
+  const double x, const double y, const double z, const double yaw, const double px,
+  const double py, const double pz)
+{
+  FeatureObjectStandIn feature_object;
+  feature_object.object = createObject(x, y, z, yaw);
+  feature_object.feature.cluster = createCluster(px, py, pz, "sensor");
+  return feature_object;
+}
+
+// A pure-translation Eigen 4x4 transform matrix (matching makeTransform's translation component).
+Eigen::Matrix4f makeTranslationMatrix(const float x, const float y, const float z)
+{
+  Eigen::Matrix4f mat = Eigen::Matrix4f::Identity();
+  mat(0, 3) = x;
+  mat(1, 3) = y;
+  mat(2, 3) = z;
+  return mat;
 }
 }  // namespace
 
@@ -192,4 +255,205 @@ TEST(transform, transformObjectsAppliesBufferedTransform)
   EXPECT_NEAR(pose.position.x, 11.0, 1e-9);
   EXPECT_NEAR(pose.position.y, 22.0, 1e-9);
   EXPECT_NEAR(pose.position.z, 0.0, 1e-9);
+}
+
+// applyTransformToObjects on an empty objects vector must rewrite the header frame and produce an
+// empty output without throwing (empty-container degenerate case).
+TEST(transform, applyTransformToObjectsEmptyObjects)
+{
+  using autoware::object_recognition_utils::detail::applyTransformToObjects;
+
+  autoware_perception_msgs::msg::DetectedObjects input;
+  input.header.frame_id = "sensor";
+
+  const auto tf_target2world = makeTransform(10.0, 20.0, 0.0, 0.0);
+
+  autoware_perception_msgs::msg::DetectedObjects output;
+  applyTransformToObjects(input, "map", tf_target2world, output);
+
+  EXPECT_EQ(output.header.frame_id, "map");
+  EXPECT_TRUE(output.objects.empty());
+}
+
+// applyTransformToFeatureObjects must compose a pure translation onto the feature object's pose and
+// rewrite both the message header frame and the per-cluster header frame to the target frame.
+TEST(transform, applyTransformToFeatureObjectsTranslationOnly)
+{
+  using autoware::object_recognition_utils::detail::applyTransformToFeatureObjects;
+
+  ObjectsWithFeatureStandIn input;
+  input.header.frame_id = "sensor";
+  input.feature_objects.push_back(createFeatureObject(1.0, 2.0, 0.0, 0.0, 0.5, 0.5, 0.0));
+
+  const auto tf_target2world = makeTransform(10.0, 20.0, 0.0, 0.0);
+  const auto tf_matrix = makeTranslationMatrix(10.0F, 20.0F, 0.0F);
+
+  ObjectsWithFeatureStandIn output;
+  applyTransformToFeatureObjects(input, "map", tf_target2world, tf_matrix, output);
+
+  ASSERT_EQ(output.feature_objects.size(), 1U);
+  EXPECT_EQ(output.header.frame_id, "map");
+
+  // object pose is composed with the world transform: (1,2) + (10,20) = (11,22)
+  const auto & pose = output.feature_objects.at(0).object.kinematics.pose_with_covariance.pose;
+  EXPECT_NEAR(pose.position.x, 11.0, 1e-6);
+  EXPECT_NEAR(pose.position.y, 22.0, 1e-6);
+  EXPECT_NEAR(pose.position.z, 0.0, 1e-6);
+  EXPECT_NEAR(pose.orientation.z, 0.0, 1e-6);
+  EXPECT_NEAR(pose.orientation.w, 1.0, 1e-6);
+
+  // cluster header frame is rewritten to the target frame (computed contract value)
+  const auto & cluster = output.feature_objects.at(0).feature.cluster;
+  EXPECT_EQ(cluster.header.frame_id, "map");
+
+  // the single cluster point is translated by tf_matrix: (0.5,0.5) + (10,20) = (10.5,20.5)
+  ASSERT_EQ(cluster.width * cluster.height, 1U);
+  pcl::PointCloud<pcl::PointXYZ> transformed_points;
+  pcl::fromROSMsg(cluster, transformed_points);
+  ASSERT_EQ(transformed_points.size(), 1U);
+  EXPECT_NEAR(transformed_points.at(0).x, 10.5, 1e-5);
+  EXPECT_NEAR(transformed_points.at(0).y, 20.5, 1e-5);
+  EXPECT_NEAR(transformed_points.at(0).z, 0.0, 1e-5);
+}
+
+// applyTransformToFeatureObjects on an empty feature_objects vector must rewrite the header frame
+// and produce an empty output without throwing (empty-container degenerate case).
+TEST(transform, applyTransformToFeatureObjectsEmptyFeatureObjects)
+{
+  using autoware::object_recognition_utils::detail::applyTransformToFeatureObjects;
+
+  ObjectsWithFeatureStandIn input;
+  input.header.frame_id = "sensor";
+
+  const auto tf_target2world = makeTransform(10.0, 20.0, 0.0, 0.0);
+  const auto tf_matrix = makeTranslationMatrix(10.0F, 20.0F, 0.0F);
+
+  ObjectsWithFeatureStandIn output;
+  applyTransformToFeatureObjects(input, "map", tf_target2world, tf_matrix, output);
+
+  EXPECT_EQ(output.header.frame_id, "map");
+  EXPECT_TRUE(output.feature_objects.empty());
+}
+
+// applyTransformToFeatureObjects must tolerate a feature object whose cluster has zero points: the
+// pose is still composed and the (empty) cluster header is rewritten to the target frame.
+TEST(transform, applyTransformToFeatureObjectsEmptyCluster)
+{
+  using autoware::object_recognition_utils::detail::applyTransformToFeatureObjects;
+
+  ObjectsWithFeatureStandIn input;
+  input.header.frame_id = "sensor";
+  FeatureObjectStandIn feature_object;
+  feature_object.object = createObject(1.0, 2.0, 0.0, 0.0);
+  feature_object.feature.cluster.header.frame_id = "sensor";  // no points
+  input.feature_objects.push_back(feature_object);
+
+  const auto tf_target2world = makeTransform(10.0, 20.0, 0.0, 0.0);
+  const auto tf_matrix = makeTranslationMatrix(10.0F, 20.0F, 0.0F);
+
+  ObjectsWithFeatureStandIn output;
+  applyTransformToFeatureObjects(input, "map", tf_target2world, tf_matrix, output);
+
+  ASSERT_EQ(output.feature_objects.size(), 1U);
+  EXPECT_EQ(output.header.frame_id, "map");
+  const auto & pose = output.feature_objects.at(0).object.kinematics.pose_with_covariance.pose;
+  EXPECT_NEAR(pose.position.x, 11.0, 1e-6);
+  EXPECT_NEAR(pose.position.y, 22.0, 1e-6);
+
+  const auto & cluster = output.feature_objects.at(0).feature.cluster;
+  EXPECT_EQ(cluster.header.frame_id, "map");
+  EXPECT_EQ(cluster.width * cluster.height, 0U);
+}
+
+// transformObjectsWithFeature wired through a live buffer with a known static transform must
+// compose the object pose and rewrite each cluster header to the target frame, reporting success.
+TEST(transform, transformObjectsWithFeatureAppliesBufferedTransform)
+{
+  using autoware::object_recognition_utils::transformObjectsWithFeature;
+
+  // Static transform: target("map") <- source("sensor") = translate (10, 20, 0)
+  geometry_msgs::msg::TransformStamped tf_stamped;
+  tf_stamped.header.frame_id = "map";
+  tf_stamped.child_frame_id = "sensor";
+  tf_stamped.transform.translation.x = 10.0;
+  tf_stamped.transform.translation.y = 20.0;
+  tf_stamped.transform.translation.z = 0.0;
+  tf_stamped.transform.rotation.w = 1.0;
+
+  tf2_ros::Buffer buffer{std::make_shared<rclcpp::Clock>(RCL_ROS_TIME)};
+  buffer.setTransform(tf_stamped, "test_authority", true);
+
+  ObjectsWithFeatureStandIn input;
+  input.header.frame_id = "sensor";
+  input.feature_objects.push_back(createFeatureObject(1.0, 2.0, 0.0, 0.0, 0.5, 0.5, 0.0));
+
+  ObjectsWithFeatureStandIn output;
+  ASSERT_TRUE(transformObjectsWithFeature(input, "map", buffer, output));
+  ASSERT_EQ(output.feature_objects.size(), 1U);
+  EXPECT_EQ(output.header.frame_id, "map");
+  const auto & pose = output.feature_objects.at(0).object.kinematics.pose_with_covariance.pose;
+  // object pose is composed with the buffered world transform: (1,2) + (10,20) = (11,22)
+  EXPECT_NEAR(pose.position.x, 11.0, 1e-6);
+  EXPECT_NEAR(pose.position.y, 22.0, 1e-6);
+  // cluster header frame is rewritten to the target frame
+  const auto & cluster = output.feature_objects.at(0).feature.cluster;
+  EXPECT_EQ(cluster.header.frame_id, "map");
+  // the single cluster point is translated by the buffered transform: (0.5,0.5) + (10,20) =
+  // (10.5,20.5)
+  ASSERT_EQ(cluster.width * cluster.height, 1U);
+  pcl::PointCloud<pcl::PointXYZ> transformed_points;
+  pcl::fromROSMsg(cluster, transformed_points);
+  ASSERT_EQ(transformed_points.size(), 1U);
+  EXPECT_NEAR(transformed_points.at(0).x, 10.5, 1e-5);
+  EXPECT_NEAR(transformed_points.at(0).y, 20.5, 1e-5);
+  EXPECT_NEAR(transformed_points.at(0).z, 0.0, 1e-5);
+}
+
+// transformObjectsWithFeature must pass the message through unchanged when the input frame already
+// equals the target frame (identity passthrough branch) and report success.
+TEST(transform, transformObjectsWithFeatureIdentityPassthrough)
+{
+  using autoware::object_recognition_utils::transformObjectsWithFeature;
+
+  ObjectsWithFeatureStandIn input;
+  input.header.frame_id = "map";
+  input.feature_objects.push_back(createFeatureObject(1.0, 2.0, 3.0, 0.0, 0.5, 0.5, 0.0));
+
+  tf2_ros::Buffer empty_buffer{std::make_shared<rclcpp::Clock>(RCL_ROS_TIME)};
+  ObjectsWithFeatureStandIn output;
+
+  // Same frame: no lookup needed, so the (empty) buffer is never queried.
+  EXPECT_TRUE(transformObjectsWithFeature(input, "map", empty_buffer, output));
+  ASSERT_EQ(output.feature_objects.size(), 1U);
+  EXPECT_EQ(output.header.frame_id, "map");
+  const auto & pose = output.feature_objects.at(0).object.kinematics.pose_with_covariance.pose;
+  EXPECT_DOUBLE_EQ(pose.position.x, 1.0);
+  EXPECT_DOUBLE_EQ(pose.position.y, 2.0);
+  EXPECT_DOUBLE_EQ(pose.position.z, 3.0);
+}
+
+// transformObjectsWithFeature returns false when the buffer cannot resolve the requested transform.
+// Mirrors transformObjectsMissingTransformReturnsFalse for the feature path.
+TEST(transform, transformObjectsWithFeatureMissingTransformReturnsFalse)
+{
+  using autoware::object_recognition_utils::transformObjectsWithFeature;
+
+  ObjectsWithFeatureStandIn input;
+  input.header.frame_id = "sensor";
+  input.feature_objects.push_back(createFeatureObject(1.0, 2.0, 3.0, 0.0, 0.5, 0.5, 0.0));
+
+  tf2_ros::Buffer empty_buffer{std::make_shared<rclcpp::Clock>(RCL_ROS_TIME)};
+  ObjectsWithFeatureStandIn output;
+
+  // Different frame + empty buffer => lookup fails => false.
+  EXPECT_FALSE(transformObjectsWithFeature(input, "map", empty_buffer, output));
+  // Failure-path contract: the target frame is written to the output header before the lookup, so
+  // it stays at the requested target frame on a failed lookup, while the (copied) feature objects
+  // are left untransformed.
+  EXPECT_EQ(output.header.frame_id, "map");
+  ASSERT_EQ(output.feature_objects.size(), 1U);
+  const auto & pose = output.feature_objects.at(0).object.kinematics.pose_with_covariance.pose;
+  EXPECT_DOUBLE_EQ(pose.position.x, 1.0);
+  EXPECT_DOUBLE_EQ(pose.position.y, 2.0);
+  EXPECT_DOUBLE_EQ(pose.position.z, 3.0);
 }


### PR DESCRIPTION
**Review-only PR — do not merge via GitHub.** (Reworked.)

Addresses `interimadd`'s #1129 change-request (the feature-object transform path had no test coverage while the objects path had two layers) **without adding a non-Core dependency**.

Key realization: `applyTransformToFeatureObjects` / `transformObjectsWithFeature` are duck-typed function templates and are never instantiated inside `autoware_core` (the header does not include `tier4_perception_msgs`), which is why the package builds without it. So the feature path is testable in Core by instantiating the templates against a small **Core-local stand-in struct** built from Core-available types (`autoware_perception_msgs::DetectedObject` + `sensor_msgs::PointCloud2`) — no `tier4_perception_msgs`, no `__has_include` gate, no `package.xml` change.

Adds 6 feature-path tests symmetric with the objects path (all run + pass in-container; transform suite 6 → 12):
- `applyTransformToFeatureObjects` direct unit: translation-only pose+cluster transform (independent hand-computed `EXPECT_NEAR` oracles), empty-feature-objects, empty-cluster.
- `transformObjectsWithFeature` e2e through a live `tf2_ros::Buffer`: buffered transform, identity passthrough, and missing-transform-returns-false (failure-path contract).

Diff = exactly one fix commit on top of `refactor/autoware_object_recognition_utils` (upstream PR autowarefoundation/autoware_core#1129, fork PR #34). After approval the commit is pushed fast-forward onto that branch.
