### PR TITLE
refactor(autoware_ekf_localizer): split parameter parsing from HyperParameters data

### DIFF
--- a/localization/autoware_ekf_localizer/CMakeLists.txt
+++ b/localization/autoware_ekf_localizer/CMakeLists.txt
@@ -16,6 +16,7 @@ ament_auto_find_build_dependencies()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/ekf_localizer.cpp
+  src/hyper_parameters.cpp
   src/covariance.cpp
   src/diagnostics.cpp
   src/mahalanobis.cpp

--- a/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
@@ -49,7 +49,7 @@ EKFLocalizer::EKFLocalizer(const rclcpp::NodeOptions & node_options)
   warning_(std::make_shared<Warning>(this)),
   tf2_buffer_(this->get_clock()),
   tf2_listener_(tf2_buffer_),
-  params_(this),
+  params_(load_hyper_parameters(this)),
   ekf_dt_(params_.ekf_dt),
   pose_queue_(params_.pose_smoothing_steps, params_.max_pose_queue_size),
   twist_queue_(params_.twist_smoothing_steps, params_.max_twist_queue_size),

--- a/localization/autoware_ekf_localizer/src/hyper_parameters.cpp
+++ b/localization/autoware_ekf_localizer/src/hyper_parameters.cpp
@@ -1,0 +1,77 @@
+// Copyright 2022 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "include/hyper_parameters.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <algorithm>
+#include <string>
+
+namespace autoware::ekf_localizer
+{
+
+HyperParameters load_hyper_parameters(rclcpp::Node * node)
+{
+  HyperParameters p;
+  p.show_debug_info = node->declare_parameter<bool>("node.show_debug_info");
+  p.ekf_rate = node->declare_parameter<double>("node.predict_frequency");
+  p.ekf_dt = 1.0 / std::max(p.ekf_rate, 0.1);
+  p.tf_rate_ = node->declare_parameter<double>("node.tf_rate");
+  p.enable_yaw_bias_estimation = node->declare_parameter<bool>("node.enable_yaw_bias_estimation");
+  p.extend_state_step = node->declare_parameter<int>("node.extend_state_step");
+  p.pose_frame_id = node->declare_parameter<std::string>("misc.pose_frame_id");
+  p.pose_additional_delay =
+    node->declare_parameter<double>("pose_measurement.pose_additional_delay");
+  p.pose_gate_dist = node->declare_parameter<double>("pose_measurement.pose_gate_dist");
+  p.pose_smoothing_steps = node->declare_parameter<int>("pose_measurement.pose_smoothing_steps");
+  p.max_pose_queue_size = node->declare_parameter<int>("pose_measurement.max_pose_queue_size");
+  p.twist_additional_delay =
+    node->declare_parameter<double>("twist_measurement.twist_additional_delay");
+  p.twist_gate_dist = node->declare_parameter<double>("twist_measurement.twist_gate_dist");
+  p.twist_smoothing_steps = node->declare_parameter<int>("twist_measurement.twist_smoothing_steps");
+  p.max_twist_queue_size = node->declare_parameter<int>("twist_measurement.max_twist_queue_size");
+  p.proc_stddev_vx_c = node->declare_parameter<double>("process_noise.proc_stddev_vx_c");
+  p.proc_stddev_wz_c = node->declare_parameter<double>("process_noise.proc_stddev_wz_c");
+  p.proc_stddev_yaw_c = node->declare_parameter<double>("process_noise.proc_stddev_yaw_c");
+  p.z_filter_proc_dev =
+    node->declare_parameter<double>("simple_1d_filter_parameters.z_filter_proc_dev");
+  p.roll_filter_proc_dev =
+    node->declare_parameter<double>("simple_1d_filter_parameters.roll_filter_proc_dev");
+  p.pitch_filter_proc_dev =
+    node->declare_parameter<double>("simple_1d_filter_parameters.pitch_filter_proc_dev");
+  p.pose_no_update_count_threshold_warn =
+    node->declare_parameter<int>("diagnostics.pose_no_update_count_threshold_warn");
+  p.pose_no_update_count_threshold_error =
+    node->declare_parameter<int>("diagnostics.pose_no_update_count_threshold_error");
+  p.twist_no_update_count_threshold_warn =
+    node->declare_parameter<int>("diagnostics.twist_no_update_count_threshold_warn");
+  p.twist_no_update_count_threshold_error =
+    node->declare_parameter<int>("diagnostics.twist_no_update_count_threshold_error");
+  p.ellipse_scale = node->declare_parameter<double>("diagnostics.ellipse_scale");
+  p.error_ellipse_size = node->declare_parameter<double>("diagnostics.error_ellipse_size");
+  p.warn_ellipse_size = node->declare_parameter<double>("diagnostics.warn_ellipse_size");
+  p.error_ellipse_size_lateral_direction =
+    node->declare_parameter<double>("diagnostics.error_ellipse_size_lateral_direction");
+  p.warn_ellipse_size_lateral_direction =
+    node->declare_parameter<double>("diagnostics.warn_ellipse_size_lateral_direction");
+  p.diagnostics_publish_frequency =
+    node->declare_parameter<double>("diagnostics.diagnostics_publish_frequency");
+  p.diagnostics_publish_period = 1.0 / p.diagnostics_publish_frequency;
+  p.threshold_observable_velocity_mps =
+    node->declare_parameter<double>("misc.threshold_observable_velocity_mps");
+  return p;
+}
+
+}  // namespace autoware::ekf_localizer

--- a/localization/autoware_ekf_localizer/src/include/hyper_parameters.hpp
+++ b/localization/autoware_ekf_localizer/src/include/hyper_parameters.hpp
@@ -15,122 +15,61 @@
 #ifndef HYPER_PARAMETERS_HPP_
 #define HYPER_PARAMETERS_HPP_
 
-#include <rclcpp/rclcpp.hpp>
-
-#include <algorithm>
+#include <cstddef>
 #include <string>
+
+namespace rclcpp
+{
+class Node;
+}  // namespace rclcpp
 
 namespace autoware::ekf_localizer
 {
 
-class HyperParameters
+// Plain data struct: it carries the tuned hyper-parameters and has no rclcpp dependency. Parsing
+// lives in the free function load_hyper_parameters() below, so production has a single construction
+// path (params_(load_hyper_parameters(this))) and a unit test can build the struct by hand.
+struct HyperParameters
 {
-public:
-  // Additive seam: a default constructor so the parameters can be hand-set in a unit test
-  // without a live rclcpp::Node. The fields below are intentionally non-const so a test can
-  // populate them directly. The node-based constructor still fully initializes every field.
-  //
-  // The in-class member initializers below give the default-constructed instance SAFE, non-zero
-  // values for every field that EKFModule relies on at construction time. In particular
-  // extend_state_step is set to a realistic >= 1 value: EKFModule sizes accumulated_delay_times_
-  // as std::vector<double>(extend_state_step, 1.0E15) and find_closest_delay_time_index() reads
-  // accumulated_delay_times_.back(). A misconfigured extend_state_step == 0 would leave that table
-  // empty; find_closest_delay_time_index() now guards the empty table (returns 0) instead of
-  // dereferencing .back(), so the degenerate configuration no longer triggers undefined behaviour.
-  // The other sizing/rate defaults (ekf_rate/ekf_dt, smoothing steps, queue sizes, gate distances,
-  // process/filter noise) are likewise non-zero so a default-constructed instance is immediately
-  // usable.
-  HyperParameters() = default;
+  bool show_debug_info;
+  double ekf_rate;  // ekf update frequency = predict_frequency [Hz]
+  double ekf_dt;    // ekf update period [s]
+  double tf_rate_;
+  bool enable_yaw_bias_estimation;
+  size_t extend_state_step;
+  std::string pose_frame_id;
+  double pose_additional_delay;
+  double pose_gate_dist;
+  size_t pose_smoothing_steps;
+  size_t max_pose_queue_size;
+  double twist_additional_delay;
+  double twist_gate_dist;
+  size_t twist_smoothing_steps;
+  size_t max_twist_queue_size;
+  double proc_stddev_vx_c;   //!< @brief  vx process noise
+  double proc_stddev_wz_c;   //!< @brief  wz process noise
+  double proc_stddev_yaw_c;  //!< @brief  yaw process noise
+  double z_filter_proc_dev;
+  double roll_filter_proc_dev;
+  double pitch_filter_proc_dev;
+  size_t pose_no_update_count_threshold_warn;
+  size_t pose_no_update_count_threshold_error;
+  size_t twist_no_update_count_threshold_warn;
+  size_t twist_no_update_count_threshold_error;
+  double ellipse_scale;
+  double error_ellipse_size;
+  double warn_ellipse_size;
+  double error_ellipse_size_lateral_direction;
+  double warn_ellipse_size_lateral_direction;
+  double diagnostics_publish_frequency;  //!< @brief diagnostics publish frequency [Hz]
+  double diagnostics_publish_period;     //!< @brief diagnostics publish period [s]
 
-  explicit HyperParameters(rclcpp::Node * node)
-  : show_debug_info(node->declare_parameter<bool>("node.show_debug_info")),
-    ekf_rate(node->declare_parameter<double>("node.predict_frequency")),
-    ekf_dt(1.0 / std::max(ekf_rate, 0.1)),
-    tf_rate_(node->declare_parameter<double>("node.tf_rate")),
-    enable_yaw_bias_estimation(node->declare_parameter<bool>("node.enable_yaw_bias_estimation")),
-    extend_state_step(node->declare_parameter<int>("node.extend_state_step")),
-    pose_frame_id(node->declare_parameter<std::string>("misc.pose_frame_id")),
-    pose_additional_delay(
-      node->declare_parameter<double>("pose_measurement.pose_additional_delay")),
-    pose_gate_dist(node->declare_parameter<double>("pose_measurement.pose_gate_dist")),
-    pose_smoothing_steps(node->declare_parameter<int>("pose_measurement.pose_smoothing_steps")),
-    max_pose_queue_size(node->declare_parameter<int>("pose_measurement.max_pose_queue_size")),
-    twist_additional_delay(
-      node->declare_parameter<double>("twist_measurement.twist_additional_delay")),
-    twist_gate_dist(node->declare_parameter<double>("twist_measurement.twist_gate_dist")),
-    twist_smoothing_steps(node->declare_parameter<int>("twist_measurement.twist_smoothing_steps")),
-    max_twist_queue_size(node->declare_parameter<int>("twist_measurement.max_twist_queue_size")),
-    proc_stddev_vx_c(node->declare_parameter<double>("process_noise.proc_stddev_vx_c")),
-    proc_stddev_wz_c(node->declare_parameter<double>("process_noise.proc_stddev_wz_c")),
-    proc_stddev_yaw_c(node->declare_parameter<double>("process_noise.proc_stddev_yaw_c")),
-    z_filter_proc_dev(
-      node->declare_parameter<double>("simple_1d_filter_parameters.z_filter_proc_dev")),
-    roll_filter_proc_dev(
-      node->declare_parameter<double>("simple_1d_filter_parameters.roll_filter_proc_dev")),
-    pitch_filter_proc_dev(
-      node->declare_parameter<double>("simple_1d_filter_parameters.pitch_filter_proc_dev")),
-    pose_no_update_count_threshold_warn(
-      node->declare_parameter<int>("diagnostics.pose_no_update_count_threshold_warn")),
-    pose_no_update_count_threshold_error(
-      node->declare_parameter<int>("diagnostics.pose_no_update_count_threshold_error")),
-    twist_no_update_count_threshold_warn(
-      node->declare_parameter<int>("diagnostics.twist_no_update_count_threshold_warn")),
-    twist_no_update_count_threshold_error(
-      node->declare_parameter<int>("diagnostics.twist_no_update_count_threshold_error")),
-    ellipse_scale(node->declare_parameter<double>("diagnostics.ellipse_scale")),
-    error_ellipse_size(node->declare_parameter<double>("diagnostics.error_ellipse_size")),
-    warn_ellipse_size(node->declare_parameter<double>("diagnostics.warn_ellipse_size")),
-    error_ellipse_size_lateral_direction(
-      node->declare_parameter<double>("diagnostics.error_ellipse_size_lateral_direction")),
-    warn_ellipse_size_lateral_direction(
-      node->declare_parameter<double>("diagnostics.warn_ellipse_size_lateral_direction")),
-    diagnostics_publish_frequency(
-      node->declare_parameter<double>("diagnostics.diagnostics_publish_frequency")),
-    diagnostics_publish_period(1.0 / diagnostics_publish_frequency),
-    threshold_observable_velocity_mps(
-      node->declare_parameter<double>("misc.threshold_observable_velocity_mps"))
-  {
-  }
-
-  // NOTE: these members are non-const so the default constructor (additive test seam) can set
-  // them. The node-based constructor still initializes all of them in its member initializer list.
-  bool show_debug_info{false};
-  double ekf_rate{50.0};      // ekf update frequency = predict_frequency [Hz]
-  double ekf_dt{1.0 / 50.0};  // ekf update period [s]
-  double tf_rate_{10.0};
-  bool enable_yaw_bias_estimation{true};
-  // Sizes accumulated_delay_times_ to this length; 0 leaves the table empty, which
-  // find_closest_delay_time_index() guards against (see ekf_module.cpp).
-  size_t extend_state_step{50};
-  std::string pose_frame_id{"map"};
-  double pose_additional_delay{0.0};
-  double pose_gate_dist{10000.0};
-  size_t pose_smoothing_steps{5};
-  size_t max_pose_queue_size{5};
-  double twist_additional_delay{0.0};
-  double twist_gate_dist{10000.0};
-  size_t twist_smoothing_steps{2};
-  size_t max_twist_queue_size{5};
-  double proc_stddev_vx_c{10.0};    //!< @brief  vx process noise
-  double proc_stddev_wz_c{5.0};     //!< @brief  wz process noise
-  double proc_stddev_yaw_c{0.005};  //!< @brief  yaw process noise
-  double z_filter_proc_dev{1.0};
-  double roll_filter_proc_dev{0.01};
-  double pitch_filter_proc_dev{0.01};
-  size_t pose_no_update_count_threshold_warn{0};
-  size_t pose_no_update_count_threshold_error{0};
-  size_t twist_no_update_count_threshold_warn{0};
-  size_t twist_no_update_count_threshold_error{0};
-  double ellipse_scale{0.0};
-  double error_ellipse_size{0.0};
-  double warn_ellipse_size{0.0};
-  double error_ellipse_size_lateral_direction{0.0};
-  double warn_ellipse_size_lateral_direction{0.0};
-  double diagnostics_publish_frequency{0.0};  //!< @brief diagnostics publish frequency [Hz]
-  double diagnostics_publish_period{0.0};     //!< @brief diagnostics publish period [s]
-
-  double threshold_observable_velocity_mps{0.0};
+  double threshold_observable_velocity_mps;
 };
+
+// Declares all of the node parameters and returns a fully-populated HyperParameters. This is the
+// only place that touches rclcpp, keeping HyperParameters itself a plain data struct.
+HyperParameters load_hyper_parameters(rclcpp::Node * node);
 
 }  // namespace autoware::ekf_localizer
 

--- a/localization/autoware_ekf_localizer/test/test_ekf_module.cpp
+++ b/localization/autoware_ekf_localizer/test/test_ekf_module.cpp
@@ -37,11 +37,12 @@ namespace autoware::ekf_localizer
 
 namespace
 {
-// Build a HyperParameters instance with hand-set values via the additive default-constructor
-// seam, so EKFModule can be exercised without a live rclcpp::Node.
+// Build a HyperParameters instance with hand-set values, so EKFModule can be exercised without a
+// live rclcpp::Node. HyperParameters is a plain data struct (no rclcpp dependency); the test owns
+// the values it cares about and value-initializes the rest to zero/empty.
 HyperParameters make_params()
 {
-  HyperParameters params;
+  HyperParameters params{};  // value-initialize every field to zero/empty
   params.show_debug_info = false;
   params.ekf_rate = 50.0;
   params.ekf_dt = 1.0 / 50.0;


### PR DESCRIPTION
**Review-fix for #1098** — addresses @interimadd's change-request.

Base of this PR is the existing PR branch `test/autoware_ekf_localizer`, so the diff below is exactly the single additive fix commit — no rebase/force-push of the shared head. Merging this PR lands the fix on `test/autoware_ekf_localizer` and updates upstream #1098.

---

Revert the unit-test-only default-value seam on `HyperParameters`. The struct is now plain data with no rclcpp dependency and no production-looking default member values that could silently diverge from the YAML source of truth.

All `declare_parameter` calls are mechanically moved into a free function `load_hyper_parameters(rclcpp::Node * node)` (new `src/hyper_parameters.cpp`) that returns a fully-populated instance. Production keeps a single construction path (`params_(load_hyper_parameters(this))`) and `params_` stays `const HyperParameters`, so the production instance remains immutable. The `EKFModule` unit test builds the struct directly by hand-setting fields, with no special default constructor.

Behavior is identical: same parameter names and defaults as the YAML.

Refs: autowarefoundation/autoware_core#1096
