### PR TITLE
refactor(autoware_command_gate): split mode-output and response builders

### DIFF
--- a/control/autoware_command_gate/CMakeLists.txt
+++ b/control/autoware_command_gate/CMakeLists.txt
@@ -34,6 +34,7 @@ if(BUILD_TESTING)
   )
   ament_target_dependencies(test_command_gate_mode_builder
     autoware_adapi_v1_msgs
+    autoware_common_msgs
     autoware_system_msgs
     autoware_vehicle_msgs
     builtin_interfaces

--- a/control/autoware_command_gate/src/autoware_command_gate.cpp
+++ b/control/autoware_command_gate/src/autoware_command_gate.cpp
@@ -20,8 +20,6 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
 
-#include <autoware_adapi_v1_msgs/msg/response_status.hpp>
-#include <autoware_common_msgs/msg/response_status.hpp>
 #include <autoware_vehicle_msgs/msg/gear_command.hpp>
 
 #include <rmw/types.h>
@@ -77,19 +75,11 @@ public:
         const SystemChangeOperationMode::Service::Request::SharedPtr req,
         const SystemChangeOperationMode::Service::Response::SharedPtr res) {
         const builtin_interfaces::msg::Time stamp = now();
-        const auto outputs = CommandGateModeBuilder::dispatch_mode(req->mode, stamp);
-
-        if (!outputs) {
-          res->status.success = false;
-          res->status.code = autoware_common_msgs::msg::ResponseStatus::PARAMETER_ERROR;
-          res->status.message = "Unknown operation mode requested.";
-          return;
+        const auto outputs = CommandGateModeBuilder::create_mode_output(*req, stamp);
+        if (outputs) {
+          publish(*outputs);
         }
-
-        publish(*outputs);
-        res->status.success = true;
-        res->status.code = 0;
-        res->status.message = outputs->status.message;
+        *res = CommandGateModeBuilder::create_response(*req, stamp);
       });
   }
 

--- a/control/autoware_command_gate/src/command_gate_mode_builder.cpp
+++ b/control/autoware_command_gate/src/command_gate_mode_builder.cpp
@@ -14,7 +14,7 @@
 
 #include "command_gate_mode_builder.hpp"
 
-#include <autoware_system_msgs/srv/change_operation_mode.hpp>
+#include <autoware_common_msgs/msg/response_status.hpp>
 
 #include <optional>
 #include <string>
@@ -22,11 +22,49 @@
 namespace autoware::control::command_gate
 {
 
+std::optional<ModeOutputs> CommandGateModeBuilder::create_mode_output(
+  const Request & request, const builtin_interfaces::msg::Time & stamp)
+{
+  return dispatch_mode(request.mode, stamp);
+}
+
+CommandGateModeBuilder::Response CommandGateModeBuilder::create_response(
+  const Request & request, const builtin_interfaces::msg::Time & /*stamp*/)
+{
+  Response response;
+  const auto message = success_message(request.mode);
+  if (!message) {
+    response.status.success = false;
+    response.status.code = autoware_common_msgs::msg::ResponseStatus::PARAMETER_ERROR;
+    response.status.message = "Unknown operation mode requested.";
+    return response;
+  }
+
+  response.status.success = true;
+  response.status.code = 0;  // 0 represents success (no specific success code defined)
+  response.status.message = *message;
+  return response;
+}
+
+std::optional<std::string> CommandGateModeBuilder::success_message(uint16_t mode)
+{
+  switch (mode) {
+    case Request::STOP:
+      return "Switched to STOP";
+    case Request::AUTONOMOUS:
+      return "Switched to AUTONOMOUS";
+    case Request::LOCAL:
+      return "Switched to LOCAL";
+    case Request::REMOTE:
+      return "Switched to REMOTE";
+    default:
+      return std::nullopt;
+  }
+}
+
 std::optional<ModeOutputs> CommandGateModeBuilder::dispatch_mode(
   uint16_t mode, const builtin_interfaces::msg::Time & stamp)
 {
-  using Request = autoware_system_msgs::srv::ChangeOperationMode::Request;
-
   switch (mode) {
     case Request::STOP:
       return make_stop(stamp);
@@ -46,7 +84,6 @@ ModeOutputs CommandGateModeBuilder::make_stop(const builtin_interfaces::msg::Tim
   ModeOutputs outputs;
   fill_state(outputs.state, autoware_adapi_v1_msgs::msg::OperationModeState::STOP, stamp);
   fill_gear(outputs.gear, autoware_vehicle_msgs::msg::GearCommand::PARK, stamp);
-  outputs.status = make_status("Switched to STOP");
   return outputs;
 }
 
@@ -55,7 +92,6 @@ ModeOutputs CommandGateModeBuilder::make_autonomous(const builtin_interfaces::ms
   ModeOutputs outputs;
   fill_state(outputs.state, autoware_adapi_v1_msgs::msg::OperationModeState::AUTONOMOUS, stamp);
   fill_gear(outputs.gear, autoware_vehicle_msgs::msg::GearCommand::DRIVE, stamp);
-  outputs.status = make_status("Switched to AUTONOMOUS");
   return outputs;
 }
 
@@ -64,7 +100,6 @@ ModeOutputs CommandGateModeBuilder::make_local(const builtin_interfaces::msg::Ti
   ModeOutputs outputs;
   fill_state(outputs.state, autoware_adapi_v1_msgs::msg::OperationModeState::LOCAL, stamp);
   fill_gear(outputs.gear, autoware_vehicle_msgs::msg::GearCommand::NONE, stamp);
-  outputs.status = make_status("Switched to LOCAL");
   return outputs;
 }
 
@@ -73,7 +108,6 @@ ModeOutputs CommandGateModeBuilder::make_remote(const builtin_interfaces::msg::T
   ModeOutputs outputs;
   fill_state(outputs.state, autoware_adapi_v1_msgs::msg::OperationModeState::REMOTE, stamp);
   fill_gear(outputs.gear, autoware_vehicle_msgs::msg::GearCommand::NONE, stamp);
-  outputs.status = make_status("Switched to REMOTE");
   return outputs;
 }
 
@@ -98,16 +132,6 @@ void CommandGateModeBuilder::fill_gear(
 {
   msg.stamp = stamp;
   msg.command = command;
-}
-
-autoware_adapi_v1_msgs::msg::ResponseStatus CommandGateModeBuilder::make_status(
-  const std::string & message)
-{
-  autoware_adapi_v1_msgs::msg::ResponseStatus status;
-  status.success = true;
-  status.code = 0;  // 0 represents success (no specific success code defined)
-  status.message = message;
-  return status;
 }
 
 }  // namespace autoware::control::command_gate

--- a/control/autoware_command_gate/src/command_gate_mode_builder.hpp
+++ b/control/autoware_command_gate/src/command_gate_mode_builder.hpp
@@ -18,7 +18,7 @@
 #include <builtin_interfaces/msg/time.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
-#include <autoware_adapi_v1_msgs/msg/response_status.hpp>
+#include <autoware_system_msgs/srv/change_operation_mode.hpp>
 #include <autoware_vehicle_msgs/msg/gear_command.hpp>
 
 #include <cstdint>
@@ -32,32 +32,49 @@ struct ModeOutputs
 {
   autoware_adapi_v1_msgs::msg::OperationModeState state;
   autoware_vehicle_msgs::msg::GearCommand gear;
-  autoware_adapi_v1_msgs::msg::ResponseStatus status;
 };
 
+/// Pure (ROS-node-free) builders that convert a ChangeOperationMode request message into the
+/// messages the command gate emits. Every entry point is a plain message-in -> message-out
+/// function so it can be unit-tested without spinning up a ROS node, publisher or service.
 class CommandGateModeBuilder
 {
 public:
+  using Request = autoware_system_msgs::srv::ChangeOperationMode::Request;
+  using Response = autoware_system_msgs::srv::ChangeOperationMode::Response;
+
+  /// Build the messages to publish for the requested operation mode.
+  /// Returns std::nullopt for unknown/unsupported modes so the caller publishes nothing.
+  /// The accepted values mirror the constants of
+  /// autoware_system_msgs::srv::ChangeOperationMode::Request (STOP/AUTONOMOUS/LOCAL/REMOTE).
+  static std::optional<ModeOutputs> create_mode_output(
+    const Request & request, const builtin_interfaces::msg::Time & stamp);
+
+  /// Build the service response for the requested operation mode.
+  /// Reports success for known modes and a PARAMETER_ERROR for unknown ones, mirroring the
+  /// publish decision made by create_mode_output().
+  static Response create_response(
+    const Request & request, const builtin_interfaces::msg::Time & stamp);
+
   static ModeOutputs make_stop(const builtin_interfaces::msg::Time & stamp);
   static ModeOutputs make_autonomous(const builtin_interfaces::msg::Time & stamp);
   static ModeOutputs make_local(const builtin_interfaces::msg::Time & stamp);
   static ModeOutputs make_remote(const builtin_interfaces::msg::Time & stamp);
 
-  /// Map an operation-mode request value to its outputs.
-  /// Returns std::nullopt for unknown/unsupported modes so callers can emit a
-  /// PARAMETER_ERROR response. The accepted values mirror the constants of
-  /// autoware_system_msgs::srv::ChangeOperationMode::Request (STOP/AUTONOMOUS/LOCAL/REMOTE).
+private:
+  /// Map an operation-mode request value to its outputs, or std::nullopt for unknown modes.
   static std::optional<ModeOutputs> dispatch_mode(
     uint16_t mode, const builtin_interfaces::msg::Time & stamp);
 
-private:
+  /// Human-readable success message for a known mode, or std::nullopt for unknown modes.
+  static std::optional<std::string> success_message(uint16_t mode);
+
   static void fill_state(
     autoware_adapi_v1_msgs::msg::OperationModeState & msg, uint8_t mode,
     const builtin_interfaces::msg::Time & stamp);
   static void fill_gear(
     autoware_vehicle_msgs::msg::GearCommand & msg, uint8_t command,
     const builtin_interfaces::msg::Time & stamp);
-  static autoware_adapi_v1_msgs::msg::ResponseStatus make_status(const std::string & message);
 };
 
 }  // namespace autoware::control::command_gate

--- a/control/autoware_command_gate/test/unit/test_command_gate_mode_builder.cpp
+++ b/control/autoware_command_gate/test/unit/test_command_gate_mode_builder.cpp
@@ -17,6 +17,7 @@
 #include <builtin_interfaces/msg/time.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
+#include <autoware_common_msgs/msg/response_status.hpp>
 #include <autoware_system_msgs/srv/change_operation_mode.hpp>
 #include <autoware_vehicle_msgs/msg/gear_command.hpp>
 
@@ -25,14 +26,25 @@
 namespace autoware::control::command_gate
 {
 
+using Request = autoware_system_msgs::srv::ChangeOperationMode::Request;
+
+namespace
+{
+Request make_request(uint16_t mode)
+{
+  Request request;
+  request.mode = mode;
+  return request;
+}
+}  // namespace
+
 TEST(CommandGateModeBuilder, MakeStop)
 {
-  CommandGateModeBuilder builder;
   builtin_interfaces::msg::Time stamp;
   stamp.sec = 42;
   stamp.nanosec = 100;
 
-  const auto outputs = builder.make_stop(stamp);
+  const auto outputs = CommandGateModeBuilder::make_stop(stamp);
 
   EXPECT_EQ(outputs.state.stamp.sec, stamp.sec);
   EXPECT_EQ(outputs.state.stamp.nanosec, stamp.nanosec);
@@ -47,20 +59,15 @@ TEST(CommandGateModeBuilder, MakeStop)
   EXPECT_EQ(outputs.gear.stamp.sec, stamp.sec);
   EXPECT_EQ(outputs.gear.stamp.nanosec, stamp.nanosec);
   EXPECT_EQ(outputs.gear.command, autoware_vehicle_msgs::msg::GearCommand::PARK);
-
-  EXPECT_TRUE(outputs.status.success);
-  EXPECT_EQ(outputs.status.code, 0);
-  EXPECT_EQ(outputs.status.message, "Switched to STOP");
 }
 
 TEST(CommandGateModeBuilder, MakeAutonomous)
 {
-  CommandGateModeBuilder builder;
   builtin_interfaces::msg::Time stamp;
   stamp.sec = 99;
   stamp.nanosec = 1;
 
-  const auto outputs = builder.make_autonomous(stamp);
+  const auto outputs = CommandGateModeBuilder::make_autonomous(stamp);
 
   EXPECT_EQ(outputs.state.stamp.sec, stamp.sec);
   EXPECT_EQ(outputs.state.stamp.nanosec, stamp.nanosec);
@@ -75,20 +82,15 @@ TEST(CommandGateModeBuilder, MakeAutonomous)
   EXPECT_EQ(outputs.gear.stamp.sec, stamp.sec);
   EXPECT_EQ(outputs.gear.stamp.nanosec, stamp.nanosec);
   EXPECT_EQ(outputs.gear.command, autoware_vehicle_msgs::msg::GearCommand::DRIVE);
-
-  EXPECT_TRUE(outputs.status.success);
-  EXPECT_EQ(outputs.status.code, 0);
-  EXPECT_EQ(outputs.status.message, "Switched to AUTONOMOUS");
 }
 
 TEST(CommandGateModeBuilder, MakeLocal)
 {
-  CommandGateModeBuilder builder;
   builtin_interfaces::msg::Time stamp;
   stamp.sec = 7;
   stamp.nanosec = 77;
 
-  const auto outputs = builder.make_local(stamp);
+  const auto outputs = CommandGateModeBuilder::make_local(stamp);
 
   EXPECT_EQ(outputs.state.stamp.sec, stamp.sec);
   EXPECT_EQ(outputs.state.stamp.nanosec, stamp.nanosec);
@@ -103,20 +105,15 @@ TEST(CommandGateModeBuilder, MakeLocal)
   EXPECT_EQ(outputs.gear.stamp.sec, stamp.sec);
   EXPECT_EQ(outputs.gear.stamp.nanosec, stamp.nanosec);
   EXPECT_EQ(outputs.gear.command, autoware_vehicle_msgs::msg::GearCommand::NONE);
-
-  EXPECT_TRUE(outputs.status.success);
-  EXPECT_EQ(outputs.status.code, 0);
-  EXPECT_EQ(outputs.status.message, "Switched to LOCAL");
 }
 
 TEST(CommandGateModeBuilder, MakeRemote)
 {
-  CommandGateModeBuilder builder;
   builtin_interfaces::msg::Time stamp;
   stamp.sec = 13;
   stamp.nanosec = 130;
 
-  const auto outputs = builder.make_remote(stamp);
+  const auto outputs = CommandGateModeBuilder::make_remote(stamp);
 
   EXPECT_EQ(outputs.state.stamp.sec, stamp.sec);
   EXPECT_EQ(outputs.state.stamp.nanosec, stamp.nanosec);
@@ -131,20 +128,16 @@ TEST(CommandGateModeBuilder, MakeRemote)
   EXPECT_EQ(outputs.gear.stamp.sec, stamp.sec);
   EXPECT_EQ(outputs.gear.stamp.nanosec, stamp.nanosec);
   EXPECT_EQ(outputs.gear.command, autoware_vehicle_msgs::msg::GearCommand::NONE);
-
-  EXPECT_TRUE(outputs.status.success);
-  EXPECT_EQ(outputs.status.code, 0);
-  EXPECT_EQ(outputs.status.message, "Switched to REMOTE");
 }
 
-TEST(CommandGateModeBuilder, DispatchModeStop)
+TEST(CommandGateModeBuilder, CreateModeOutputStop)
 {
-  using Request = autoware_system_msgs::srv::ChangeOperationMode::Request;
   builtin_interfaces::msg::Time stamp;
   stamp.sec = 5;
   stamp.nanosec = 50;
 
-  const auto outputs = CommandGateModeBuilder::dispatch_mode(Request::STOP, stamp);
+  const auto outputs =
+    CommandGateModeBuilder::create_mode_output(make_request(Request::STOP), stamp);
 
   ASSERT_TRUE(outputs.has_value());
   EXPECT_EQ(outputs->state.mode, autoware_adapi_v1_msgs::msg::OperationModeState::STOP);
@@ -152,16 +145,18 @@ TEST(CommandGateModeBuilder, DispatchModeStop)
   EXPECT_EQ(outputs->gear.command, autoware_vehicle_msgs::msg::GearCommand::PARK);
   EXPECT_EQ(outputs->state.stamp.sec, stamp.sec);
   EXPECT_EQ(outputs->state.stamp.nanosec, stamp.nanosec);
+  EXPECT_EQ(outputs->gear.stamp.sec, stamp.sec);
+  EXPECT_EQ(outputs->gear.stamp.nanosec, stamp.nanosec);
 }
 
-TEST(CommandGateModeBuilder, DispatchModeAutonomous)
+TEST(CommandGateModeBuilder, CreateModeOutputAutonomous)
 {
-  using Request = autoware_system_msgs::srv::ChangeOperationMode::Request;
   builtin_interfaces::msg::Time stamp;
   stamp.sec = 99;
   stamp.nanosec = 1;
 
-  const auto outputs = CommandGateModeBuilder::dispatch_mode(Request::AUTONOMOUS, stamp);
+  const auto outputs =
+    CommandGateModeBuilder::create_mode_output(make_request(Request::AUTONOMOUS), stamp);
 
   ASSERT_TRUE(outputs.has_value());
   EXPECT_EQ(outputs->state.mode, autoware_adapi_v1_msgs::msg::OperationModeState::AUTONOMOUS);
@@ -171,14 +166,14 @@ TEST(CommandGateModeBuilder, DispatchModeAutonomous)
   EXPECT_EQ(outputs->state.stamp.nanosec, stamp.nanosec);
 }
 
-TEST(CommandGateModeBuilder, DispatchModeLocal)
+TEST(CommandGateModeBuilder, CreateModeOutputLocal)
 {
-  using Request = autoware_system_msgs::srv::ChangeOperationMode::Request;
   builtin_interfaces::msg::Time stamp;
   stamp.sec = 7;
   stamp.nanosec = 77;
 
-  const auto outputs = CommandGateModeBuilder::dispatch_mode(Request::LOCAL, stamp);
+  const auto outputs =
+    CommandGateModeBuilder::create_mode_output(make_request(Request::LOCAL), stamp);
 
   ASSERT_TRUE(outputs.has_value());
   EXPECT_EQ(outputs->state.mode, autoware_adapi_v1_msgs::msg::OperationModeState::LOCAL);
@@ -187,14 +182,14 @@ TEST(CommandGateModeBuilder, DispatchModeLocal)
   EXPECT_EQ(outputs->state.stamp.nanosec, stamp.nanosec);
 }
 
-TEST(CommandGateModeBuilder, DispatchModeRemote)
+TEST(CommandGateModeBuilder, CreateModeOutputRemote)
 {
-  using Request = autoware_system_msgs::srv::ChangeOperationMode::Request;
   builtin_interfaces::msg::Time stamp;
   stamp.sec = 13;
   stamp.nanosec = 130;
 
-  const auto outputs = CommandGateModeBuilder::dispatch_mode(Request::REMOTE, stamp);
+  const auto outputs =
+    CommandGateModeBuilder::create_mode_output(make_request(Request::REMOTE), stamp);
 
   ASSERT_TRUE(outputs.has_value());
   EXPECT_EQ(outputs->state.mode, autoware_adapi_v1_msgs::msg::OperationModeState::REMOTE);
@@ -203,15 +198,76 @@ TEST(CommandGateModeBuilder, DispatchModeRemote)
   EXPECT_EQ(outputs->state.stamp.nanosec, stamp.nanosec);
 }
 
-TEST(CommandGateModeBuilder, DispatchModeUnknownReturnsNullopt)
+TEST(CommandGateModeBuilder, CreateModeOutputUnknownReturnsNullopt)
 {
   builtin_interfaces::msg::Time stamp;
 
   // 0 is reserved (no mode constant) and any value outside STOP/AUTONOMOUS/LOCAL/REMOTE
-  // must be rejected so the node can report a PARAMETER_ERROR.
-  EXPECT_FALSE(CommandGateModeBuilder::dispatch_mode(0, stamp).has_value());
-  EXPECT_FALSE(CommandGateModeBuilder::dispatch_mode(5, stamp).has_value());
-  EXPECT_FALSE(CommandGateModeBuilder::dispatch_mode(255, stamp).has_value());
+  // must publish nothing so the node only reports a PARAMETER_ERROR.
+  EXPECT_FALSE(CommandGateModeBuilder::create_mode_output(make_request(0), stamp).has_value());
+  EXPECT_FALSE(CommandGateModeBuilder::create_mode_output(make_request(5), stamp).has_value());
+  EXPECT_FALSE(CommandGateModeBuilder::create_mode_output(make_request(255), stamp).has_value());
+}
+
+TEST(CommandGateModeBuilder, CreateResponseStop)
+{
+  builtin_interfaces::msg::Time stamp;
+
+  const auto response = CommandGateModeBuilder::create_response(make_request(Request::STOP), stamp);
+
+  EXPECT_TRUE(response.status.success);
+  EXPECT_EQ(response.status.code, 0);
+  EXPECT_EQ(response.status.message, "Switched to STOP");
+}
+
+TEST(CommandGateModeBuilder, CreateResponseAutonomous)
+{
+  builtin_interfaces::msg::Time stamp;
+
+  const auto response =
+    CommandGateModeBuilder::create_response(make_request(Request::AUTONOMOUS), stamp);
+
+  EXPECT_TRUE(response.status.success);
+  EXPECT_EQ(response.status.code, 0);
+  EXPECT_EQ(response.status.message, "Switched to AUTONOMOUS");
+}
+
+TEST(CommandGateModeBuilder, CreateResponseLocal)
+{
+  builtin_interfaces::msg::Time stamp;
+
+  const auto response =
+    CommandGateModeBuilder::create_response(make_request(Request::LOCAL), stamp);
+
+  EXPECT_TRUE(response.status.success);
+  EXPECT_EQ(response.status.code, 0);
+  EXPECT_EQ(response.status.message, "Switched to LOCAL");
+}
+
+TEST(CommandGateModeBuilder, CreateResponseRemote)
+{
+  builtin_interfaces::msg::Time stamp;
+
+  const auto response =
+    CommandGateModeBuilder::create_response(make_request(Request::REMOTE), stamp);
+
+  EXPECT_TRUE(response.status.success);
+  EXPECT_EQ(response.status.code, 0);
+  EXPECT_EQ(response.status.message, "Switched to REMOTE");
+}
+
+TEST(CommandGateModeBuilder, CreateResponseUnknownReportsParameterError)
+{
+  builtin_interfaces::msg::Time stamp;
+
+  // Unknown modes must surface a PARAMETER_ERROR while create_mode_output publishes nothing.
+  for (const uint16_t mode :
+       {static_cast<uint16_t>(0), static_cast<uint16_t>(5), static_cast<uint16_t>(255)}) {
+    const auto response = CommandGateModeBuilder::create_response(make_request(mode), stamp);
+    EXPECT_FALSE(response.status.success);
+    EXPECT_EQ(response.status.code, autoware_common_msgs::msg::ResponseStatus::PARAMETER_ERROR);
+    EXPECT_EQ(response.status.message, "Unknown operation mode requested.");
+  }
 }
 
 }  // namespace autoware::control::command_gate


### PR DESCRIPTION
**Review-only PR — do not merge via GitHub.**

Shows the single additional commit that addresses `interimadd`'s change-request on top of `refactor/autoware_command_gate`, the head of:
- upstream PR autowarefoundation/autoware_core#1145
- fork PR youtalk/autoware_core#52

Diff here = exactly that one fix commit (base = `refactor/autoware_command_gate`). After approval the commit is pushed fast-forward onto `refactor/autoware_command_gate` (no rebase/amend), updating both PRs; this `review/autoware_command_gate` branch is then deleted.

**Fix:** Completes the testability extraction interimadd asked for: splits the service callback into two pure message-in -> message-out functions, CommandGateModeBuilder::create_mode_output (std::optional outputs to publish) and create_response, and unit-tests both (including the nullopt / unknown-mode cases). Behavior preserved; no new mutable state.
