### PR TITLE
test(autoware_test_utils): assert MakeInitialPose position against independent literals

### DIFF
--- a/testing/autoware_test_utils/test/test_autoware_test_utils.cpp
+++ b/testing/autoware_test_utils/test/test_autoware_test_utils.cpp
@@ -80,12 +80,14 @@ TEST(AutowareTestUtils, MakeInitialPose)
   const auto odometry = makeInitialPose(shift);
 
   constexpr double yaw = 0.9724497591854532;
-  const double expected_x = 3722.16015625 + shift * std::sin(yaw);
-  const double expected_y = 73723.515625 + shift * std::cos(yaw);
+  // Independent pre-computed oracle (offline) for shift = 4.0 and yaw above,
+  // decoupled from the implementation's shift * sin/cos formula.
+  constexpr double expected_x = 3725.465228587888;
+  constexpr double expected_y = 73725.76873326223;
 
   EXPECT_EQ(odometry.header.frame_id, "map");
-  EXPECT_DOUBLE_EQ(odometry.pose.pose.position.x, expected_x);
-  EXPECT_DOUBLE_EQ(odometry.pose.pose.position.y, expected_y);
+  EXPECT_NEAR(odometry.pose.pose.position.x, expected_x, 1e-6);
+  EXPECT_NEAR(odometry.pose.pose.position.y, expected_y, 1e-6);
   EXPECT_DOUBLE_EQ(odometry.pose.pose.position.z, 0.233112560494183);
   // Orientation is a yaw-only quaternion: z = sin(yaw/2), w = cos(yaw/2)
   EXPECT_NEAR(odometry.pose.pose.orientation.z, std::sin(yaw / 2.0), 1e-12);


### PR DESCRIPTION
**Review-only PR — do not merge via GitHub.** (Proactive fix ahead of @interimadd's review.)

Addresses an independent-oracle (tautological-test) issue of the same class @interimadd flagged on #1094/#1105 — found by re-auditing this not-yet-reviewed PR against his demonstrated review priorities.

Shows the single additional commit on top of `test/autoware_test_utils`, the head of:
- upstream PR autowarefoundation/autoware_core#1149
- fork PR youtalk/autoware_core#56

Diff = exactly that one fix commit (base = `test/autoware_test_utils`). After approval the commit is pushed fast-forward onto `test/autoware_test_utils` (no rebase/amend), updating both PRs; this `review/autoware_test_utils` branch is then deleted.

**Fix:** Replaces a tautological oracle in MakeInitialPose: expected x/y were recomputed with the implementation's own shift*sin(yaw)/shift*cos(yaw) formula and base constants. Now asserts independent pre-computed literals via EXPECT_NEAR; the quaternion-from-yaw identity check was already independent and is kept.
