### PR TITLE
test(autoware_planning_test_manager): extract poseFromCenterline and pin degenerate-centerline branches

### DIFF
--- a/testing/autoware_planning_test_manager/include/autoware/planning_test_manager/autoware_planning_test_manager_utils.hpp
+++ b/testing/autoware_planning_test_manager/include/autoware/planning_test_manager/autoware_planning_test_manager_utils.hpp
@@ -35,14 +35,17 @@ using geometry_msgs::msg::Pose;
 using nav_msgs::msg::Odometry;
 using RouteSections = std::vector<autoware_planning_msgs::msg::LaneletSegment>;
 
-// Compute the mid-lanelet pose for the given lanelet id using an already-loaded RouteHandler.
-// The orientation is derived from the heading between the two central centerline points.
-inline Pose createPoseFromLaneID(const RouteHandler & route_handler, const lanelet::Id & lane_id)
+// Compute the mid-centerline pose for a lanelet centerline. This is the ROS/map-free core of
+// createPoseFromLaneID: it operates purely on the centerline points so every branch (including
+// the degenerate empty / single-point / two-point cases) is unit-testable without a RouteHandler.
+//
+// Postconditions:
+//   - empty centerline      -> zero position with identity orientation (w == 1).
+//   - single-point          -> that point's position with identity orientation (no heading).
+//   - two-point             -> middle point's position; heading from the preceding segment.
+//   - three-or-more points  -> middle point's position; heading from the forward segment.
+inline Pose poseFromCenterline(const lanelet::ConstLineString3d & center_line)
 {
-  // get middle idx of the lanelet
-  const auto lanelet = route_handler.getLaneletsFromId(lane_id);
-  const auto center_line = lanelet.centerline();
-
   geometry_msgs::msg::Pose middle_pose;
   // Pose default-constructs its quaternion to (0,0,0,0), which is invalid; start from identity
   // so degenerate centerlines (empty / single point) still return a valid orientation.
@@ -51,6 +54,7 @@ inline Pose createPoseFromLaneID(const RouteHandler & route_handler, const lanel
     return middle_pose;
   }
 
+  // get middle idx of the lanelet
   const size_t middle_point_idx = static_cast<size_t>(std::floor(center_line.size() / 2.0));
 
   // get middle position of the lanelet
@@ -85,6 +89,14 @@ inline Pose createPoseFromLaneID(const RouteHandler & route_handler, const lanel
   middle_pose.orientation = autoware_utils_geometry::create_quaternion_from_yaw(yaw);
 
   return middle_pose;
+}
+
+// Compute the mid-lanelet pose for the given lanelet id using an already-loaded RouteHandler.
+// The orientation is derived from the heading between the two central centerline points.
+inline Pose createPoseFromLaneID(const RouteHandler & route_handler, const lanelet::Id & lane_id)
+{
+  const auto lanelet = route_handler.getLaneletsFromId(lane_id);
+  return poseFromCenterline(lanelet.centerline());
 }
 
 inline Pose createPoseFromLaneID(

--- a/testing/autoware_planning_test_manager/test/test_planning_test_manager_utils.cpp
+++ b/testing/autoware_planning_test_manager/test/test_planning_test_manager_utils.cpp
@@ -18,8 +18,13 @@
 #include <autoware_test_utils/autoware_test_utils.hpp>
 
 #include <gtest/gtest.h>
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/primitives/LineString.h>
+#include <lanelet2_core/primitives/Point.h>
 
 #include <cmath>
+#include <utility>
+#include <vector>
 
 namespace autoware_planning_test_manager::utils
 {
@@ -30,6 +35,18 @@ namespace
 // by autoware_test_utils::makeBehaviorGoalOnLeftSideRoute().
 constexpr lanelet::Id g_start_lane_id = 9102;
 constexpr lanelet::Id g_goal_lane_id = 112;
+
+// Build an in-process centerline (no map / RouteHandler) from (x, y) pairs so the
+// poseFromCenterline branch logic can be exercised directly.
+lanelet::ConstLineString3d make_centerline(const std::vector<std::pair<double, double>> & xy)
+{
+  std::vector<lanelet::Point3d> points;
+  points.reserve(xy.size());
+  for (const auto & [x, y] : xy) {
+    points.emplace_back(lanelet::utils::getId(), x, y, 0.0);
+  }
+  return lanelet::ConstLineString3d(lanelet::utils::getId(), points);
+}
 }  // namespace
 
 TEST(PlanningTestManagerUtils, CreatePoseFromLaneIdReturnsPoseOnCenterline)
@@ -99,6 +116,63 @@ TEST(PlanningTestManagerUtils, MakeInitialPoseFromLaneIdSetsMapFrame)
   EXPECT_EQ(odometry.header.frame_id, "map");
   EXPECT_NE(odometry.pose.pose.position.x, 0.0);
   EXPECT_NE(odometry.pose.pose.position.y, 0.0);
+}
+
+// --- poseFromCenterline branch coverage (ROS/map-free degenerate-centerline cases) ---
+
+TEST(PlanningTestManagerUtils, PoseFromCenterlineEmptyReturnsIdentity)
+{
+  // empty centerline -> zero position with identity orientation (w == 1)
+  const auto pose = poseFromCenterline(make_centerline({}));
+
+  EXPECT_DOUBLE_EQ(pose.position.x, 0.0);
+  EXPECT_DOUBLE_EQ(pose.position.y, 0.0);
+  EXPECT_DOUBLE_EQ(pose.position.z, 0.0);
+  EXPECT_DOUBLE_EQ(pose.orientation.x, 0.0);
+  EXPECT_DOUBLE_EQ(pose.orientation.y, 0.0);
+  EXPECT_DOUBLE_EQ(pose.orientation.z, 0.0);
+  EXPECT_DOUBLE_EQ(pose.orientation.w, 1.0);
+}
+
+TEST(PlanningTestManagerUtils, PoseFromCenterlineSinglePointKeepsIdentityOrientation)
+{
+  // single point -> that point's position, identity orientation (a point has no heading)
+  const auto pose = poseFromCenterline(make_centerline({{5.0, 7.0}}));
+
+  EXPECT_DOUBLE_EQ(pose.position.x, 5.0);
+  EXPECT_DOUBLE_EQ(pose.position.y, 7.0);
+  EXPECT_DOUBLE_EQ(pose.orientation.x, 0.0);
+  EXPECT_DOUBLE_EQ(pose.orientation.y, 0.0);
+  EXPECT_DOUBLE_EQ(pose.orientation.z, 0.0);
+  EXPECT_DOUBLE_EQ(pose.orientation.w, 1.0);
+}
+
+TEST(PlanningTestManagerUtils, PoseFromCenterlineTwoPointsUsesPrecedingSegmentHeading)
+{
+  // two points -> middle idx is 1 (the last point), so the heading falls back to the
+  // preceding segment (0 -> 1). Segment (0,0) -> (2,2) has yaw = +pi/4.
+  const auto pose = poseFromCenterline(make_centerline({{0.0, 0.0}, {2.0, 2.0}}));
+
+  EXPECT_DOUBLE_EQ(pose.position.x, 2.0);
+  EXPECT_DOUBLE_EQ(pose.position.y, 2.0);
+
+  constexpr double expected_yaw = M_PI_4;
+  EXPECT_NEAR(pose.orientation.z, std::sin(expected_yaw / 2.0), 1e-9);
+  EXPECT_NEAR(pose.orientation.w, std::cos(expected_yaw / 2.0), 1e-9);
+}
+
+TEST(PlanningTestManagerUtils, PoseFromCenterlineMultiPointUsesForwardSegmentHeading)
+{
+  // three points -> middle idx is 1, heading from the forward segment (1 -> 2).
+  // Segment (1,1) -> (1,2) points straight up: yaw = +pi/2.
+  const auto pose = poseFromCenterline(make_centerline({{0.0, 0.0}, {1.0, 1.0}, {1.0, 2.0}}));
+
+  EXPECT_DOUBLE_EQ(pose.position.x, 1.0);
+  EXPECT_DOUBLE_EQ(pose.position.y, 1.0);
+
+  constexpr double expected_yaw = M_PI_2;
+  EXPECT_NEAR(pose.orientation.z, std::sin(expected_yaw / 2.0), 1e-9);
+  EXPECT_NEAR(pose.orientation.w, std::cos(expected_yaw / 2.0), 1e-9);
 }
 
 }  // namespace autoware_planning_test_manager::utils


### PR DESCRIPTION
**Review-only PR — do not merge via GitHub.**

Shows the single spec-v2 test-quality fix commit applied on top of `perf/autoware_planning_test_manager`, which is the head of:
- upstream PR autowarefoundation/autoware_core#1150
- fork PR youtalk/autoware_core#58 (same branch)

The diff here is exactly that one additional commit (base = `perf/autoware_planning_test_manager`). After approval the commit will be pushed directly onto `perf/autoware_planning_test_manager` (fast-forward, no rebase/amend — a clean additional commit), updating both the fork and upstream PRs; this `review/autoware_planning_test_manager` branch is then deleted. Merging via GitHub would add a merge commit, so don't.

**Fix:** Extract a pure ROS/map-free poseFromCenterline() free function and unit-test the degenerate-centerline branches (empty / single-point / two-point / N-point); the OOB-guard behavior is preserved.
