### PR TITLE
test(autoware_simple_pure_pursuit): drop tautological rear-position consistency test

### DIFF
--- a/control/autoware_simple_pure_pursuit/test/test_pure_pursuit_util.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_pure_pursuit_util.cpp
@@ -60,23 +60,6 @@ TEST(PurePursuitUtil, calc_rear_position)
   }
 }
 
-TEST(PurePursuitUtil, calc_rear_position_yaw_overload_matches_pose_overload)
-{
-  // The yaw overload must reproduce the pose overload bit-for-bit when fed the pose's planar yaw.
-  const auto pose = make_pose(10.0, 5.0, 0.73);  // non-trivial orientation
-  const double wheel_base = 2.7;
-
-  // Extract the yaw exactly as the pose overload does, so the comparison pins bit-for-bit equality.
-  const double yaw = autoware_utils_geometry::get_rpy(pose.orientation).z;
-
-  const auto from_pose = calc_rear_position(pose, wheel_base);
-  const auto from_yaw = calc_rear_position(pose, wheel_base, yaw);
-
-  EXPECT_DOUBLE_EQ(from_yaw.x, from_pose.x);
-  EXPECT_DOUBLE_EQ(from_yaw.y, from_pose.y);
-  EXPECT_DOUBLE_EQ(from_yaw.z, from_pose.z);
-}
-
 TEST(PurePursuitUtil, find_lookahead_point_normal)
 {
   const std::vector<TrajectoryPoint> points{


### PR DESCRIPTION
**Review-only PR — do not merge via GitHub.** (Proactive fix ahead of @interimadd's review.)

Addresses an independent-oracle (tautological-test) issue of the same class @interimadd flagged on #1094/#1105 — found by re-auditing this not-yet-reviewed PR against his demonstrated review priorities.

Shows the single additional commit on top of `refactor/autoware_simple_pure_pursuit`, the head of:
- upstream PR autowarefoundation/autoware_core#1126
- fork PR youtalk/autoware_core#31

Diff = exactly that one fix commit (base = `refactor/autoware_simple_pure_pursuit`). After approval the commit is pushed fast-forward onto `refactor/autoware_simple_pure_pursuit` (no rebase/amend), updating both PRs; this `review/autoware_simple_pure_pursuit` branch is then deleted.

**Fix:** Removes the consistency-only TEST calc_rear_position_yaw_overload_matches_pose_overload: it fed the yaw overload get_rpy(pose.orientation).z (the pose overload's own internal expression) and asserted equality, so a wrong rear-axle formula passed green. The math is already correctness-pinned independently by PurePursuitUtil.calc_rear_position (literals (9.0,5.0)/(10.0,3.0)).
