### PR TITLE
test(autoware_signal_processing): guard printDiscreteTimeTF against OOB read

### DIFF
--- a/common/autoware_signal_processing/src/butterworth.cpp
+++ b/common/autoware_signal_processing/src/butterworth.cpp
@@ -309,6 +309,19 @@ void ButterworthFilter::printDiscreteTimeTF() const
 {
   const int & n = filter_specs_.N;
 
+  // The numerator and denominator are sized to (N + 1) only after computeDiscreteTimeTF() has run.
+  // Since this method is public it may be called beforehand, when both still have their default
+  // size, so guard against indexing past the end.
+  if (
+    dt_tf_.discrete_time_numerator_.size() < static_cast<size_t>(n) + 1 ||
+    dt_tf_.discrete_time_denominator_.size() < static_cast<size_t>(n) + 1) {
+    RCLCPP_INFO(
+      rclcpp::get_logger("rclcpp"),
+      "The discrete-time transfer function has not been computed yet. Call "
+      "computeDiscreteTimeTF() first.");
+    return;
+  }
+
   std::stringstream stream;
   stream << "\nThe Discrete Time Transfer Function of the Filter is ;\n";
 

--- a/common/autoware_signal_processing/test/src/butterworth_filter_test.cpp
+++ b/common/autoware_signal_processing/test/src/butterworth_filter_test.cpp
@@ -294,3 +294,13 @@ TEST_F(ButterWorthTestFixture, printContinuousTimeTFBeforeComputeDoesNotOverrun)
   ButterworthFilter bf;
   ASSERT_NO_THROW(bf.printContinuousTimeTF());
 }
+
+TEST_F(ButterWorthTestFixture, printDiscreteTimeTFBeforeComputeDoesNotOverrun)
+{
+  // printDiscreteTimeTF() is public and indexes the numerator/denominator at [N]. Before
+  // computeDiscreteTimeTF() runs, both still have their default size, so it must not read past the
+  // end. The order is left at its default (N = 1), where [N] would otherwise be out of bounds for
+  // the size-1 default numerator/denominator.
+  ButterworthFilter bf;
+  ASSERT_NO_THROW(bf.printDiscreteTimeTF());
+}


### PR DESCRIPTION
**Review-only PR — do not merge via GitHub.**

Shows the single spec-v2 test-quality fix commit applied on top of `test/autoware_signal_processing`, which is the head of:
- upstream PR autowarefoundation/autoware_core#1146
- fork PR youtalk/autoware_core#53 (same branch)

The diff here is exactly that one additional commit (base = `test/autoware_signal_processing`). After approval the commit will be pushed directly onto `test/autoware_signal_processing` (fast-forward, no rebase/amend — a clean additional commit), updating both the fork and upstream PRs; this `review/autoware_signal_processing` branch is then deleted. Merging via GitHub would add a merge commit, so don't.

**Fix:** Guard printDiscreteTimeTF() against the same out-of-bounds read fixed for printContinuousTimeTF(), with a before-compute no-throw test. NOTE: the upstream PR body is stale (describes *AsString() extractions reverted in the prior trim) and a rewrite is proposed (held for approval).
