### PR TITLE
test(autoware_ndt_scan_matcher): assert rotation covariance against independent oracle

### DIFF
--- a/localization/autoware_ndt_scan_matcher/test/test_estimate_covariance.cpp
+++ b/localization/autoware_ndt_scan_matcher/test/test_estimate_covariance.cpp
@@ -115,12 +115,21 @@ TEST(EstimateCovariance, RotateCovarianceMapAndBaseLinkAreInverses)  // NOLINT
   Eigen::Matrix2d cov;
   cov << 4.0, 1.0, 1.0, 9.0;
 
-  const Eigen::Matrix2d rot = pose.topLeftCorner<2, 2>().cast<double>();
-  const Eigen::Matrix2d expected_map = rot * cov * rot.transpose();
-
   const Eigen::Matrix2d cov_map = pclomp::rotate_covariance_to_map(cov, pose);
+
+  // Independent oracle: explicit scalar expansion of R * cov * R^T with
+  // R = [[c, -s], [s, c]], cov = [[4, 1], [1, 9]]. These literals are derived by hand
+  // from the rotation algebra, not from the matrix product the production code evaluates.
+  const double c = std::cos(theta);
+  const double s = std::sin(theta);
+  const double exp00 = c * c * 4.0 - 2.0 * c * s * 1.0 + s * s * 9.0;
+  const double exp01 = c * s * 4.0 + (c * c - s * s) * 1.0 - c * s * 9.0;
+  const double exp11 = s * s * 4.0 + 2.0 * c * s * 1.0 + c * c * 9.0;
   // The pose rotation is stored as float, so the achievable precision is limited to ~float eps.
-  EXPECT_TRUE(cov_map.isApprox(expected_map, 1e-6));
+  EXPECT_NEAR(cov_map(0, 0), exp00, 1e-6);
+  EXPECT_NEAR(cov_map(0, 1), exp01, 1e-6);
+  EXPECT_NEAR(cov_map(1, 0), exp01, 1e-6);
+  EXPECT_NEAR(cov_map(1, 1), exp11, 1e-6);
 
   // Rotating back to base_link must recover the original covariance.
   const Eigen::Matrix2d round_trip = pclomp::rotate_covariance_to_base_link(cov_map, pose);


### PR DESCRIPTION
**Review-only PR — do not merge via GitHub.** (Proactive fix ahead of @interimadd's review.)

Addresses an independent-oracle (tautological-test) issue of the same class @interimadd flagged on #1094/#1105 — found by re-auditing this not-yet-reviewed PR against his demonstrated review priorities.

Shows the single additional commit on top of `test/autoware_ndt_scan_matcher`, the head of:
- upstream PR autowarefoundation/autoware_core#1108
- fork PR youtalk/autoware_core#17

Diff = exactly that one fix commit (base = `test/autoware_ndt_scan_matcher`). After approval the commit is pushed fast-forward onto `test/autoware_ndt_scan_matcher` (no rebase/amend), updating both PRs; this `review/autoware_ndt_scan_matcher` branch is then deleted.

**Fix:** Replaces a tautological oracle in EstimateCovariance.RotateCovarianceMapAndBaseLinkAreInverses: the expected value was recomputed with the same rot*cov*rot.transpose() expression as rotate_covariance_to_map (a transpose/sign error would pass). Now asserts an independent stdlib scalar expansion of R*C*R^T via EXPECT_NEAR (sanity-checked: a transposed production formula now fails).
