### PR TITLE
refactor(autoware_twist2accel): move accel covariance into pure AccelEstimator

### DIFF
--- a/localization/autoware_twist2accel/src/accel_estimator.cpp
+++ b/localization/autoware_twist2accel/src/accel_estimator.cpp
@@ -49,7 +49,7 @@ geometry_msgs::msg::AccelWithCovariance AccelEstimator::estimate(
   accel.accel.angular.z =
     lpf_aaz_.filter((curr_twist.angular.z - prev_twist.angular.z) / clamped_dt);
 
-  // Ideally speaking, these covariance should be properly estimated. Until that
+  // Ideally speaking, this covariance should be properly estimated. Until that
   // is done, report constant diagonal variances; off-diagonal terms stay at the
   // default zero.
   accel.covariance[XYZRPY_COV_IDX::X_X] = g_linear_accel_variance;

--- a/localization/autoware_twist2accel/src/accel_estimator.cpp
+++ b/localization/autoware_twist2accel/src/accel_estimator.cpp
@@ -14,10 +14,14 @@
 
 #include "accel_estimator.hpp"
 
+#include <autoware_utils_geometry/msg/covariance.hpp>
+
 #include <algorithm>
 
 namespace autoware::twist2accel
 {
+using autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
+
 AccelEstimator::AccelEstimator(const double lowpass_gain)
 : lpf_alx_(lowpass_gain),
   lpf_aly_(lowpass_gain),
@@ -28,19 +32,33 @@ AccelEstimator::AccelEstimator(const double lowpass_gain)
 {
 }
 
-geometry_msgs::msg::Accel AccelEstimator::estimate(
+geometry_msgs::msg::AccelWithCovariance AccelEstimator::estimate(
   const geometry_msgs::msg::Twist & prev_twist, const geometry_msgs::msg::Twist & curr_twist,
   const double dt)
 {
   const double clamped_dt = std::max(dt, g_min_dt);
 
-  geometry_msgs::msg::Accel accel;
-  accel.linear.x = lpf_alx_.filter((curr_twist.linear.x - prev_twist.linear.x) / clamped_dt);
-  accel.linear.y = lpf_aly_.filter((curr_twist.linear.y - prev_twist.linear.y) / clamped_dt);
-  accel.linear.z = lpf_alz_.filter((curr_twist.linear.z - prev_twist.linear.z) / clamped_dt);
-  accel.angular.x = lpf_aax_.filter((curr_twist.angular.x - prev_twist.angular.x) / clamped_dt);
-  accel.angular.y = lpf_aay_.filter((curr_twist.angular.y - prev_twist.angular.y) / clamped_dt);
-  accel.angular.z = lpf_aaz_.filter((curr_twist.angular.z - prev_twist.angular.z) / clamped_dt);
+  geometry_msgs::msg::AccelWithCovariance accel;
+  accel.accel.linear.x = lpf_alx_.filter((curr_twist.linear.x - prev_twist.linear.x) / clamped_dt);
+  accel.accel.linear.y = lpf_aly_.filter((curr_twist.linear.y - prev_twist.linear.y) / clamped_dt);
+  accel.accel.linear.z = lpf_alz_.filter((curr_twist.linear.z - prev_twist.linear.z) / clamped_dt);
+  accel.accel.angular.x =
+    lpf_aax_.filter((curr_twist.angular.x - prev_twist.angular.x) / clamped_dt);
+  accel.accel.angular.y =
+    lpf_aay_.filter((curr_twist.angular.y - prev_twist.angular.y) / clamped_dt);
+  accel.accel.angular.z =
+    lpf_aaz_.filter((curr_twist.angular.z - prev_twist.angular.z) / clamped_dt);
+
+  // Ideally speaking, these covariance should be properly estimated. Until that
+  // is done, report constant diagonal variances; off-diagonal terms stay at the
+  // default zero.
+  accel.covariance[XYZRPY_COV_IDX::X_X] = g_linear_accel_variance;
+  accel.covariance[XYZRPY_COV_IDX::Y_Y] = g_linear_accel_variance;
+  accel.covariance[XYZRPY_COV_IDX::Z_Z] = g_linear_accel_variance;
+  accel.covariance[XYZRPY_COV_IDX::ROLL_ROLL] = g_angular_accel_variance;
+  accel.covariance[XYZRPY_COV_IDX::PITCH_PITCH] = g_angular_accel_variance;
+  accel.covariance[XYZRPY_COV_IDX::YAW_YAW] = g_angular_accel_variance;
+
   return accel;
 }
 }  // namespace autoware::twist2accel

--- a/localization/autoware_twist2accel/src/accel_estimator.hpp
+++ b/localization/autoware_twist2accel/src/accel_estimator.hpp
@@ -17,7 +17,7 @@
 
 #include "autoware/signal_processing/lowpass_filter_1d.hpp"
 
-#include <geometry_msgs/msg/accel.hpp>
+#include <geometry_msgs/msg/accel_with_covariance.hpp>
 #include <geometry_msgs/msg/twist.hpp>
 
 namespace autoware::twist2accel
@@ -27,6 +27,15 @@ namespace autoware::twist2accel
 /// avoid division by (near-)zero when stamps are equal or out of order.
 constexpr double g_min_dt = 1.0e-3;
 
+/// Fixed covariance assigned to the estimated acceleration. The current
+/// estimator does not propagate the input twist covariance through the
+/// finite-difference / low-pass smoothing, so it reports these constant
+/// diagonal variances (off-diagonal terms stay zero):
+/// - linear x/y/z variance = g_linear_accel_variance
+/// - angular roll/pitch/yaw variance = g_angular_accel_variance
+constexpr double g_linear_accel_variance = 1.0;
+constexpr double g_angular_accel_variance = 0.05;
+
 /// @brief Pure acceleration estimator with no rclcpp::Node / spinning dependency.
 ///
 /// Estimates acceleration by finite-differencing two successive twist samples
@@ -34,21 +43,29 @@ constexpr double g_min_dt = 1.0e-3;
 /// Owns the six LowpassFilter1d instances so the filter state persists across
 /// calls, mirroring the per-component smoothing performed by the node.
 ///
-/// It operates directly on the plain geometry_msgs Twist/Accel data structs:
-/// those are header-only value types that need no running ROS node, so the
-/// estimator stays unit-testable while avoiding any conversion layer.
+/// In addition to the acceleration values it fills in the acceleration
+/// covariance, keeping the full estimation contract (value + uncertainty) in
+/// one pure place instead of splitting it between the core and the node.
+///
+/// It operates directly on the plain geometry_msgs Twist/AccelWithCovariance
+/// data structs: those are header-only value types that need no running ROS
+/// node, so the estimator stays unit-testable while avoiding any conversion
+/// layer.
 class AccelEstimator
 {
 public:
   explicit AccelEstimator(double lowpass_gain);
 
-  /// @brief Estimate acceleration from a finite difference of two twists.
+  /// @brief Estimate acceleration and its covariance from a finite difference
+  ///   of two twists.
   /// @param prev_twist twist sample at the previous time step
   /// @param curr_twist twist sample at the current time step
   /// @param dt time delta in seconds between the two samples; values below
   ///   g_min_dt are clamped up to g_min_dt before the division
-  /// @return per-component, low-pass-filtered acceleration
-  geometry_msgs::msg::Accel estimate(
+  /// @return per-component, low-pass-filtered acceleration together with its
+  ///   covariance (constant diagonal variances, see g_linear_accel_variance /
+  ///   g_angular_accel_variance)
+  geometry_msgs::msg::AccelWithCovariance estimate(
     const geometry_msgs::msg::Twist & prev_twist, const geometry_msgs::msg::Twist & curr_twist,
     double dt);
 

--- a/localization/autoware_twist2accel/src/twist2accel.cpp
+++ b/localization/autoware_twist2accel/src/twist2accel.cpp
@@ -16,7 +16,6 @@
 
 #include "accel_estimator.hpp"
 
-#include <autoware_utils_geometry/msg/covariance.hpp>
 #include <rclcpp/logging.hpp>
 
 #include <functional>
@@ -24,7 +23,6 @@
 
 namespace autoware::twist2accel
 {
-using autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
 using std::placeholders::_1;
 
 Twist2Accel::Twist2Accel(const rclcpp::NodeOptions & node_options)
@@ -73,15 +71,7 @@ void Twist2Accel::estimate_accel(const geometry_msgs::msg::TwistStamped & twist)
     const double dt =
       (rclcpp::Time(twist.header.stamp) - rclcpp::Time(prev_twist_->header.stamp)).seconds();
 
-    accel_msg.accel.accel = accel_estimator_->estimate(prev_twist_->twist, twist.twist, dt);
-
-    // Ideally speaking, these covariance should be properly estimated.
-    accel_msg.accel.covariance[XYZRPY_COV_IDX::X_X] = 1.0;
-    accel_msg.accel.covariance[XYZRPY_COV_IDX::Y_Y] = 1.0;
-    accel_msg.accel.covariance[XYZRPY_COV_IDX::Z_Z] = 1.0;
-    accel_msg.accel.covariance[XYZRPY_COV_IDX::ROLL_ROLL] = 0.05;
-    accel_msg.accel.covariance[XYZRPY_COV_IDX::PITCH_PITCH] = 0.05;
-    accel_msg.accel.covariance[XYZRPY_COV_IDX::YAW_YAW] = 0.05;
+    accel_msg.accel = accel_estimator_->estimate(prev_twist_->twist, twist.twist, dt);
   }
 
   pub_accel_->publish(accel_msg);

--- a/localization/autoware_twist2accel/test/test_accel_estimator.cpp
+++ b/localization/autoware_twist2accel/test/test_accel_estimator.cpp
@@ -14,12 +14,17 @@
 
 #include "../src/accel_estimator.hpp"
 
-#include <geometry_msgs/msg/accel.hpp>
+#include <geometry_msgs/msg/accel_with_covariance.hpp>
 #include <geometry_msgs/msg/twist.hpp>
 
 #include <gtest/gtest.h>
 
+#include <array>
+#include <cstddef>
+
 using autoware::twist2accel::AccelEstimator;
+using autoware::twist2accel::g_angular_accel_variance;
+using autoware::twist2accel::g_linear_accel_variance;
 using autoware::twist2accel::g_min_dt;
 
 namespace
@@ -52,14 +57,14 @@ TEST(AccelEstimatorTest, FiniteDifferenceNoSmoothingOnFirstSample)
   const auto curr = make_twist(2.0, 4.0, 6.0, 0.2, 0.4, 0.6);
   const double dt = 0.5;
 
-  const geometry_msgs::msg::Accel accel = estimator.estimate(prev, curr, dt);
+  const geometry_msgs::msg::AccelWithCovariance accel = estimator.estimate(prev, curr, dt);
 
-  EXPECT_NEAR(accel.linear.x, 4.0, kTol);   // (2.0 - 0.0) / 0.5
-  EXPECT_NEAR(accel.linear.y, 8.0, kTol);   // (4.0 - 0.0) / 0.5
-  EXPECT_NEAR(accel.linear.z, 12.0, kTol);  // (6.0 - 0.0) / 0.5
-  EXPECT_NEAR(accel.angular.x, 0.4, kTol);  // (0.2 - 0.0) / 0.5
-  EXPECT_NEAR(accel.angular.y, 0.8, kTol);  // (0.4 - 0.0) / 0.5
-  EXPECT_NEAR(accel.angular.z, 1.2, kTol);  // (0.6 - 0.0) / 0.5
+  EXPECT_NEAR(accel.accel.linear.x, 4.0, kTol);   // (2.0 - 0.0) / 0.5
+  EXPECT_NEAR(accel.accel.linear.y, 8.0, kTol);   // (4.0 - 0.0) / 0.5
+  EXPECT_NEAR(accel.accel.linear.z, 12.0, kTol);  // (6.0 - 0.0) / 0.5
+  EXPECT_NEAR(accel.accel.angular.x, 0.4, kTol);  // (0.2 - 0.0) / 0.5
+  EXPECT_NEAR(accel.accel.angular.y, 0.8, kTol);  // (0.4 - 0.0) / 0.5
+  EXPECT_NEAR(accel.accel.angular.z, 1.2, kTol);  // (0.6 - 0.0) / 0.5
 }
 
 // Equal successive twists give a zero finite difference on every channel,
@@ -69,14 +74,14 @@ TEST(AccelEstimatorTest, ZeroVelocityChangeYieldsZeroAccel)
   AccelEstimator estimator(0.5);
   const auto twist = make_twist(1.0, -2.0, 3.0, 0.1, -0.2, 0.3);
 
-  const geometry_msgs::msg::Accel accel = estimator.estimate(twist, twist, 0.1);
+  const geometry_msgs::msg::AccelWithCovariance accel = estimator.estimate(twist, twist, 0.1);
 
-  EXPECT_NEAR(accel.linear.x, 0.0, kTol);
-  EXPECT_NEAR(accel.linear.y, 0.0, kTol);
-  EXPECT_NEAR(accel.linear.z, 0.0, kTol);
-  EXPECT_NEAR(accel.angular.x, 0.0, kTol);
-  EXPECT_NEAR(accel.angular.y, 0.0, kTol);
-  EXPECT_NEAR(accel.angular.z, 0.0, kTol);
+  EXPECT_NEAR(accel.accel.linear.x, 0.0, kTol);
+  EXPECT_NEAR(accel.accel.linear.y, 0.0, kTol);
+  EXPECT_NEAR(accel.accel.linear.z, 0.0, kTol);
+  EXPECT_NEAR(accel.accel.angular.x, 0.0, kTol);
+  EXPECT_NEAR(accel.accel.angular.y, 0.0, kTol);
+  EXPECT_NEAR(accel.accel.angular.z, 0.0, kTol);
 }
 
 // The second and later samples smooth the raw finite difference with the
@@ -88,23 +93,23 @@ TEST(AccelEstimatorTest, LowPassSmoothingAcrossSamples)
   const double dt = 1.0;
 
   // First sample: linear_x ramps 0 -> 1, raw accel = 1.0, LPF returns it as-is.
-  const geometry_msgs::msg::Accel first =
+  const geometry_msgs::msg::AccelWithCovariance first =
     estimator.estimate(make_twist(0.0, 0, 0, 0, 0, 0), make_twist(1.0, 0, 0, 0, 0, 0), dt);
-  EXPECT_NEAR(first.linear.x, 1.0, kTol);
+  EXPECT_NEAR(first.accel.linear.x, 1.0, kTol);
 
   // Second sample: linear_x ramps 1 -> 3, raw accel = 2.0.
   // Smoothed: 0.9 * 1.0 + 0.1 * 2.0 = 1.1.
-  const geometry_msgs::msg::Accel second =
+  const geometry_msgs::msg::AccelWithCovariance second =
     estimator.estimate(make_twist(1.0, 0, 0, 0, 0, 0), make_twist(3.0, 0, 0, 0, 0, 0), dt);
-  EXPECT_NEAR(second.linear.x, gain * 1.0 + (1.0 - gain) * 2.0, kTol);
-  EXPECT_NEAR(second.linear.x, 1.1, kTol);
+  EXPECT_NEAR(second.accel.linear.x, gain * 1.0 + (1.0 - gain) * 2.0, kTol);
+  EXPECT_NEAR(second.accel.linear.x, 1.1, kTol);
 
   // Third sample: linear_x ramps 3 -> 3, raw accel = 0.0.
   // Smoothed: 0.9 * 1.1 + 0.1 * 0.0 = 0.99.
-  const geometry_msgs::msg::Accel third =
+  const geometry_msgs::msg::AccelWithCovariance third =
     estimator.estimate(make_twist(3.0, 0, 0, 0, 0, 0), make_twist(3.0, 0, 0, 0, 0, 0), dt);
-  EXPECT_NEAR(third.linear.x, gain * 1.1 + (1.0 - gain) * 0.0, kTol);
-  EXPECT_NEAR(third.linear.x, 0.99, kTol);
+  EXPECT_NEAR(third.accel.linear.x, gain * 1.1 + (1.0 - gain) * 0.0, kTol);
+  EXPECT_NEAR(third.accel.linear.x, 0.99, kTol);
 }
 
 // dt below g_min_dt (including zero or negative, e.g. near-simultaneous or
@@ -117,18 +122,21 @@ TEST(AccelEstimatorTest, DtClampForNearSimultaneousStamps)
 
   // dt == 0 is clamped to g_min_dt: accel = 1.0 / g_min_dt.
   AccelEstimator zero_dt_estimator(0.0);  // gain 0 -> filter passes raw value through
-  const geometry_msgs::msg::Accel zero_dt = zero_dt_estimator.estimate(prev, curr, 0.0);
-  EXPECT_NEAR(zero_dt.linear.x, 1.0 / g_min_dt, kTol);
+  const geometry_msgs::msg::AccelWithCovariance zero_dt =
+    zero_dt_estimator.estimate(prev, curr, 0.0);
+  EXPECT_NEAR(zero_dt.accel.linear.x, 1.0 / g_min_dt, kTol);
 
   // Negative dt is also clamped to g_min_dt, not used directly.
   AccelEstimator negative_dt_estimator(0.0);
-  const geometry_msgs::msg::Accel negative_dt = negative_dt_estimator.estimate(prev, curr, -5.0);
-  EXPECT_NEAR(negative_dt.linear.x, 1.0 / g_min_dt, kTol);
+  const geometry_msgs::msg::AccelWithCovariance negative_dt =
+    negative_dt_estimator.estimate(prev, curr, -5.0);
+  EXPECT_NEAR(negative_dt.accel.linear.x, 1.0 / g_min_dt, kTol);
 
   // dt above the threshold is used unchanged.
   AccelEstimator large_dt_estimator(0.0);
-  const geometry_msgs::msg::Accel large_dt = large_dt_estimator.estimate(prev, curr, 2.0);
-  EXPECT_NEAR(large_dt.linear.x, 1.0 / 2.0, kTol);
+  const geometry_msgs::msg::AccelWithCovariance large_dt =
+    large_dt_estimator.estimate(prev, curr, 2.0);
+  EXPECT_NEAR(large_dt.accel.linear.x, 1.0 / 2.0, kTol);
 }
 
 // Each of the six channels is filtered independently (its own LPF state),
@@ -142,17 +150,52 @@ TEST(AccelEstimatorTest, ChannelsAreIndependent)
   estimator.estimate(make_twist(0, 0, 0, 0, 0, 0), make_twist(2.0, 0, 0, 0, 0, 0), dt);
 
   // Now move only angular_z; linear_x sees raw accel 0 but retains its history.
-  const geometry_msgs::msg::Accel accel =
+  const geometry_msgs::msg::AccelWithCovariance accel =
     estimator.estimate(make_twist(2.0, 0, 0, 0, 0, 0), make_twist(2.0, 0, 0, 0, 0, 1.0), dt);
 
   // linear_x: 0.5 * 2.0 (history) + 0.5 * 0.0 (raw) = 1.0. Its history is
   // preserved independently of the other channels.
-  EXPECT_NEAR(accel.linear.x, 1.0, kTol);
+  EXPECT_NEAR(accel.accel.linear.x, 1.0, kTol);
   // angular_z was initialized to 0.0 raw on the first call, so this second
   // sample smooths raw 1.0 against that: 0.5 * 0.0 + 0.5 * 1.0 = 0.5. This
   // proves angular_z carries its own state and is not affected by linear_x.
-  EXPECT_NEAR(accel.angular.z, 0.5, kTol);
+  EXPECT_NEAR(accel.accel.angular.z, 0.5, kTol);
   // Untouched channels stay at zero.
-  EXPECT_NEAR(accel.linear.y, 0.0, kTol);
-  EXPECT_NEAR(accel.angular.x, 0.0, kTol);
+  EXPECT_NEAR(accel.accel.linear.y, 0.0, kTol);
+  EXPECT_NEAR(accel.accel.angular.x, 0.0, kTol);
+}
+
+// The estimator fills in a constant diagonal covariance for the acceleration:
+// variance 1.0 on the three linear (x, y, z) channels and 0.05 on the three
+// angular (roll, pitch, yaw) channels, with every off-diagonal term zero. The
+// expected entries below are hand-written literals derived from the documented
+// constants, not read back from the estimator. The covariance is a flat
+// row-major 6x6 matrix, so element (row, col) lives at index row * 6 + col.
+TEST(AccelEstimatorTest, CovarianceIsConstantDiagonal)
+{
+  AccelEstimator estimator(0.9);
+  const auto prev = make_twist(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+  const auto curr = make_twist(2.0, 4.0, 6.0, 0.2, 0.4, 0.6);
+
+  const geometry_msgs::msg::AccelWithCovariance accel = estimator.estimate(prev, curr, 0.5);
+
+  // Hand-written expectation: a 36-entry array that is zero everywhere except
+  // the six diagonal variances. The diagonal of a row-major 6x6 lives at
+  // indices 0, 7, 14, 21, 28, 35.
+  std::array<double, 36> expected{};  // value-initialized to all zeros
+  expected[0] = 1.0;                  // X_X    (linear x)  index 0 * 6 + 0
+  expected[7] = 1.0;                  // Y_Y    (linear y)  index 1 * 6 + 1
+  expected[14] = 1.0;                 // Z_Z    (linear z)  index 2 * 6 + 2
+  expected[21] = 0.05;                // R_R    (roll)      index 3 * 6 + 3
+  expected[28] = 0.05;                // P_P    (pitch)     index 4 * 6 + 4
+  expected[35] = 0.05;                // Y_Y    (yaw)       index 5 * 6 + 5
+
+  for (std::size_t i = 0; i < expected.size(); ++i) {
+    EXPECT_NEAR(accel.covariance[i], expected[i], kTol) << "covariance index " << i;
+  }
+
+  // Cross-check the magnitudes against the named public constants so a future
+  // change to either the literals above or the constants is caught.
+  EXPECT_DOUBLE_EQ(g_linear_accel_variance, 1.0);
+  EXPECT_DOUBLE_EQ(g_angular_accel_variance, 0.05);
 }

--- a/localization/autoware_twist2accel/test/test_twist2accel_node.cpp
+++ b/localization/autoware_twist2accel/test/test_twist2accel_node.cpp
@@ -22,7 +22,9 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <chrono>
+#include <cstddef>
 #include <memory>
 #include <thread>
 #include <vector>
@@ -167,6 +169,23 @@ TEST_F(Twist2AccelNodeTest, UseOdomTrueRoutesOdomAndIgnoresTwist)
 
   ASSERT_EQ(received.size(), 2u);
   EXPECT_DOUBLE_EQ(received.back().accel.accel.linear.x, 1.0);
+
+  // Characterization: the published covariance must stay byte-for-byte what the
+  // node emitted before the covariance logic moved into the pure core, i.e. a
+  // constant diagonal (linear variance 1.0, angular variance 0.05) with all
+  // off-diagonal terms zero. The literals below are hand-written, not read back
+  // from the estimator. Diagonal of a row-major 6x6 lives at row * 6 + row.
+  const auto & cov = received.back().accel.covariance;
+  std::array<double, 36> expected{};  // value-initialized to all zeros
+  expected[0] = 1.0;                  // linear x variance
+  expected[7] = 1.0;                  // linear y variance
+  expected[14] = 1.0;                 // linear z variance
+  expected[21] = 0.05;                // roll variance
+  expected[28] = 0.05;                // pitch variance
+  expected[35] = 0.05;                // yaw variance
+  for (std::size_t i = 0; i < expected.size(); ++i) {
+    EXPECT_DOUBLE_EQ(cov[i], expected[i]) << "covariance index " << i;
+  }
 }
 
 // With use_odom=false the twist callback drives estimation while the odom


### PR DESCRIPTION
**Review-fix for #1111** — addresses @interimadd's change-request.

Base of this PR is the existing PR branch `refactor/autoware_twist2accel`, so the diff below is exactly the single additive fix commit — no rebase/force-push of the shared head. Merging this PR lands the fix on `refactor/autoware_twist2accel` and updates upstream #1111.

---

## What

Per @interimadd's review on #1111, the acceleration COVARIANCE is core estimation logic and should live with the value estimate inside the pure `AccelEstimator`, not stay in the node.

`AccelEstimator::estimate` now returns `geometry_msgs::msg::AccelWithCovariance` (acceleration value + covariance) instead of bare `Accel`. It fills the same constant diagonal covariance the node previously wrote — linear x/y/z variance `1.0`, angular roll/pitch/yaw variance `0.05`, off-diagonal terms zero — addressed via `XYZRPY_COV_IDX` and exposed as named constants `g_linear_accel_variance` / `g_angular_accel_variance`. The node simply assigns `accel_msg.accel = estimator->estimate(...)`, and the `autoware_utils_geometry` covariance include/using moved from the node into the core.

## Behavior preservation

The published covariance is byte-for-byte unchanged: the original node set exactly these hardcoded placeholder values, and the same values are now produced by the core. The covariance is not derived from the input twist covariance or the LPF/dt because the original implementation did not do so either — it used fixed placeholders, faithfully relocated here (the existing `// Ideally speaking, these covariance should be properly estimated.` note is preserved).

## Tests

- New core unit test `CovarianceIsConstantDiagonal` asserts all 36 covariance entries against a hand-written `std::array` literal (independent oracle; diagonal at indices 0, 7, 14, 21, 28, 35) and cross-checks the named constants.
- Node test `UseOdomTrueRoutesOdomAndIgnoresTwist` gains a characterization assertion locking the published covariance to the same hand-written literals.
- Existing value tests updated for the new `AccelWithCovariance` return type.

Built and tested in the core devel container: `colcon build` + `colcon test` green (9 gtest cases pass, all linters pass).

Refs: autowarefoundation/autoware_core#1096
